### PR TITLE
Persist chat drafts across navigation

### DIFF
--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export { useDraft } from "./useDraft";
 export { useRequiredParams } from "./useRequiredParams";
 export { useMapData, type MapData } from "./useMapData";

--- a/packages/web/src/hooks/useDraft.ts
+++ b/packages/web/src/hooks/useDraft.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from "react";
+
+const useDraft = (
+  gameId: string,
+  channelId: string
+): [string, (value: string) => void] => {
+  const key = `draft:${gameId}:${channelId}`;
+
+  const [draft, setDraftState] = useState(
+    () => sessionStorage.getItem(key) ?? ""
+  );
+
+  const setDraft = useCallback(
+    (value: string) => {
+      setDraftState(value);
+      if (value) {
+        sessionStorage.setItem(key, value);
+      } else {
+        sessionStorage.removeItem(key);
+      }
+    },
+    [key]
+  );
+
+  return [draft, setDraft];
+};
+
+export { useDraft };

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,8 +1,8 @@
-import React, { Suspense, useState, useRef, useEffect } from "react";
+import React, { Suspense, useRef, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle } from "lucide-react";
-import { useRequiredParams } from "@/hooks";
+import { useDraft, useRequiredParams } from "@/hooks";
 import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
@@ -75,7 +75,7 @@ const ChannelScreen: React.FC = () => {
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useDraft(gameId, channelId);
 
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: channels } = useGamesChannelsListSuspense(gameId);


### PR DESCRIPTION
## Summary
- Chat message drafts were lost when navigating away from a channel screen because `useState("")` resets on unmount
- Added a `useDraft` hook backed by `sessionStorage`, keyed by `gameId:channelId`, so drafts survive route changes within the browser session
- Clearing the draft (e.g., on send) removes the sessionStorage key to avoid orphaned entries

## Test plan
- [ ] Open a channel, type a draft, navigate to Map tab, navigate back — draft should be preserved
- [ ] Type different drafts in two channels, verify each shows its own draft
- [ ] Send a message, navigate away and back — input should be empty
- [ ] Close and reopen the tab — drafts should be gone (sessionStorage, not localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)