### PR TITLE
Add Private Game Creation Support

### DIFF
--- a/.claude/commands/write-pull-request-description.md
+++ b/.claude/commands/write-pull-request-description.md
@@ -1,0 +1,1 @@
+Write a pull request description based on the work we have completed. The pull request description should be concise.

--- a/changelog/2025-09-29-private-game-creation.md
+++ b/changelog/2025-09-29-private-game-creation.md
@@ -1,0 +1,54 @@
+# Feature: Private Game Creation
+
+**Date:** 2025-09-29
+**Session:** Private games implementation with visibility controls
+
+## Summary
+Implemented private game creation functionality allowing users to create games that are only accessible via direct links and excluded from public game listings.
+
+## Problem Solved
+Users needed the ability to create private games for playing with friends without having those games appear in public browse listings. This enables more intimate gaming sessions while maintaining the existing public game discovery system.
+
+## Implementation Details
+
+### Backend Changes
+- **Modified:** `service/game/serializers.py` - Added `private` field to GameSerializer for API read/write operations
+- **Modified:** `service/game/filters.py` - Updated GameFilter to exclude private games from `can_join` listings while preserving access in `mine` listings
+- **Modified:** `service/game/tests.py` - Added comprehensive test suite for private game creation, filtering, and access patterns
+- **Generated:** Updated TypeScript API client types to include private field in GameRead/GameWrite interfaces
+
+### Frontend Changes
+- **Modified:** `packages/web/src/screens/Home/CreateGame.tsx` - Added private checkbox with descriptive help text
+- **Modified:** `packages/web/src/screens/Home/GameInfo.tsx` - Added "Visibility" field showing Private/Public status
+- **Modified:** `packages/web/src/screens/GameDetail/GameInfoScreen.tsx` - Added matching visibility indicator
+- **Modified:** `packages/web/src/components/GameCard.tsx` - Added subtle lock icon for private games
+- **Modified:** `packages/web/src/components/Icon.tsx` - Added Lock icon to icon system
+
+### Database Schema
+- Leveraged existing `private` boolean field in Game model (no migration required)
+
+## Rationale
+
+**Filtering Approach:** Private games are excluded only from `can_join=true` queries (public browsing) but remain visible in `mine=true` queries (user's own games). This ensures:
+- Private games don't appear in public listings
+- Users can still manage their own private games
+- Direct links work for all users (no additional access restrictions)
+
+**UI Design Decisions:**
+- Checkbox defaults to unchecked (public by default) to maintain current user expectations
+- Lock icon placement before game name for immediate visibility
+- Consistent "Visibility" field placement across game info screens
+- Subtle visual treatment (small icon, reduced opacity) to avoid UI clutter
+
+**Security Model:** Link-only access (no additional permissions) was chosen for simplicity and to match the requirement of "anyone with the link" access.
+
+## Testing
+- **Backend:** 5 comprehensive tests covering private game creation, public listing exclusion, mine listing inclusion, and direct access
+- **Build:** Frontend TypeScript compilation verified with new private field integration
+- **API Integration:** Verified API client regeneration includes private field in request/response types
+
+## Notes
+- The `private` field existed in the Django model from initial migration, suggesting this feature was planned from the beginning
+- No additional authentication/authorization logic needed beyond existing game access patterns
+- Lock icon uses Material UI's standard Lock icon for consistency with design system
+- Private game functionality is fully backward compatible with existing public games

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -16,6 +16,7 @@ import { InteractiveMap } from "./InteractiveMap/InteractiveMap";
 import { getCurrentPhase } from "../util";
 import { createUseStyles } from "./utils/styles";
 import { PlayerAvatar } from "./PlayerAvatar";
+import { Icon, IconName } from "./Icon";
 
 const MAX_AVATARS = 10;
 
@@ -52,6 +53,10 @@ const useStyles = createUseStyles<GameCardProps>(() => ({
   },
   extraMembersText: {
     marginLeft: "4px",
+  },
+  privateIcon: {
+    fontSize: 14,
+    opacity: 0.6,
   },
 }));
 
@@ -100,9 +105,17 @@ const GameCard: React.FC<GameCardProps> = (game) => {
       <Stack>
         <ListItemText
           primary={
-            <Link underline="hover" onClick={handleClickGame}>
-              {game.name}
-            </Link>
+            <Stack direction="row" alignItems="center" gap={1}>
+              {game.private && (
+                <Icon
+                  name={IconName.Lock}
+                  sx={styles.privateIcon}
+                />
+              )}
+              <Link underline="hover" onClick={handleClickGame}>
+                {game.name}
+              </Link>
+            </Stack>
           }
         />
         <Stack sx={styles.secondaryContainer}>
@@ -121,7 +134,7 @@ const GameCard: React.FC<GameCardProps> = (game) => {
           </Button>
         </Stack>
       </Stack>
-    </ListItem>
+    </ListItem >
   );
 };
 

