### PR TITLE
Add XcodeBuildMCP server for iOS simulator tooling (#174)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,8 @@
       "Bash(uniq:*)",
       "Bash(wc:*)",
       "Read(~/.claude/*)",
-      "Skill(react)"
+      "Skill(react)",
+      "mcp__XcodeBuildMCP"
     ],
     "deny": [],
     "defaultMode": "plan"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "XcodeBuildMCP": {
+      "command": "npx",
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Registers `XcodeBuildMCP` as an MCP server in `.mcp.json` at the project root, giving all Claude Code sessions access to 79 iOS development tools (simulator management, Xcode builds, UI automation, screenshots, accessibility inspection)
- Adds `mcp__XcodeBuildMCP` to the allow list in `.claude/settings.json` so agents can use the tools without interactive permission prompts
- Uses only `XcodeBuildMCP` (single-server configuration) — it covers all required capabilities including UI automation (`tap`, `swipe`, `type_text`), accessibility inspection (`snapshot_ui`), and screenshots (`screenshot`), making `ios-simulator-mcp` unnecessary

Closes #174

## Acceptance Criteria Verification

**Note:** MCP server configuration is loaded at Claude Code session start. Full validation requires opening a new Claude Code session in this repo after merging. The configuration files have been set up correctly based on the [XcodeBuildMCP documentation](https://github.com/getsentry/XcodeBuildMCP).

**Tooling setup:**
- [x] `.mcp.json` at project root registers XcodeBuildMCP — verified by file inspection
- [x] `.claude/settings.json` includes `mcp__XcodeBuildMCP` in the allow list — verified by file inspection
- [ ] When a new Claude Code session is opened, the tools are available — **requires human validation in a new session**

**Validation — simulator control:**
- [ ] `list_sims` returns available devices — **requires new session**
- [ ] `boot_sim` transitions a simulator to "Booted" — **requires new session**
- [ ] `install_app_sim` installs an app — **requires new session**
- [ ] `launch_app_sim` launches an app — **requires new session**

**Validation — UI interaction and inspection:**
- [ ] `screenshot` returns a simulator image — **requires new session**
- [ ] `snapshot_ui` returns accessibility elements — **requires new session**
- [ ] `tap` registers at coordinates — **requires new session**
- [ ] `type_text` enters text — **requires new session**

**Validation — build and project management:**
- [ ] `build_sim` compiles a project — **requires new session**
- [ ] Build failure produces structured error output — **requires new session**

**Edge cases:**
- [ ] No simulators → `list_sims` returns empty or error — **requires new session**
- [ ] MCP server failure doesn't crash the Claude Code session — **requires new session**

**Validation evidence:**
- [ ] Validation log to be added by human after testing in a new session

## Technical Notes

- **Single-server decision:** The issue recommended evaluating `XcodeBuildMCP` first. Based on its [TOOLS.md documentation](https://github.com/getsentry/XcodeBuildMCP/blob/main/docs/TOOLS.md), it provides 79 tools covering all acceptance criteria including UI automation (`tap`, `swipe`, `type_text`, `long_press`, `gesture`), accessibility (`snapshot_ui`), screenshots (`screenshot`), and video recording (`record_sim_video`). `ios-simulator-mcp` is not needed.
- **Validation limitation:** As a Claude Code agent, I cannot restart my own session to validate the MCP server configuration. The configuration is correct per the documented format, but live validation must be performed by a human opening a new Claude Code session after this PR is merged (or by checking out this branch and opening a new session).
- **Prerequisites confirmed:** Xcode 26.2 is installed with iOS 18.3 and iOS 26.2 simulator runtimes available (22+ devices).