### PR TITLE
Fix SVG text positioning for Inkscape exports

### DIFF
--- a/packages/variant-creator/src/utils/svg.ts
+++ b/packages/variant-creator/src/utils/svg.ts
@@ -142,13 +142,19 @@ function extractTextElements(textLayer: Element | null): TextElement[] {
   if (!textLayer) return [];
 
   const texts = textLayer.querySelectorAll("text");
-  return Array.from(texts).map(text => ({
-    content: text.textContent ?? "",
-    x: parseFloat(text.getAttribute("x") ?? "0"),
-    y: parseFloat(text.getAttribute("y") ?? "0"),
-    rotation: extractTextRotation(text),
-    styles: extractTextStyles(text),
-  }));
+  return Array.from(texts).map(text => {
+    const firstTspan = text.querySelector("tspan");
+    const x = text.getAttribute("x") ?? firstTspan?.getAttribute("x") ?? "0";
+    const y = text.getAttribute("y") ?? firstTspan?.getAttribute("y") ?? "0";
+
+    return {
+      content: text.textContent ?? "",
+      x: parseFloat(x),
+      y: parseFloat(y),
+      rotation: extractTextRotation(text),
+      styles: extractTextStyles(text),
+    };
+  });
 }
 
 function getLayerName(group: Element): string | null {


### PR DESCRIPTION
### Why?

When loading Inkscape-exported SVGs in the variant-creator app, all text labels appear at the top-left corner (0, 0) instead of their correct positions. This is because Inkscape places positioning attributes (`x`/`y`) on `<tspan>` child elements rather than the parent `<text>` element.

### How?

The SVG text extraction now falls back to reading position from the first `<tspan>` child when the `<text>` element doesn't have `x`/`y` attributes.

<details>
<summary>Implementation Plan</summary>

## Root Cause

The `extractTextElements()` function reads `x` and `y` attributes from the `<text>` element:

```typescript
x: parseFloat(text.getAttribute("x") ?? "0"),
y: parseFloat(text.getAttribute("y") ?? "0"),
```

However, in Inkscape-exported SVGs, the positioning is on the `<tspan>` child element:

```xml
<text id="Paris" ...>
  <tspan x="370.15201" y="538" id="tspan253">Paris</tspan>
</text>
```

Since the `<text>` element has no `x`/`y` attributes, both default to `"0"`.

## Verification

1. Load an Inkscape-exported SVG in the variant-creator app
2. Verify text labels appear at their correct positions (not clustered at top-left)
3. Verify text rotation is preserved
4. Test with SVGs that have `x`/`y` on the `<text>` element to ensure backward compatibility

</details>

<sub>Generated with Claude Code</sub>