--- a/packages/web/src/components/Icon.tsx
+++ b/packages/web/src/components/Icon.tsx
@@ -23,6 +23,7 @@ import Close from "@mui/icons-material/Close";
 import Delete from "@mui/icons-material/Delete";
 import Fullscreen from "@mui/icons-material/Fullscreen";
 import FullscreenExit from "@mui/icons-material/FullscreenExit";
+import Lock from "@mui/icons-material/Lock";
 
 import { SxProps, Theme } from "@mui/material";
 
@@ -52,6 +53,7 @@ enum IconName {
   Delete = "delete",
   Fullscreen = "fullscreen",
   FullscreenExit = "fullscreen-exit",
+  Lock = "lock",
 }
 
 const IconMap = {
@@ -80,6 +82,7 @@ const IconMap = {
   [IconName.Delete]: Delete,
   [IconName.Fullscreen]: Fullscreen,
   [IconName.FullscreenExit]: FullscreenExit,
+  [IconName.Lock]: Lock,
 };
 
 interface IconProps {

--- a/packages/web/src/screens/GameDetail/GameInfoScreen.tsx
+++ b/packages/web/src/screens/GameDetail/GameInfoScreen.tsx
@@ -70,6 +70,17 @@ const GameInfoScreen: React.FC = () => {
                                             ),
                                             icon: IconName.StartYear,
                                         },
+                                        {
+                                            label: "Visibility",
+                                            value: query.data ? (
+                                                query.data.private ? "Private" : "Public"
+                                            ) : (
+                                                <Stack alignItems="flex-end">
+                                                    <Skeleton variant="text" width={60} />
+                                                </Stack>
+                                            ),
+                                            icon: IconName.Lock,
+                                        },
                                     ]}
                                 />
                                 <Divider />

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import {
   Button,
+  Checkbox,
   Divider,
   FormControl,
+  FormControlLabel,
   MenuItem,
   Stack,
   TextField,
   Typography,
   Skeleton,
+  FormHelperText,
 } from "@mui/material";
 import { HomeLayout } from "./Layout";
 import { NationAssignmentEnum, service } from "../../store";
@@ -24,6 +27,7 @@ const initialValues = {
   name: randomGameName(),
   variantId: "classical",
   nationAssignment: "random" as NationAssignmentEnum,
+  private: false,
 };
 
 const CreateGame: React.FC = () => {
@@ -72,6 +76,20 @@ const CreateGame: React.FC = () => {
                     onBlur={formik.handleBlur}
                     disabled={createGameQuery.isLoading}
                   />
+                </FormControl>
+                <FormControl>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={formik.values.private}
+                        onChange={e => formik.setFieldValue("private", e.target.checked)}
+                        disabled={createGameQuery.isLoading}
+                        name="private"
+                      />
+                    }
+                    label="Private"
+                  />
+                  <FormHelperText sx={{ margin: 0 }}>Make this game private (only accessible via direct link, not shown in public listings).</FormHelperText>
                 </FormControl>
                 <Divider />
                 <Typography variant="h4">Variant</Typography>

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -90,6 +90,17 @@ const GameInfo: React.FC = () => {
                     ),
                     icon: IconName.StartYear,
                   },
+                  {
+                    label: "Visibility",
+                    value: query.data ? (
+                      query.data.private ? "Private" : "Public"
+                    ) : (
+                      <Stack alignItems="flex-end">
+                        <Skeleton variant="text" width={60} />
+                      </Stack>
+                    ),
+                    icon: IconName.Lock,
+                  },
                 ]}
               />
               <Divider />

