### PR TITLE
Fix: Sheet close button registers as Hold order on mobile

### DIFF
--- a/packages/web/src/components/ui/sheet.tsx
+++ b/packages/web/src/components/ui/sheet.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -72,10 +71,6 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>
   )

--- a/packages/web/src/components/ui/sidebar.tsx
+++ b/packages/web/src/components/ui/sidebar.tsx
@@ -187,7 +187,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
## Summary
- Removed the Sheet component's built-in close button, which had a 16x16px tap target that overlapped with the first `FloatingMenuItem` (typically "Hold") on mobile
- Cleaned up the sidebar's `[&>button]:hidden` workaround that was already hiding the same button
- Tapping outside the sheet already closes it, so the close button was redundant

## Test plan
- [ ] On mobile, open the order creation menu by tapping a province with a unit
- [ ] Verify the bottom sheet shows order options without an "X" close button
- [ ] Verify tapping outside the sheet still closes it
- [ ] Verify the sidebar (hamburger menu) still opens and closes correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)