### PR TITLE
Add state persistence with localStorage (Variant Creator Phase 4)

### DIFF
--- a/packages/variant-creator/src/App.tsx
+++ b/packages/variant-creator/src/App.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
 import { FileUpload } from "@/components/common/FileUpload";
 import { MapCanvas } from "@/components/map/MapCanvas";
+import { Button } from "@/components/ui/button";
+import { useVariant } from "@/hooks/useVariant";
 import { parseSvg } from "@/utils/svg";
 import { createInitialVariant } from "@/utils/variantFactory";
 import type { SvgValidationResult } from "@/types/svg";
-import type { VariantDefinition } from "@/types/variant";
 
 function App() {
-  const [variant, setVariant] = useState<VariantDefinition | null>(null);
+  const { variant, setVariant, clearDraft } = useVariant();
 
   const handleFileValidated = (
     result: SvgValidationResult,
@@ -17,8 +17,6 @@ function App() {
       const parsed = parseSvg(svgContent);
       const initialVariant = createInitialVariant(parsed);
       setVariant(initialVariant);
-    } else {
-      setVariant(null);
     }
   };
 
@@ -35,9 +33,14 @@ function App() {
 
         {variant && (
           <div className="mt-8 w-full">
-            <p className="mb-4 text-lg font-medium">
-              {variant.provinces.length} provinces detected
-            </p>
+            <div className="mb-4 flex items-center justify-between">
+              <p className="text-lg font-medium">
+                {variant.provinces.length} provinces detected
+              </p>
+              <Button variant="outline" onClick={clearDraft}>
+                Clear Draft
+              </Button>
+            </div>
             <MapCanvas variant={variant} />
           </div>
         )}

--- a/packages/variant-creator/src/hooks/__tests__/useVariant.test.ts
+++ b/packages/variant-creator/src/hooks/__tests__/useVariant.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVariant, STORAGE_KEY } from "../useVariant";
+import type { VariantDefinition } from "@/types/variant";
+
+const createMockVariant = (name: string = "test"): VariantDefinition => ({
+  name,
+  description: "",
+  author: "",
+  version: "1.0.0",
+  soloVictorySCCount: 0,
+  nations: [],
+  provinces: [
+    {
+      id: "prov1",
+      elementId: "prov1",
+      name: "Province 1",
+      type: "land",
+      path: "M0,0 L10,10",
+      homeNation: null,
+      supplyCenter: false,
+      startingUnit: null,
+      adjacencies: [],
+      labels: [],
+      unitPosition: { x: 5, y: 5 },
+      dislodgedUnitPosition: { x: 10, y: 10 },
+    },
+  ],
+  namedCoasts: [],
+  decorativeElements: [],
+  dimensions: { width: 100, height: 100 },
+});
+
+describe("useVariant", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("initialization", () => {
+    it("returns null when no saved draft exists", () => {
+      const { result } = renderHook(() => useVariant());
+
+      expect(result.current.variant).toBeNull();
+    });
+
+    it("loads variant from localStorage on init", () => {
+      const mockVariant = createMockVariant("saved");
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockVariant));
+
+      const { result } = renderHook(() => useVariant());
+
+      expect(result.current.variant).toEqual(mockVariant);
+    });
+
+    it("returns null and clears storage when saved data is corrupted", () => {
+      localStorage.setItem(STORAGE_KEY, "not valid json{{{");
+
+      const { result } = renderHook(() => useVariant());
+
+      expect(result.current.variant).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("setVariant", () => {
+    it("updates variant state", () => {
+      const { result } = renderHook(() => useVariant());
+      const mockVariant = createMockVariant();
+
+      act(() => {
+        result.current.setVariant(mockVariant);
+      });
+
+      expect(result.current.variant).toEqual(mockVariant);
+    });
+
+    it("saves to localStorage on state change", () => {
+      const { result } = renderHook(() => useVariant());
+      const mockVariant = createMockVariant();
+
+      act(() => {
+        result.current.setVariant(mockVariant);
+      });
+
+      const saved = localStorage.getItem(STORAGE_KEY);
+      expect(saved).not.toBeNull();
+      expect(JSON.parse(saved!)).toEqual(mockVariant);
+    });
+
+    it("persists updates across multiple changes", () => {
+      const { result } = renderHook(() => useVariant());
+
+      act(() => {
+        result.current.setVariant(createMockVariant("first"));
+      });
+
+      act(() => {
+        result.current.setVariant(createMockVariant("second"));
+      });
+
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(saved.name).toBe("second");
+    });
+  });
+
+  describe("clearDraft", () => {
+    it("removes variant from state", () => {
+      const { result } = renderHook(() => useVariant());
+
+      act(() => {
+        result.current.setVariant(createMockVariant());
+      });
+      expect(result.current.variant).not.toBeNull();
+
+      act(() => {
+        result.current.clearDraft();
+      });
+
+      expect(result.current.variant).toBeNull();
+    });
+
+    it("removes from localStorage", () => {
+      const { result } = renderHook(() => useVariant());
+
+      act(() => {
+        result.current.setVariant(createMockVariant());
+      });
+      expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+      act(() => {
+        result.current.clearDraft();
+      });
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles localStorage quota exceeded gracefully", () => {
+      const { result } = renderHook(() => useVariant());
+
+      const originalSetItem = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = vi.fn(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+      expect(() => {
+        act(() => {
+          result.current.setVariant(createMockVariant());
+        });
+      }).not.toThrow();
+
+      expect(result.current.variant).not.toBeNull();
+
+      localStorage.setItem = originalSetItem;
+    });
+  });
+});

--- a/packages/variant-creator/src/hooks/useVariant.ts
+++ b/packages/variant-creator/src/hooks/useVariant.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback } from "react";
+import type { VariantDefinition } from "@/types/variant";
+
+const STORAGE_KEY = "variant-creator-draft";
+
+function loadFromStorage(): VariantDefinition | null {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return null;
+    return JSON.parse(saved) as VariantDefinition;
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function useVariant() {
+  const [variant, setVariant] = useState<VariantDefinition | null>(() => {
+    return loadFromStorage();
+  });
+
+  useEffect(() => {
+    if (variant) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(variant));
+      } catch {
+        // localStorage full - fail silently
+      }
+    }
+  }, [variant]);
+
+  const clearDraft = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setVariant(null);
+  }, []);
+
+  return { variant, setVariant, clearDraft };
+}
+
+export { STORAGE_KEY };

