### PR TITLE
Fix retreat phase source_unit returning attacker instead of dislodged unit

### DIFF
--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -85,7 +85,8 @@ const buildNationGroups = (
         items: (ps.orderableProvinces as Province[]).map(province => ({
           province,
           order: orders.find(o => o.source.id === province.id),
-          unit: phase.units.find(u => u.province.id === province.id),
+          unit: phase.units.find(u => u.province.id === province.id && u.dislodged)
+            ?? phase.units.find(u => u.province.id === province.id),
         })),
       }));
   }
@@ -105,7 +106,8 @@ const buildNationGroups = (
     items: nationOrders.map(order => ({
       province: order.source,
       order,
-      unit: phase.units.find(u => u.province.id === order.source.id),
+      unit: phase.units.find(u => u.province.id === order.source.id && u.dislodged)
+        ?? phase.units.find(u => u.province.id === order.source.id),
     })),
   }));
 };

--- a/service/order/conftest.py
+++ b/service/order/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from django.apps import apps
-from common.constants import PhaseStatus, GameStatus
+from common.constants import PhaseStatus, PhaseType, GameStatus
 from nation.models import Nation
 from province.models import Province
 
@@ -133,3 +133,25 @@ def game_with_many_phase_states(primary_user, classical_variant):
     phase.save()
 
     return game
+
+
+@pytest.fixture
+def retreat_phase(db):
+    def _create_phase(game):
+        phase = game.phases.create(
+            variant=game.variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.RETREAT,
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        england_nation = Nation.objects.get(name="England", variant=game.variant)
+        france_nation = Nation.objects.get(name="France", variant=game.variant)
+
+        primary_member = game.members.first()
+        phase.phase_states.create(member=primary_member)
+
+        return phase
+
+    return _create_phase

--- a/service/order/models.py
+++ b/service/order/models.py
@@ -171,7 +171,10 @@ class Order(BaseModel):
 
     @property
     def source_unit(self):
-        return self.phase.units.filter(province=self.source).first()
+        units = self.phase.units.filter(province=self.source)
+        if self.phase.type == PhaseType.RETREAT:
+            return units.filter(dislodged=True).first() or units.first()
+        return units.first()
 
     @property
     def options_display(self):

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -2554,7 +2554,7 @@ class TestOrderSourceUnit:
         assert order.source_unit is None
 
     @pytest.mark.django_db
-    def test_source_unit_with_multiple_units_returns_first(
+    def test_source_unit_with_multiple_units_in_movement_phase_returns_first(
         self,
         test_phase_state,
         classical_london_province,
@@ -2562,6 +2562,7 @@ class TestOrderSourceUnit:
         classical_france_nation,
     ):
         phase = test_phase_state.phase
+        assert phase.type == PhaseType.MOVEMENT
 
         fleet_unit = phase.units.create(
             type=UnitType.FLEET,
@@ -2584,3 +2585,40 @@ class TestOrderSourceUnit:
         result = order.source_unit
         assert result is not None
         assert result in [fleet_unit, army_unit]
+
+    @pytest.mark.django_db
+    def test_source_unit_returns_dislodged_unit_during_retreat_phase(
+        self,
+        order_active_game,
+        primary_user,
+        retreat_phase,
+        classical_london_province,
+        classical_england_nation,
+        classical_france_nation,
+    ):
+        phase = retreat_phase(order_active_game)
+        phase_state = phase.phase_states.get(member__user=primary_user)
+
+        army_unit = phase.units.create(
+            type=UnitType.ARMY,
+            nation=classical_england_nation,
+            province=classical_london_province,
+            dislodged=True,
+        )
+
+        phase.units.create(
+            type=UnitType.FLEET,
+            nation=classical_france_nation,
+            province=classical_london_province,
+            dislodged=False,
+        )
+
+        order = Order(
+            phase_state=phase_state,
+            source=classical_london_province,
+            order_type=OrderType.MOVE,
+        )
+
+        assert order.source_unit == army_unit
+        assert order.source_unit.type == UnitType.ARMY
+        assert order.source_unit.dislodged is True


### PR DESCRIPTION
## Summary
- **Backend**: `Order.source_unit` now prefers dislodged units during retreat phases, preventing it from returning the attacker (e.g. a Fleet) instead of the dislodged unit (e.g. an Army) when both coexist at a province
- **Frontend**: `buildNationGroups` unit lookups in OrdersScreen also prefer dislodged units, fixing the Order List displaying the wrong unit type during retreats
- Both fixes are no-ops for non-retreat phases (no units have `dislodged=true` in movement/adjustment phases)

Closes #168

## Test plan
- [x] Backend: `TestOrderSourceUnit` — 5 tests pass, including new `test_source_unit_returns_dislodged_unit_during_retreat_phase`
- [x] Frontend: ESLint clean on OrdersScreen.tsx
- [ ] Manual: In a retreat phase where an Army is dislodged by a Fleet at a coastal province (e.g. Greece), confirm the Order List shows "Army" and Move → Bulgaria completes without a coast selection prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)