### PR TITLE
Add error handling to notifications controls

### DIFF
--- a/changelog/2025-09-30-notification-permission-error-handling.md
+++ b/changelog/2025-09-30-notification-permission-error-handling.md
@@ -1,0 +1,81 @@
+# Feature: Notification Permission Error Handling and User Feedback
+
+**Date:** 2025-09-30
+**Session:** Fix notification toggle broken state for users with denied permissions
+
+## Summary
+Enhanced the push notification system to properly handle browser permission states, provide clear error feedback, and prevent the notification banner from flashing on page load. Users with blocked permissions now see helpful guidance instead of a non-functional toggle.
+
+## Problem Solved
+Users reported that the notification toggle on the profile screen appeared inactive and did nothing when clicked. This occurred when:
+1. Browser permission was already denied (e.g., previously blocked or in browsers like Edge)
+2. `Notification.requestPermission()` returns `"denied"` immediately without showing prompt
+3. Errors were logged to console but not surfaced to users
+4. NotificationBanner would flash briefly on every page load before state was determined
+
+## Implementation Details
+
+**Files Modified:**
+- `packages/web/src/context/MessagingContext.tsx`
+  - Added `permissionDenied` boolean to track `Notification.permission === "denied"`
+  - Added `error` state for user-facing error messages
+  - Added `isLoading` state to prevent premature UI rendering
+  - Enhanced `enableMessaging()` to check permission before requesting
+  - Modified initial useEffect to only get token if permission already granted
+  - Set `isCheckingToken` state to track initialization completion
+
+- `packages/web/src/screens/Home/Profile.tsx`
+  - Added error Alert banner for displaying error messages
+  - Added warning Alert with instructions when permission is permanently denied
+  - Disabled toggle switch when `permissionDenied` is true
+  - Consumed new `permissionDenied`, `error` context values
+
+- `packages/web/src/components/NotificationBanner.tsx`
+  - Returns `null` while `isLoading` to prevent flash
+  - Removed unnecessary `query.isSuccess` check (simplified to just `!enabled`)
+
+## Rationale
+
+**Permission State Check First:** Checking `Notification.permission` before calling `requestPermission()` allows us to:
+- Detect already-denied state and show instructions
+- Avoid silent failures that confused users
+- Disable UI elements that won't work
+
+**Loading State:** Without tracking initialization state, the banner would always appear briefly because:
+- `enabled` starts as `false`
+- Token retrieval and device list loading are async
+- Banner would render before state determination completed
+
+**Error State in Context:** Centralizing error state in the context (rather than component-level) allows:
+- Consistent error handling across enable/disable flows
+- Errors from async token operations to surface to UI
+- Clear communication about what went wrong
+
+**Initial Token Check:** On mount, we check if permission is `"granted"` and get token silently. This:
+- Preserves existing user sessions (no re-prompt needed)
+- Allows NotificationBanner to show correctly for users who haven't enabled
+- Doesn't trigger errors for users with denied permissions
+- No unexpected permission prompts on page load
+
+## Testing
+Manual testing performed across browsers:
+- **Chrome (working case):** Toggle and banner behave correctly
+- **Edge (broken case reproduced):** Permission denied error properly caught and displayed
+- **Fresh browser:** Permission prompt shown, correct feedback for allow/deny
+- **Permission already denied:** Warning banner + disabled toggle shown with instructions
+
+## Notes
+
+**Future Considerations:**
+- Consider adding a "retry" or "refresh" button after user enables permission in browser settings
+- Could add toast notifications instead of/in addition to Alert banners
+- The `onClose` handler in Profile.tsx error Alert is currently a no-op (no way to clear error from component)
+
+**Browser Compatibility:**
+- `Notification.permission` is standard across modern browsers
+- Service worker requirement means notifications only work on HTTPS (except localhost)
+- iOS Safari has limited PWA notification support
+
+**Related Files:**
+- `packages/web/src/messaging.ts` - Firebase setup and token management
+- `packages/web/public/firebase-messaging-sw.js` - Service worker for background notifications