--- a/packages/web/src/store/service.ts
+++ b/packages/web/src/store/service.ts
@@ -448,6 +448,7 @@ export type NationAssignmentEnum = "random" | "ordered";
 export type Game = {
   name: string;
   nationAssignment: NationAssignmentEnum;
+  private: boolean;
 };
 export type StatusEnum = "pending" | "active" | "completed" | "template";
 export type Nation = {
@@ -560,11 +561,13 @@ export type GameRead = {
   phaseConfirmed: boolean;
   name: string;
   nationAssignment: NationAssignmentEnum;
+  private: boolean;
 };
 export type GameWrite = {
   name: string;
   variantId: string;
   nationAssignment: NationAssignmentEnum;
+  private: boolean;
 };
 export type PhaseState = {};
 export type PhaseStateRead = {

--- a/service/game/filters.py
+++ b/service/game/filters.py
@@ -19,5 +19,8 @@ class GameFilter(django_filters.FilterSet):
 
     def filter_can_join(self, queryset, name, value):
         if value:
-            return queryset.filter(status=GameStatus.PENDING).exclude(members__user=self.request.user)
+            return queryset.filter(
+                status=GameStatus.PENDING,
+                private=False
+            ).exclude(members__user=self.request.user)
         return queryset

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -23,6 +23,7 @@ class GameSerializer(serializers.Serializer):
     name = serializers.CharField()
     variant_id = serializers.CharField(write_only=True)
     nation_assignment = serializers.ChoiceField(choices=NationAssignment.NATION_ASSIGNMENT_CHOICES)
+    private = serializers.BooleanField()
 
     @extend_schema_field(serializers.BooleanField)
     def get_can_join(self, obj):
@@ -51,4 +52,5 @@ class GameSerializer(serializers.Serializer):
                 request.user,
                 name=validated_data["name"],
                 nation_assignment=validated_data["nation_assignment"],
+                private=validated_data["private"],
             )

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -445,6 +445,7 @@ class TestGameCreateView:
             "name": "New Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -475,6 +476,7 @@ class TestGameCreateView:
             "name": "New Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = unauthenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -486,6 +488,7 @@ class TestGameCreateView:
             "name": "Ordered Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.ORDERED,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -499,6 +502,7 @@ class TestGameCreateView:
         payload = {
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -510,6 +514,7 @@ class TestGameCreateView:
         payload = {
             "name": "Test Game",
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -521,6 +526,7 @@ class TestGameCreateView:
         payload = {
             "name": "Test Game",
             "variant_id": classical_variant.id,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -533,6 +539,7 @@ class TestGameCreateView:
             "name": "Test Game",
             "variant_id": "non-existent-variant",
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -545,6 +552,7 @@ class TestGameCreateView:
             "name": "Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": "invalid-assignment",
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -556,6 +564,7 @@ class TestGameCreateView:
             "name": "",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -567,6 +576,7 @@ class TestGameCreateView:
             "name": "Membership Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -582,6 +592,7 @@ class TestGameCreateView:
             "name": "Channel Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -598,6 +609,7 @@ class TestGameCreateView:
             "name": "Phase Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -616,6 +628,7 @@ class TestGameCreateView:
             "name": "Unique ID Test",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
 
         response1 = authenticated_client.post(url, payload, format="json")
@@ -632,6 +645,7 @@ class TestGameCreateView:
             "name": "Test Game! @#$%^&*()",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -644,6 +658,7 @@ class TestGameCreateView:
             "name": "Тест Игра 测试游戏 🎮",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -657,11 +672,13 @@ class TestGameCreateView:
             "name": "Game 1",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         payload2 = {
             "name": "Game 2",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
 
         response1 = authenticated_client.post(url, payload1, format="json")
@@ -687,6 +704,7 @@ class TestGameCreateView:
             "name": "Join Leave Test Game",
             "variant_id": classical_variant.id,
             "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
         }
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
@@ -697,3 +715,102 @@ class TestGameCreateView:
         assert response.data["can_join"] is False
         assert response.data["can_leave"] is True
         assert response.data["phase_confirmed"] is False
+
+    @pytest.mark.django_db
+    def test_create_private_game_success(self, authenticated_client, classical_variant):
+        url = reverse(create_viewname)
+        payload = {
+            "name": "Private Test Game",
+            "variant_id": classical_variant.id,
+            "nation_assignment": NationAssignment.RANDOM,
+            "private": True,
+        }
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["private"] is True
+
+        # Verify game is created as private in database
+        game = Game.objects.get(id=response.data["id"])
+        assert game.private is True
+
+    @pytest.mark.django_db
+    def test_create_public_game_default(self, authenticated_client, classical_variant):
+        url = reverse(create_viewname)
+        payload = {
+            "name": "Public Test Game",
+            "variant_id": classical_variant.id,
+            "nation_assignment": NationAssignment.RANDOM,
+            "private": False,
+        }
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["private"] is False
+
+
+class TestGamePrivateFiltering:
+
+    @pytest.mark.django_db
+    def test_private_games_excluded_from_can_join_filter(self, authenticated_client, secondary_user, classical_variant):
+        # Create a private game by secondary user
+        private_game = Game.objects.create_from_template(
+            classical_variant,
+            secondary_user,
+            name="Private Game",
+            nation_assignment=NationAssignment.RANDOM,
+            private=True,
+        )
+
+        # Create a public game by secondary user
+        public_game = Game.objects.create_from_template(
+            classical_variant,
+            secondary_user,
+            name="Public Game",
+            nation_assignment=NationAssignment.RANDOM,
+            private=False,
+        )
+
+        # Request games with can_join=true (should exclude private games)
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url, {"can_join": "true"})
+        assert response.status_code == status.HTTP_200_OK
+
+        game_ids = [game["id"] for game in response.data]
+        assert public_game.id in game_ids
+        assert private_game.id not in game_ids
+
+    @pytest.mark.django_db
+    def test_private_games_visible_in_mine_filter(self, authenticated_client, primary_user, classical_variant):
+        # Create a private game by primary user
+        private_game = Game.objects.create_from_template(
+            classical_variant,
+            primary_user,
+            name="My Private Game",
+            nation_assignment=NationAssignment.RANDOM,
+            private=True,
+        )
+
+        # Request games with mine=true (should include private games for user)
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url, {"mine": "true"})
+        assert response.status_code == status.HTTP_200_OK
+
+        game_ids = [game["id"] for game in response.data]
+        assert private_game.id in game_ids
+
+    @pytest.mark.django_db
+    def test_private_game_accessible_via_direct_link(self, authenticated_client, secondary_user, classical_variant):
+        # Create a private game by secondary user
+        private_game = Game.objects.create_from_template(
+            classical_variant,
+            secondary_user,
+            name="Private Game",
+            nation_assignment=NationAssignment.RANDOM,
+            private=True,
+        )
+
+        # Authenticated user should be able to access private game via direct link
+        url = reverse(retrieve_viewname, args=[private_game.id])
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == private_game.id
+        assert response.data["private"] is True

--- a/service/integration/tests.py
+++ b/service/integration/tests.py
@@ -16,6 +16,7 @@ def create_active_game(authenticated_client, authenticated_client_for_secondary_
         "name": "Italy vs Germany Test",
         "variant_id": italy_vs_germany_variant.id,
         "nation_assignment": NationAssignment.ORDERED,
+        "private": False,
     }
     create_response = authenticated_client.post(create_url, create_payload, format="json")
     game_id = create_response.data["id"]
@@ -45,6 +46,7 @@ def test_create_game_with_classical_variant_one_user_joins(
         "name": "Integration Test Game",
         "variant_id": classical_variant.id,
         "nation_assignment": NationAssignment.RANDOM,
+        "private": False,
     }
     create_response = authenticated_client.post(create_url, create_payload, format="json")
     assert create_response.status_code == status.HTTP_201_CREATED
@@ -117,6 +119,7 @@ def test_create_game_with_italy_vs_germany_variant_one_user_joins(
         "name": "Italy vs Germany Test",
         "variant_id": italy_vs_germany_variant.id,
         "nation_assignment": NationAssignment.RANDOM,
+        "private": False,
     }
     create_response = authenticated_client.post(create_url, create_payload, format="json")
     assert create_response.status_code == status.HTTP_201_CREATED
@@ -169,6 +172,7 @@ def test_create_game_with_classical_variant_one_user_leaves_and_rejoins(
         "name": "Leave/Rejoin Test",
         "variant_id": classical_variant.id,
         "nation_assignment": NationAssignment.RANDOM,
+        "private": False,
     }
     create_response = authenticated_client.post(create_url, create_payload, format="json")
     game_id = create_response.data["id"]

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -848,6 +848,8 @@ components:
           writeOnly: true
         nationAssignment:
           $ref: '#/components/schemas/NationAssignmentEnum'
+        private:
+          type: boolean
       required:
       - canJoin
       - canLeave
@@ -858,6 +860,7 @@ components:
       - nationAssignment
       - phaseConfirmed
       - phases
+      - private
       - status
       - variant
       - variantId


### PR DESCRIPTION
  Summary

  Implements private game creation allowing users to create games accessible only via direct link,
  excluded from public game listings.

  Changes

  Backend

  - Added private field to GameSerializer for API read/write operations
  - Updated GameFilter to exclude private games from public browse listings (can_join=true)
  - Private games remain visible in user's own games (mine=true)
  - Added comprehensive test coverage (5 new tests)

  Frontend

  - Added "Make this game private" checkbox to game creation form with explanatory text
  - Display "Visibility" (Private/Public) in game info screens
  - Show lock icon on private game cards for quick visual identification
  - Added Lock icon to icon system

  Testing

  - ✅ 5 backend tests covering private game creation, filtering, and access patterns
  - ✅ Frontend TypeScript build validation
  - ✅ API types regenerated with private field

  Behavior

  - Private games: Excluded from public browse lists, accessible via direct link
  - Public games: Default unchanged, shown in all listings
  - My games: Private games visible to members in their own games list

  Files Changed

  Backend: service/game/serializers.py, service/game/filters.py, service/game/tests.pyFrontend:
  CreateGame.tsx, GameInfo.tsx, GameInfoScreen.tsx, GameCard.tsx, Icon.tsxGenerated: service.ts (API
  types)

Closes: #51 