### PR TITLE
Show X icon on primary game detail screens

### DIFF
--- a/packages/web/src/screens/GameDetail/AppBar.tsx
+++ b/packages/web/src/screens/GameDetail/AppBar.tsx
@@ -52,7 +52,11 @@ const GameDetailAppBar: React.FC<GameDetailAppBarProps> = ({
           {leftButton ||
             (showBackButton && (
               <Button variant="ghost" size="icon" onClick={handleBack}>
-                <ArrowLeft className="size-5" />
+                {variant === "primary" ? (
+                  <X className="size-5" />
+                ) : (
+                  <ArrowLeft className="size-5" />
+                )}
               </Button>
             ))}
         </div>


### PR DESCRIPTION
## Summary
- Primary game detail screens (Map, Orders, Chat) now show an **X** icon instead of a back arrow (←) on mobile, since they navigate to the home page (`/`) rather than a previous screen in a navigation stack
- Secondary screens (Channel, Game Info, etc.) retain the back arrow, which correctly signals "go back one step"
- No behavior change — only the icon affordance is updated to match the navigation semantics

## Test plan
- [ ] Open a game → Map/Orders/Chat tabs → verify back button shows X → tapping navigates to home
- [ ] Navigate to a chat channel → verify back button shows ← arrow
- [ ] Navigate to Game Info → verify back button shows ← arrow
- [ ] Desktop: verify no change (primary screens have no back button; secondary screens show X on right side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)