--- a/packages/web/src/components/NotificationBanner.tsx
+++ b/packages/web/src/components/NotificationBanner.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Alert, Divider, Link } from "@mui/material";
 import { Warning as WarningIcon } from "@mui/icons-material";
 import { useNavigate } from "react-router";
-import { service } from "../store";
+import { useMessaging } from "../context";
 
 const NotificationBanner: React.FC = () => {
-  const query = service.endpoints.devicesList.useQuery(undefined);
+  const { enabled, isLoading } = useMessaging();
   const navigate = useNavigate();
 
   const handleLinkClick = (
@@ -15,7 +15,12 @@ const NotificationBanner: React.FC = () => {
     navigate("/profile");
   };
 
-  if (query.data && !query.data.find((device) => device.type === "web")) {
+  // Don't show banner while loading initial state
+  if (isLoading) {
+    return null;
+  }
+
+  if (!enabled) {
     return (
       <>
         <Alert severity="warning" icon={<WarningIcon />}>

--- a/packages/web/src/screens/Home/Profile.tsx
+++ b/packages/web/src/screens/Home/Profile.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
   Divider,
   Skeleton,
+  Alert,
 } from "@mui/material";
 import { HomeLayout } from "./Layout";
 import { authSlice, service } from "../../store";
@@ -26,7 +27,7 @@ const Profile: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const query = service.endpoints.userRetrieve.useQuery();
-  const { enableMessaging, enabled, disableMessaging } = useMessaging();
+  const { enableMessaging, enabled, disableMessaging, permissionDenied, error } = useMessaging();
 
   const handleLogout = () => {
     dispatch(authSlice.actions.logout());
@@ -92,12 +93,23 @@ const Profile: React.FC = () => {
           <Divider />
           <Stack p={2} gap={2}>
             <Typography variant="h4">Notifications</Typography>
-            <Stack>
+            <Stack gap={2}>
+              {error && (
+                <Alert severity="error">
+                  {error}
+                </Alert>
+              )}
+              {permissionDenied && !error && (
+                <Alert severity="warning">
+                  Notifications are blocked in your browser. To enable them, click the icon in your address bar and allow notifications.
+                </Alert>
+              )}
               <FormControl>
                 <FormControlLabel
                   control={
                     <Switch
                       checked={enabled}
+                      disabled={permissionDenied}
                       onChange={(_, checked) => {
                         if (checked) {
                           enableMessaging();


### PR DESCRIPTION
Fix notification permission error handling and UI feedback

  Summary

  - Fixed notification toggle appearing broken for users with denied browser permissions
  - Added proper error messages and user guidance when permissions are blocked
  - Prevented notification banner from flashing on page load during state initialization

  Changes

  MessagingContext (packages/web/src/context/MessagingContext.tsx)
  - Added permissionDenied, error, and isLoading to context state
  - Check Notification.permission before requesting to detect already-denied state
  - Only attempt silent token retrieval if permission already granted
  - Surface error messages for failed operations

  Profile Screen (packages/web/src/screens/Home/Profile.tsx)
  - Display error Alert when notification operations fail
  - Show warning Alert with instructions when permission is blocked
  - Disable toggle when permissionDenied is true

  NotificationBanner (packages/web/src/components/NotificationBanner.tsx)
  - Hide banner while loading initial notification state
  - Simplified enabled check logic

  Test Plan

  - Fresh browser: toggle shows permission prompt, handles allow/deny correctly
  - Permission denied: shows warning banner with instructions, toggle disabled
  - Permission granted: toggle works without new prompts, banner hidden
  - No banner flash on page load
  - Error messages display for API failures

  Notes

  Fixes issue reported by users on Edge and other browsers where the toggle appeared
  unresponsive when notification permission was previously denied.