### PR TITLE
Add wizard Phase 2 for text association (Variant Creator Phase 9)

### DIFF
--- a/packages/variant-creator/src/Router.tsx
+++ b/packages/variant-creator/src/Router.tsx
@@ -3,10 +3,12 @@ import { LandingPage } from "@/components/LandingPage";
 import { WizardLayout } from "@/components/wizard/WizardLayout";
 import { PhaseSetup } from "@/components/wizard/PhaseSetup";
 import { PhaseProvinces } from "@/components/wizard/PhaseProvinces";
+import { PhaseTextAssoc } from "@/components/wizard/PhaseTextAssoc";
 
 const WIZARD_PHASES = [
   { path: "0", title: "Variant Setup", component: PhaseSetup },
   { path: "1", title: "Province Details", component: PhaseProvinces },
+  { path: "2", title: "Text Association", component: PhaseTextAssoc },
 ];
 
 function WizardOutlet() {

--- a/packages/variant-creator/src/components/common/__tests__/JsonUpload.test.tsx
+++ b/packages/variant-creator/src/components/common/__tests__/JsonUpload.test.tsx
@@ -30,6 +30,7 @@ const createValidVariant = (): VariantDefinition => ({
   namedCoasts: [],
   decorativeElements: [],
   dimensions: { width: 100, height: 100 },
+  textElements: [],
 });
 
 beforeEach(() => {

--- a/packages/variant-creator/src/components/map/TextLayer.tsx
+++ b/packages/variant-creator/src/components/map/TextLayer.tsx
@@ -1,0 +1,73 @@
+import type { TextElement } from "@/types/variant";
+
+interface TextLayerProps {
+  textElements: TextElement[];
+  associations: Map<number, string | null>;
+  selectedTextIndex: number | null;
+  onTextClick?: (textIndex: number) => void;
+  onTextMouseEnter?: (textIndex: number) => void;
+  onTextMouseLeave?: () => void;
+}
+
+function getTextFill(
+  isSelected: boolean,
+  isAssociated: boolean,
+  originalFill?: string
+): string {
+  if (isSelected) {
+    return "#FFD700";
+  }
+
+  if (!isAssociated) {
+    return "#DC2626";
+  }
+
+  return originalFill ?? "#333333";
+}
+
+export const TextLayer: React.FC<TextLayerProps> = ({
+  textElements,
+  associations,
+  selectedTextIndex,
+  onTextClick,
+  onTextMouseEnter,
+  onTextMouseLeave,
+}) => {
+  return (
+    <g className="text-layer">
+      {textElements.map((text, index) => {
+        const isSelected = index === selectedTextIndex;
+        const isAssociated = associations.get(index) !== null;
+        const fill = getTextFill(isSelected, isAssociated, text.styles?.fill);
+
+        const transform = text.rotation
+          ? `rotate(${text.rotation}, ${text.x}, ${text.y})`
+          : undefined;
+
+        return (
+          <text
+            key={index}
+            x={text.x}
+            y={text.y}
+            transform={transform}
+            fill={fill}
+            fontSize={text.styles?.fontSize ?? "14px"}
+            fontFamily={text.styles?.fontFamily ?? "sans-serif"}
+            fontWeight={text.styles?.fontWeight ?? "normal"}
+            stroke={isSelected ? "#B8860B" : "none"}
+            strokeWidth={isSelected ? 0.5 : 0}
+            style={{
+              cursor: onTextClick ? "pointer" : "default",
+              userSelect: "none",
+            }}
+            onClick={() => onTextClick?.(index)}
+            onMouseEnter={() => onTextMouseEnter?.(index)}
+            onMouseLeave={() => onTextMouseLeave?.()}
+          >
+            {text.content}
+          </text>
+        );
+      })}
+    </g>
+  );
+};

--- a/packages/variant-creator/src/components/map/__tests__/MapCanvas.test.tsx
+++ b/packages/variant-creator/src/components/map/__tests__/MapCanvas.test.tsx
@@ -47,6 +47,7 @@ const createTestVariant = (
   namedCoasts: [],
   decorativeElements: [],
   dimensions: { width: 100, height: 100 },
+  textElements: [],
   ...overrides,
 });
 

--- a/packages/variant-creator/src/components/wizard/PhaseTextAssoc.tsx
+++ b/packages/variant-creator/src/components/wizard/PhaseTextAssoc.tsx
@@ -1,0 +1,302 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ProvinceLayer } from "@/components/map/ProvinceLayer";
+import { TextLayer } from "@/components/map/TextLayer";
+import { useVariant } from "@/hooks/useVariant";
+import {
+  autoAssociateText,
+  syncAssociationsToProvinces,
+  buildAssociationsFromProvinces,
+} from "@/utils/textAssociation";
+import { Wand2, X } from "lucide-react";
+
+export function PhaseTextAssoc() {
+  const { variant, setProvinces } = useVariant();
+  const [selectedTextIndex, setSelectedTextIndex] = useState<number | null>(
+    null
+  );
+  const [hoveredProvinceId, setHoveredProvinceId] = useState<string | null>(
+    null
+  );
+  const [associations, setAssociations] = useState<Map<number, string | null>>(
+    () => new Map()
+  );
+  const tableRowRefs = useRef<Map<number, HTMLTableRowElement>>(new Map());
+  const hasInitialized = useRef(false);
+
+  const textElements = useMemo(
+    () => variant?.textElements ?? [],
+    [variant?.textElements]
+  );
+  const provinces = useMemo(
+    () => variant?.provinces ?? [],
+    [variant?.provinces]
+  );
+
+  useEffect(() => {
+    if (!hasInitialized.current && variant && textElements.length > 0) {
+      const existingAssociations = buildAssociationsFromProvinces(
+        textElements,
+        provinces
+      );
+      setAssociations(existingAssociations);
+      hasInitialized.current = true;
+    }
+  }, [variant, textElements, provinces]);
+
+  const syncToProvinces = useCallback(
+    (newAssociations: Map<number, string | null>) => {
+      if (!variant) return;
+      const updatedProvinces = syncAssociationsToProvinces(
+        textElements,
+        provinces,
+        newAssociations
+      );
+      setProvinces(updatedProvinces);
+    },
+    [variant, textElements, provinces, setProvinces]
+  );
+
+  const handleAutoDetect = () => {
+    const detected = autoAssociateText(textElements, provinces);
+    setAssociations(detected);
+    syncToProvinces(detected);
+  };
+
+  const handleAssociationChange = (
+    textIndex: number,
+    provinceId: string | null
+  ) => {
+    const newAssociations = new Map(associations);
+    newAssociations.set(textIndex, provinceId);
+    setAssociations(newAssociations);
+    syncToProvinces(newAssociations);
+  };
+
+  const handleTextClick = (textIndex: number) => {
+    setSelectedTextIndex(textIndex === selectedTextIndex ? null : textIndex);
+    const row = tableRowRefs.current.get(textIndex);
+    if (row) {
+      row.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  };
+
+  const handleProvinceClick = (provinceId: string) => {
+    if (selectedTextIndex !== null) {
+      handleAssociationChange(selectedTextIndex, provinceId);
+    }
+  };
+
+  const handleClearAssociation = (textIndex: number) => {
+    handleAssociationChange(textIndex, null);
+  };
+
+  const associatedCount = useMemo(() => {
+    let count = 0;
+    associations.forEach((value) => {
+      if (value !== null) count++;
+    });
+    return count;
+  }, [associations]);
+
+  if (!variant) {
+    return null;
+  }
+
+  const { dimensions, decorativeElements, nations } = variant;
+
+  if (textElements.length === 0) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Text Association</CardTitle>
+            <CardDescription>
+              No text elements found in the SVG. You can proceed to the next
+              phase.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground">
+              The uploaded SVG does not contain a text layer, or the text layer
+              is empty. Province labels can be generated automatically in a
+              later phase.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Text Association</CardTitle>
+          <CardDescription>
+            Link text elements from the SVG to their provinces. Click a text on
+            the map, then click a province to associate them.
+            <span className="ml-2 text-muted-foreground">
+              {associatedCount} of {textElements.length} texts associated
+            </span>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-6">
+            <div>
+              <svg
+                viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+                className="w-full h-auto border rounded-lg bg-muted"
+                style={{ maxHeight: "40vh" }}
+              >
+                {decorativeElements.map((element) => (
+                  <g
+                    key={element.id}
+                    dangerouslySetInnerHTML={{ __html: element.content }}
+                  />
+                ))}
+
+                <ProvinceLayer
+                  provinces={provinces}
+                  nations={nations}
+                  selectedProvinceId={null}
+                  hoveredProvinceId={hoveredProvinceId}
+                  onProvinceClick={handleProvinceClick}
+                  onProvinceMouseEnter={setHoveredProvinceId}
+                  onProvinceMouseLeave={() => setHoveredProvinceId(null)}
+                />
+
+                <TextLayer
+                  textElements={textElements}
+                  associations={associations}
+                  selectedTextIndex={selectedTextIndex}
+                  onTextClick={handleTextClick}
+                />
+              </svg>
+
+              {selectedTextIndex !== null && (
+                <div className="mt-2 p-2 bg-muted rounded text-sm">
+                  <strong>Selected text:</strong>{" "}
+                  &quot;{textElements[selectedTextIndex].content}&quot; - Click a
+                  province to associate
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={handleAutoDetect} variant="outline">
+                <Wand2 className="mr-2 h-4 w-4" />
+                Auto-Detect
+              </Button>
+            </div>
+
+            <div className="border rounded-lg max-h-[300px] overflow-y-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 sticky top-0">
+                  <tr className="border-b">
+                    <th className="w-12 px-4 py-3 text-left font-medium">#</th>
+                    <th className="px-4 py-3 text-left font-medium">Text Content</th>
+                    <th className="w-48 px-4 py-3 text-left font-medium">Province</th>
+                    <th className="w-20 px-4 py-3 text-left font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {textElements.map((text, index) => {
+                    const isSelected = index === selectedTextIndex;
+                    const associatedProvinceId = associations.get(index);
+
+                    return (
+                      <tr
+                        key={index}
+                        ref={(el: HTMLTableRowElement | null) => {
+                          if (el) {
+                            tableRowRefs.current.set(index, el);
+                          } else {
+                            tableRowRefs.current.delete(index);
+                          }
+                        }}
+                        className={`cursor-pointer border-b hover:bg-muted/50 ${isSelected ? "bg-muted" : ""}`}
+                        onClick={() => setSelectedTextIndex(index)}
+                      >
+                        <td className="px-4 py-3 font-mono text-muted-foreground">
+                          {index + 1}
+                        </td>
+                        <td
+                          className={`px-4 py-3 ${
+                            associatedProvinceId === null
+                              ? "text-destructive"
+                              : ""
+                          }`}
+                        >
+                          {text.content || "(empty)"}
+                        </td>
+                        <td className="px-4 py-3">
+                          <Select
+                            value={associatedProvinceId ?? "none"}
+                            onValueChange={(value) =>
+                              handleAssociationChange(
+                                index,
+                                value === "none" ? null : value
+                              )
+                            }
+                          >
+                            <SelectTrigger
+                              className="w-full"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <SelectValue placeholder="Select province" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="none">
+                                (none - decorative)
+                              </SelectItem>
+                              {provinces.map((province) => (
+                                <SelectItem
+                                  key={province.id}
+                                  value={province.id}
+                                >
+                                  {province.name || province.id}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </td>
+                        <td className="px-4 py-3">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleClearAssociation(index);
+                            }}
+                            disabled={associatedProvinceId === null}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/variant-creator/src/components/wizard/__tests__/PhaseTextAssoc.test.tsx
+++ b/packages/variant-creator/src/components/wizard/__tests__/PhaseTextAssoc.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PhaseTextAssoc } from "../PhaseTextAssoc";
+import { STORAGE_KEY } from "@/hooks/useVariant";
+
+vi.mock("@/utils/geometry", () => ({
+  calculateCentroid: vi.fn((path: string) => {
+    if (path.includes("10,10")) return { x: 20, y: 20 };
+    if (path.includes("40,10")) return { x: 50, y: 20 };
+    return { x: 80, y: 20 };
+  }),
+  calculatePositions: vi.fn(() => ({
+    unitPosition: { x: 20, y: 20 },
+    dislodgedUnitPosition: { x: 35, y: 35 },
+    supplyCenterPosition: { x: 8, y: 8 },
+  })),
+}));
+
+const mockVariantWithText = {
+  name: "Test Variant",
+  description: "",
+  author: "",
+  version: "1.0.0",
+  soloVictorySCCount: 18,
+  nations: [{ id: "england", name: "England", color: "#2196F3" }],
+  provinces: [
+    {
+      id: "ber",
+      elementId: "province-1",
+      name: "Berlin",
+      type: "land" as const,
+      path: "M10,10 L30,10 L30,30 L10,30 Z",
+      homeNation: "england",
+      supplyCenter: true,
+      startingUnit: { type: "Army" as const },
+      adjacencies: [],
+      labels: [],
+      unitPosition: { x: 20, y: 20 },
+      dislodgedUnitPosition: { x: 35, y: 35 },
+      supplyCenterPosition: { x: 8, y: 8 },
+    },
+    {
+      id: "mun",
+      elementId: "province-2",
+      name: "Munich",
+      type: "land" as const,
+      path: "M40,10 L60,10 L60,30 L40,30 Z",
+      homeNation: null,
+      supplyCenter: false,
+      startingUnit: null,
+      adjacencies: [],
+      labels: [],
+      unitPosition: { x: 50, y: 20 },
+      dislodgedUnitPosition: { x: 65, y: 35 },
+    },
+  ],
+  namedCoasts: [],
+  decorativeElements: [],
+  dimensions: { width: 100, height: 100 },
+  textElements: [
+    { content: "Berlin", x: 20, y: 20 },
+    { content: "Munich", x: 50, y: 20 },
+    { content: "Far Away", x: 500, y: 500 },
+  ],
+};
+
+const mockVariantNoText = {
+  ...mockVariantWithText,
+  textElements: [],
+};
+
+function renderWithRouter() {
+  return render(
+    <MemoryRouter>
+      <PhaseTextAssoc />
+    </MemoryRouter>
+  );
+}
+
+describe("PhaseTextAssoc", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("with text elements", () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockVariantWithText));
+    });
+
+    it("renders text association section", () => {
+      renderWithRouter();
+      expect(screen.getByText("Text Association")).toBeInTheDocument();
+    });
+
+    it("displays all text elements in the table", () => {
+      renderWithRouter();
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Munich").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Far Away").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows association count", () => {
+      renderWithRouter();
+      expect(screen.getByText(/0 of 3 texts associated/)).toBeInTheDocument();
+    });
+
+    it("renders the map with provinces", () => {
+      renderWithRouter();
+
+      const svg = document.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+
+      const paths = document.querySelectorAll("path");
+      expect(paths.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("renders auto-detect button", () => {
+      renderWithRouter();
+      expect(screen.getByText("Auto-Detect")).toBeInTheDocument();
+    });
+
+    it("auto-detects associations based on proximity", async () => {
+      renderWithRouter();
+
+      const autoDetectButton = screen.getByText("Auto-Detect");
+      fireEvent.click(autoDetectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 of 3 texts associated/)).toBeInTheDocument();
+      });
+    });
+
+    it("allows selecting a text element from the table", async () => {
+      renderWithRouter();
+
+      const berlinCells = screen.getAllByText("Berlin");
+      const tableCell = berlinCells.find((el) => el.closest("td"));
+      const firstRow = tableCell?.closest("tr");
+      fireEvent.click(firstRow!);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Selected text:/)).toBeInTheDocument();
+      });
+    });
+
+    it("persists associations to localStorage", async () => {
+      renderWithRouter();
+
+      const autoDetectButton = screen.getByText("Auto-Detect");
+      fireEvent.click(autoDetectButton);
+
+      await waitFor(() => {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        const parsed = JSON.parse(saved!);
+        const berlinProvince = parsed.provinces.find(
+          (p: { id: string }) => p.id === "ber"
+        );
+        expect(berlinProvince.labels.length).toBeGreaterThan(0);
+        expect(berlinProvince.labels[0].text).toBe("Berlin");
+        expect(berlinProvince.labels[0].source).toBe("svg");
+      });
+    });
+
+    it("shows province dropdown for each text", () => {
+      renderWithRouter();
+
+      const triggers = screen.getAllByRole("combobox");
+      expect(triggers.length).toBe(3);
+    });
+
+    it("clears association when clear button is clicked", async () => {
+      renderWithRouter();
+
+      const autoDetectButton = screen.getByText("Auto-Detect");
+      fireEvent.click(autoDetectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 of 3 texts associated/)).toBeInTheDocument();
+      });
+
+      const clearButtons = screen.getAllByRole("button", { name: "" });
+      const enabledClearButton = clearButtons.find(
+        (btn) => !btn.hasAttribute("disabled")
+      );
+
+      if (enabledClearButton) {
+        fireEvent.click(enabledClearButton);
+
+        await waitFor(() => {
+          expect(screen.getByText(/1 of 3 texts associated/)).toBeInTheDocument();
+        });
+      }
+    });
+  });
+
+  describe("without text elements", () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockVariantNoText));
+    });
+
+    it("shows empty state message", () => {
+      renderWithRouter();
+      expect(
+        screen.getByText(/No text elements found in the SVG/)
+      ).toBeInTheDocument();
+    });
+
+    it("indicates user can proceed to next phase", () => {
+      renderWithRouter();
+      expect(
+        screen.getByText(/You can proceed to the next phase/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("without variant loaded", () => {
+    it("returns null when no variant is loaded", () => {
+      localStorage.clear();
+      const { container } = renderWithRouter();
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/packages/variant-creator/src/hooks/__tests__/useVariant.test.ts
+++ b/packages/variant-creator/src/hooks/__tests__/useVariant.test.ts
@@ -29,6 +29,7 @@ const createMockVariant = (name: string = "test"): VariantDefinition => ({
   namedCoasts: [],
   decorativeElements: [],
   dimensions: { width: 100, height: 100 },
+  textElements: [],
 });
 
 describe("useVariant", () => {

--- a/packages/variant-creator/src/types/variant.ts
+++ b/packages/variant-creator/src/types/variant.ts
@@ -71,6 +71,7 @@ export interface VariantDefinition {
   namedCoasts: NamedCoast[];
   decorativeElements: DecorativeElement[];
   dimensions: Dimensions;
+  textElements: TextElement[];
 }
 
 export interface ProvincePath {

--- a/packages/variant-creator/src/utils/__tests__/export.test.ts
+++ b/packages/variant-creator/src/utils/__tests__/export.test.ts
@@ -15,6 +15,7 @@ const createMockVariant = (
   namedCoasts: [],
   decorativeElements: [],
   dimensions: { width: 1000, height: 800 },
+  textElements: [],
   ...overrides,
 });
 

--- a/packages/variant-creator/src/utils/__tests__/textAssociation.test.ts
+++ b/packages/variant-creator/src/utils/__tests__/textAssociation.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  autoAssociateText,
+  textElementToLabel,
+  syncAssociationsToProvinces,
+  buildAssociationsFromProvinces,
+} from "../textAssociation";
+import type { TextElement, Province, Label } from "@/types/variant";
+
+vi.mock("../geometry", () => ({
+  calculateCentroid: vi.fn((pathD: string) => {
+    const match = pathD.match(/M(\d+),(\d+)/);
+    if (match) {
+      const x = parseInt(match[1], 10) + 10;
+      const y = parseInt(match[2], 10) + 10;
+      return { x, y };
+    }
+    return { x: 0, y: 0 };
+  }),
+}));
+
+const createProvince = (
+  id: string,
+  centroidX: number,
+  centroidY: number,
+  labels: Label[] = []
+): Province => ({
+  id,
+  elementId: `path_${id}`,
+  name: id.charAt(0).toUpperCase() + id.slice(1),
+  type: "land",
+  path: `M${centroidX - 10},${centroidY - 10} L${centroidX + 10},${centroidY - 10} L${centroidX + 10},${centroidY + 10} L${centroidX - 10},${centroidY + 10} Z`,
+  homeNation: null,
+  supplyCenter: false,
+  startingUnit: null,
+  adjacencies: [],
+  labels,
+  unitPosition: { x: centroidX, y: centroidY },
+  dislodgedUnitPosition: { x: centroidX + 15, y: centroidY + 15 },
+  supplyCenterPosition: { x: centroidX - 12, y: centroidY - 12 },
+});
+
+const createTextElement = (
+  content: string,
+  x: number,
+  y: number
+): TextElement => ({
+  content,
+  x,
+  y,
+});
+
+describe("autoAssociateText", () => {
+  it("associates text with closest province within threshold", () => {
+    const textElements: TextElement[] = [createTextElement("Berlin", 100, 100)];
+    const provinces: Province[] = [
+      createProvince("ber", 100, 100),
+      createProvince("mun", 200, 200),
+    ];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBe("ber");
+  });
+
+  it("returns null for text outside threshold", () => {
+    const textElements: TextElement[] = [createTextElement("Far Away", 500, 500)];
+    const provinces: Province[] = [createProvince("ber", 100, 100)];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBeNull();
+  });
+
+  it("handles multiple texts associating with same province", () => {
+    const textElements: TextElement[] = [
+      createTextElement("Berlin", 100, 95),
+      createTextElement("BER", 100, 105),
+    ];
+    const provinces: Province[] = [createProvince("ber", 100, 100)];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBe("ber");
+    expect(result.get(1)).toBe("ber");
+  });
+
+  it("handles empty text elements array", () => {
+    const textElements: TextElement[] = [];
+    const provinces: Province[] = [createProvince("ber", 100, 100)];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.size).toBe(0);
+  });
+
+  it("handles empty provinces array", () => {
+    const textElements: TextElement[] = [createTextElement("Berlin", 100, 100)];
+    const provinces: Province[] = [];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBeNull();
+  });
+
+  it("associates each text with closest province when multiple provinces exist", () => {
+    const textElements: TextElement[] = [
+      createTextElement("Berlin", 100, 100),
+      createTextElement("Munich", 200, 200),
+    ];
+    const provinces: Province[] = [
+      createProvince("ber", 100, 100),
+      createProvince("mun", 200, 200),
+    ];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBe("ber");
+    expect(result.get(1)).toBe("mun");
+  });
+
+  it("picks closest province when text is between two provinces", () => {
+    const textElements: TextElement[] = [createTextElement("Text", 140, 100)];
+    const provinces: Province[] = [
+      createProvince("ber", 100, 100),
+      createProvince("mun", 200, 100),
+    ];
+
+    const result = autoAssociateText(textElements, provinces);
+
+    expect(result.get(0)).toBe("ber");
+  });
+});
+
+describe("textElementToLabel", () => {
+  it("converts text element to label with svg source", () => {
+    const text: TextElement = {
+      content: "Berlin",
+      x: 100,
+      y: 200,
+      rotation: 45,
+      styles: { fontSize: "12px", fill: "#000" },
+    };
+
+    const label = textElementToLabel(text);
+
+    expect(label).toEqual({
+      text: "Berlin",
+      position: { x: 100, y: 200 },
+      rotation: 45,
+      source: "svg",
+      styles: { fontSize: "12px", fill: "#000" },
+    });
+  });
+
+  it("handles text element without optional fields", () => {
+    const text: TextElement = {
+      content: "Simple",
+      x: 50,
+      y: 75,
+    };
+
+    const label = textElementToLabel(text);
+
+    expect(label).toEqual({
+      text: "Simple",
+      position: { x: 50, y: 75 },
+      rotation: undefined,
+      source: "svg",
+      styles: undefined,
+    });
+  });
+});
+
+describe("syncAssociationsToProvinces", () => {
+  it("adds labels to provinces based on associations", () => {
+    const textElements: TextElement[] = [
+      createTextElement("Berlin", 100, 100),
+      createTextElement("Munich", 200, 200),
+    ];
+    const provinces: Province[] = [
+      createProvince("ber", 100, 100),
+      createProvince("mun", 200, 200),
+    ];
+    const associations = new Map<number, string | null>([
+      [0, "ber"],
+      [1, "mun"],
+    ]);
+
+    const result = syncAssociationsToProvinces(
+      textElements,
+      provinces,
+      associations
+    );
+
+    expect(result[0].labels).toHaveLength(1);
+    expect(result[0].labels[0].text).toBe("Berlin");
+    expect(result[1].labels).toHaveLength(1);
+    expect(result[1].labels[0].text).toBe("Munich");
+  });
+
+  it("preserves non-svg labels on provinces", () => {
+    const generatedLabel: Label = {
+      text: "Generated",
+      position: { x: 50, y: 50 },
+      source: "generated",
+    };
+    const provinces: Province[] = [createProvince("ber", 100, 100, [generatedLabel])];
+    const textElements: TextElement[] = [createTextElement("Berlin", 100, 100)];
+    const associations = new Map<number, string | null>([[0, "ber"]]);
+
+    const result = syncAssociationsToProvinces(
+      textElements,
+      provinces,
+      associations
+    );
+
+    expect(result[0].labels).toHaveLength(2);
+    expect(result[0].labels.find((l) => l.source === "generated")).toBeDefined();
+    expect(result[0].labels.find((l) => l.source === "svg")).toBeDefined();
+  });
+
+  it("removes old svg labels when syncing", () => {
+    const oldSvgLabel: Label = {
+      text: "Old",
+      position: { x: 10, y: 10 },
+      source: "svg",
+    };
+    const provinces: Province[] = [createProvince("ber", 100, 100, [oldSvgLabel])];
+    const textElements: TextElement[] = [createTextElement("New", 100, 100)];
+    const associations = new Map<number, string | null>([[0, "ber"]]);
+
+    const result = syncAssociationsToProvinces(
+      textElements,
+      provinces,
+      associations
+    );
+
+    expect(result[0].labels).toHaveLength(1);
+    expect(result[0].labels[0].text).toBe("New");
+  });
+
+  it("handles null associations (decorative text)", () => {
+    const textElements: TextElement[] = [createTextElement("Decorative", 500, 500)];
+    const provinces: Province[] = [createProvince("ber", 100, 100)];
+    const associations = new Map<number, string | null>([[0, null]]);
+
+    const result = syncAssociationsToProvinces(
+      textElements,
+      provinces,
+      associations
+    );
+
+    expect(result[0].labels).toHaveLength(0);
+  });
+
+  it("handles multiple texts on same province", () => {
+    const textElements: TextElement[] = [
+      createTextElement("Spain", 100, 100),
+      createTextElement("NC", 100, 120),
+    ];
+    const provinces: Province[] = [createProvince("spa", 100, 110)];
+    const associations = new Map<number, string | null>([
+      [0, "spa"],
+      [1, "spa"],
+    ]);
+
+    const result = syncAssociationsToProvinces(
+      textElements,
+      provinces,
+      associations
+    );
+
+    expect(result[0].labels).toHaveLength(2);
+    expect(result[0].labels[0].text).toBe("Spain");
+    expect(result[0].labels[1].text).toBe("NC");
+  });
+});
+
+describe("buildAssociationsFromProvinces", () => {
+  it("builds associations from existing province labels", () => {
+    const textElements: TextElement[] = [
+      createTextElement("Berlin", 100, 100),
+      createTextElement("Munich", 200, 200),
+    ];
+    const berLabel: Label = {
+      text: "Berlin",
+      position: { x: 100, y: 100 },
+      source: "svg",
+    };
+    const provinces: Province[] = [
+      createProvince("ber", 100, 100, [berLabel]),
+      createProvince("mun", 200, 200),
+    ];
+
+    const result = buildAssociationsFromProvinces(textElements, provinces);
+
+    expect(result.get(0)).toBe("ber");
+    expect(result.get(1)).toBeNull();
+  });
+
+  it("ignores generated labels", () => {
+    const textElements: TextElement[] = [createTextElement("Berlin", 100, 100)];
+    const generatedLabel: Label = {
+      text: "Berlin",
+      position: { x: 100, y: 100 },
+      source: "generated",
+    };
+    const provinces: Province[] = [createProvince("ber", 100, 100, [generatedLabel])];
+
+    const result = buildAssociationsFromProvinces(textElements, provinces);
+
+    expect(result.get(0)).toBeNull();
+  });
+
+  it("initializes all text indices with null", () => {
+    const textElements: TextElement[] = [
+      createTextElement("A", 0, 0),
+      createTextElement("B", 10, 10),
+      createTextElement("C", 20, 20),
+    ];
+    const provinces: Province[] = [createProvince("ber", 100, 100)];
+
+    const result = buildAssociationsFromProvinces(textElements, provinces);
+
+    expect(result.size).toBe(3);
+    expect(result.get(0)).toBeNull();
+    expect(result.get(1)).toBeNull();
+    expect(result.get(2)).toBeNull();
+  });
+});

--- a/packages/variant-creator/src/utils/__tests__/validation.test.ts
+++ b/packages/variant-creator/src/utils/__tests__/validation.test.ts
@@ -47,6 +47,7 @@ const createValidVariant = (): VariantDefinition => ({
   namedCoasts: [],
   decorativeElements: [],
   dimensions: { width: 100, height: 100 },
+  textElements: [],
 });
 
 describe("validateVariantJson", () => {

--- a/packages/variant-creator/src/utils/textAssociation.ts
+++ b/packages/variant-creator/src/utils/textAssociation.ts
@@ -1,0 +1,102 @@
+import type { TextElement, Province, Label } from "@/types/variant";
+import { calculateCentroid } from "./geometry";
+
+const ASSOCIATION_THRESHOLD = 100;
+
+export function autoAssociateText(
+  textElements: TextElement[],
+  provinces: Province[]
+): Map<number, string | null> {
+  const associations = new Map<number, string | null>();
+
+  const provinceCentroids = provinces.map((province) => ({
+    id: province.id,
+    centroid: calculateCentroid(province.path),
+  }));
+
+  textElements.forEach((text, index) => {
+    let closestProvinceId: string | null = null;
+    let closestDistance = Infinity;
+
+    provinceCentroids.forEach(({ id, centroid }) => {
+      const distance = Math.hypot(text.x - centroid.x, text.y - centroid.y);
+
+      if (distance < closestDistance && distance < ASSOCIATION_THRESHOLD) {
+        closestDistance = distance;
+        closestProvinceId = id;
+      }
+    });
+
+    associations.set(index, closestProvinceId);
+  });
+
+  return associations;
+}
+
+export function textElementToLabel(text: TextElement): Label {
+  return {
+    text: text.content,
+    position: { x: text.x, y: text.y },
+    rotation: text.rotation,
+    source: "svg",
+    styles: text.styles,
+  };
+}
+
+export function syncAssociationsToProvinces(
+  textElements: TextElement[],
+  provinces: Province[],
+  associations: Map<number, string | null>
+): Province[] {
+  const provinceLabelsMap = new Map<string, Label[]>();
+
+  provinces.forEach((province) => {
+    const existingNonSvgLabels = province.labels.filter(
+      (label) => label.source !== "svg"
+    );
+    provinceLabelsMap.set(province.id, existingNonSvgLabels);
+  });
+
+  associations.forEach((provinceId, textIndex) => {
+    if (provinceId !== null) {
+      const text = textElements[textIndex];
+      const label = textElementToLabel(text);
+      const existingLabels = provinceLabelsMap.get(provinceId) ?? [];
+      provinceLabelsMap.set(provinceId, [...existingLabels, label]);
+    }
+  });
+
+  return provinces.map((province) => ({
+    ...province,
+    labels: provinceLabelsMap.get(province.id) ?? province.labels,
+  }));
+}
+
+export function buildAssociationsFromProvinces(
+  textElements: TextElement[],
+  provinces: Province[]
+): Map<number, string | null> {
+  const associations = new Map<number, string | null>();
+
+  textElements.forEach((_, index) => {
+    associations.set(index, null);
+  });
+
+  provinces.forEach((province) => {
+    province.labels
+      .filter((label) => label.source === "svg")
+      .forEach((label) => {
+        const textIndex = textElements.findIndex(
+          (text) =>
+            text.content === label.text &&
+            text.x === label.position.x &&
+            text.y === label.position.y
+        );
+        if (textIndex !== -1) {
+          associations.set(textIndex, province.id);
+        }
+      });
+  });
+
+  return associations;
+}

--- a/packages/variant-creator/src/utils/validation.ts
+++ b/packages/variant-creator/src/utils/validation.ts
@@ -69,6 +69,14 @@ const DimensionsSchema = z.object({
   height: z.number().positive(),
 });
 
+const TextElementSchema = z.object({
+  content: z.string(),
+  x: z.number(),
+  y: z.number(),
+  rotation: z.number().optional(),
+  styles: LabelStylesSchema.optional(),
+});
+
 export const VariantDefinitionSchema = z.object({
   name: z.string(),
   description: z.string(),
@@ -80,6 +88,7 @@ export const VariantDefinitionSchema = z.object({
   namedCoasts: z.array(NamedCoastSchema),
   decorativeElements: z.array(DecorativeElementSchema),
   dimensions: DimensionsSchema,
+  textElements: z.array(TextElementSchema),
 });
 
 export type JsonValidationErrorCode =

--- a/packages/variant-creator/src/utils/variantFactory.ts
+++ b/packages/variant-creator/src/utils/variantFactory.ts
@@ -35,5 +35,6 @@ export function createInitialVariant(parsedSvg: ParsedSvg): VariantDefinition {
     namedCoasts: [],
     decorativeElements: parsedSvg.decorativeElements,
     dimensions: parsedSvg.dimensions,
+    textElements: parsedSvg.textElements,
   };
 }


### PR DESCRIPTION
### Why?

The Variant Creator wizard needs a Text Association phase (Phase 2) to enable users to link SVG text elements to provinces. This allows text labels extracted from the SVG to be associated with specific provinces for interactive highlighting when playing the variant.

### How?

Added a new wizard phase with a dual-panel interface (map + table) where users can click text elements on the map and associate them with provinces. An auto-detection algorithm pre-populates associations based on proximity to province centroids, with manual override available via dropdown or click interactions.

<details>
<summary>Implementation Plan</summary>

## Critical Fix Required

**Issue**: `textElements` from SVG parsing were discarded in `variantFactory.ts`. The `createInitialVariant()` function didn't store them.

**Solution**: Added `textElements: TextElement[]` to `VariantDefinition` and persist them during variant creation.

## Implementation Steps

1. **Add textElements to VariantDefinition** - Modified types and variantFactory
2. **Create textAssociation.ts utility** - Auto-detection algorithm using proximity to province centroids
3. **Create TextLayer component** - Renders clickable text elements on map
4. **Create PhaseTextAssoc.tsx component** - Main phase component with map view + table
5. **Update Router.tsx** - Added Phase 2 route
6. **Sync associations to province labels** - Store associations in province.labels with source: "svg"

## Files Created
- `src/utils/textAssociation.ts` - Auto-detection algorithm
- `src/components/map/TextLayer.tsx` - Text rendering on map
- `src/components/wizard/PhaseTextAssoc.tsx` - Phase 2 component
- Unit and RTL tests for all new code

</details>

<sub>Generated with Claude Code</sub>