### PR TITLE
Remove 'Inkscape' from Variant Creator landing page

### DIFF
--- a/packages/variant-creator/src/components/LandingPage.tsx
+++ b/packages/variant-creator/src/components/LandingPage.tsx
@@ -82,7 +82,7 @@ export function LandingPage() {
       <div className="flex w-full max-w-4xl flex-col items-center text-center">
         <h1 className="mb-4 text-4xl font-bold">Diplicity Variant Creator</h1>
         <p className="mb-8 text-lg text-muted-foreground">
-          Create custom Diplomacy variants using Inkscape SVG files. Upload your
+          Create custom Diplomacy variants using SVG files. Upload your
           map, define provinces and nations, and export a complete variant
           definition.
         </p>


### PR DESCRIPTION
### Why?

The Variant Creator landing page mentioned "Inkscape SVG files" specifically, but the app works with any SVG file, not just those created in Inkscape. This was unnecessarily limiting the perceived scope of the tool.

### How?

Remove "Inkscape " from the landing page description text so it reads "Create custom Diplomacy variants using SVG files."

Fixes #139

<sub>Generated with Claude Code</sub>