--- a/packages/variant-creator/vitest.setup.ts
+++ b/packages/variant-creator/vitest.setup.ts
@@ -6,4 +6,5 @@ expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });


### PR DESCRIPTION
### Why?

The Variant Creator is a wizard that takes ~90 minutes to complete a variant. Without state persistence, users would lose all progress on page refresh. Phase 4 adds localStorage integration so variant state survives browser refreshes and users can resume editing later.

### How?

Created a `useVariant` hook that wraps React's useState with localStorage auto-save on every state change and auto-load on mount. Added a "Clear Draft" button so users can intentionally start fresh.

<details>
<summary>Implementation Plan</summary>

**Files Created:**
- `src/hooks/useVariant.ts` - Hook with localStorage integration
- `src/hooks/__tests__/useVariant.test.ts` - Unit tests

**Files Modified:**
- `src/App.tsx` - Integrates hook, adds Clear Draft button
- `src/__tests__/App.test.tsx` - Persistence integration tests
- `vitest.setup.ts` - Clears localStorage between tests

**Edge Cases Handled:**
- Corrupted JSON in localStorage → clear storage, return null
- localStorage quota exceeded → fail silently, state still updates
- Invalid SVG upload with existing draft → preserves existing draft

</details>

<sub>Generated with Claude Code</sub>