### PR TITLE
Fix phase navigation arrows broken on Map screen

### DIFF
--- a/packages/web/src/components/PhaseSelect.test.tsx
+++ b/packages/web/src/components/PhaseSelect.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PhaseSelect } from "./PhaseSelect";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/api/generated/endpoints", () => ({
+  useGameRetrieveSuspense: () => ({
+    data: { isPaused: false },
+  }),
+  useGamePhaseRetrieveSuspense: () => ({
+    data: {
+      name: "Spring 1901",
+      status: "resolved",
+      previousPhaseId: 4,
+      nextPhaseId: 6,
+      scheduledResolution: null,
+      remainingTime: 0,
+    },
+  }),
+}));
+
+const renderAtRoute = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/game/:gameId/phase/:phaseId" element={<PhaseSelect />} />
+        <Route
+          path="/game/:gameId/phase/:phaseId/:subRoute"
+          element={<PhaseSelect />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("PhaseSelect", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  describe("phase navigation from index route (map screen)", () => {
+    it("navigates to previous phase on index route", async () => {
+      renderAtRoute("/game/1/phase/5");
+      await userEvent.click(screen.getByLabelText("Previous phase"));
+      expect(mockNavigate).toHaveBeenCalledWith("/game/1/phase/4");
+    });
+
+    it("navigates to next phase on index route", async () => {
+      renderAtRoute("/game/1/phase/5");
+      await userEvent.click(screen.getByLabelText("Next phase"));
+      expect(mockNavigate).toHaveBeenCalledWith("/game/1/phase/6");
+    });
+  });
+
+  describe("phase navigation from sub-routes", () => {
+    it("navigates to previous phase preserving /orders suffix", async () => {
+      renderAtRoute("/game/1/phase/5/orders");
+      await userEvent.click(screen.getByLabelText("Previous phase"));
+      expect(mockNavigate).toHaveBeenCalledWith("/game/1/phase/4/orders");
+    });
+
+    it("navigates to next phase preserving /chat suffix", async () => {
+      renderAtRoute("/game/1/phase/5/chat");
+      await userEvent.click(screen.getByLabelText("Next phase"));
+      expect(mockNavigate).toHaveBeenCalledWith("/game/1/phase/6/chat");
+    });
+  });
+});

--- a/packages/web/src/components/PhaseSelect.tsx
+++ b/packages/web/src/components/PhaseSelect.tsx
@@ -20,21 +20,17 @@ export const PhaseSelect: React.FC = () => {
 
   const goToPreviousPhase = () => {
     if (phase.previousPhaseId) {
-      const newPath = location.pathname.replace(
-        `/phase/${phaseId}/`,
-        `/phase/${phase.previousPhaseId}/`
-      );
-      navigate(newPath);
+      const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
+      const suffix = location.pathname.slice(phasePrefix.length);
+      navigate(`/game/${gameId}/phase/${phase.previousPhaseId}${suffix}`);
     }
   };
 
   const goToNextPhase = () => {
     if (phase.nextPhaseId) {
-      const newPath = location.pathname.replace(
-        `/phase/${phaseId}/`,
-        `/phase/${phase.nextPhaseId}/`
-      );
-      navigate(newPath);
+      const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
+      const suffix = location.pathname.slice(phasePrefix.length);
+      navigate(`/game/${gameId}/phase/${phase.nextPhaseId}${suffix}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Phase navigation arrows (left/right) were silently failing on the Map screen because `location.pathname.replace()` required a trailing slash after the phaseId, which the index route doesn't have
- Replaced string manipulation with param-based path construction (`slice` the suffix after the known prefix) — works for all sub-routes (map, orders, chat)
- Added test coverage for navigation from both the index route and sub-routes

## Test plan
- [x] `npx vitest run PhaseSelect` — 4 tests pass (index route + sub-route, previous + next)
- [x] `npx eslint` — no lint errors
- [ ] Manual: navigate to a game's Map screen, click phase arrows, confirm URL changes correctly
- [ ] Manual: verify arrows still work on Orders and Chat screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)