### PR TITLE
Add dark mode toggle with Light/Dark/System preference

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -15,7 +15,7 @@
   <link rel="manifest" href="/manifest.json" />
 
   <!-- PWA Meta Tags -->
-  <meta name="theme-color" content="#ffffff" />
+  <!-- theme-color is set dynamically by themeStorage.initialize() in main.tsx -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Diplicity" />

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -153,6 +153,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -479,6 +480,7 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.1.0.tgz",
       "integrity": "sha512-UfMBMWc1v7J+14AhH03QmeNwV3HZx3qnOWhpwnHfzALEwAwlV/itQOQqcasMQYhOHWL0tiymc5ByaLTn7KKQxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -619,6 +621,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -642,6 +645,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1323,6 +1327,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -1389,6 +1394,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -1404,7 +1410,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -1855,6 +1862,7 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2598,6 +2606,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8754,6 +8763,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
       "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.12"
       },
@@ -8787,6 +8797,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8982,6 +8993,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8992,6 +9004,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9077,6 +9090,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -9442,6 +9456,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9484,6 +9499,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9792,6 +9808,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10529,6 +10546,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10605,6 +10623,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11074,6 +11093,7 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.10.0.tgz",
       "integrity": "sha512-tAjHnEirksqWpa+NKDUSUMjulOnsTcsPC1X1rQ+gwPtjlhJS572na91CwaBXQJHXharIrfj7sw/okDkXOsphjA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/ai": "2.9.0",
         "@firebase/analytics": "0.10.20",
@@ -12021,6 +12041,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -12738,6 +12759,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -13075,6 +13097,7 @@
       "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -13441,6 +13464,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13816,6 +13840,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13873,6 +13898,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13885,6 +13911,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14284,6 +14311,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14644,6 +14672,7 @@
       "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.14"
       },
@@ -15200,6 +15229,7 @@
       "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -15276,6 +15306,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15511,6 +15542,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -16661,6 +16693,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17188,7 +17221,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -153,7 +153,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -480,7 +479,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.1.0.tgz",
       "integrity": "sha512-UfMBMWc1v7J+14AhH03QmeNwV3HZx3qnOWhpwnHfzALEwAwlV/itQOQqcasMQYhOHWL0tiymc5ByaLTn7KKQxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -621,7 +619,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -645,7 +642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1327,7 +1323,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -1394,7 +1389,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -1410,8 +1404,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -1862,7 +1855,6 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2606,7 +2598,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8763,7 +8754,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
       "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.12"
       },
@@ -8797,7 +8787,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8993,7 +8982,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9004,7 +8992,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -9090,7 +9077,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -9456,7 +9442,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9499,7 +9484,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9808,7 +9792,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10546,7 +10529,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10623,7 +10605,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11093,7 +11074,6 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.10.0.tgz",
       "integrity": "sha512-tAjHnEirksqWpa+NKDUSUMjulOnsTcsPC1X1rQ+gwPtjlhJS572na91CwaBXQJHXharIrfj7sw/okDkXOsphjA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/ai": "2.9.0",
         "@firebase/analytics": "0.10.20",
@@ -12041,7 +12021,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -12759,7 +12738,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -13097,7 +13075,6 @@
       "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -13464,7 +13441,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13840,7 +13816,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13898,7 +13873,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13911,7 +13885,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14311,7 +14284,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14672,7 +14644,6 @@
       "integrity": "sha512-sVKbCj/OTx67jhmauhxc2dcr1P+yOgz/x3h0krwjyMgdc5Oubvxyg4NYDZmzAw+ym36g/lzH8N0Ccp4dwtdfxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.14"
       },
@@ -15229,7 +15200,6 @@
       "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -15306,7 +15276,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15542,7 +15511,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -16693,7 +16661,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -17221,8 +17188,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -8,10 +8,6 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -69,13 +65,6 @@ body {
   width: 100%;
   height: 100%;
   object-fit: contain;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
 }
 
 @theme inline {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -8,7 +8,9 @@ import "@fontsource/roboto/700.css";
 import App from "./App.tsx";
 import { initializeObservability } from "./observability";
 import { initializeSentry } from "./sentry";
+import { themeStorage } from "./theme/themeStorage";
 
+themeStorage.initialize();
 initializeObservability();
 initializeSentry();
 

--- a/packages/web/src/screens/Home/Profile.test.tsx
+++ b/packages/web/src/screens/Home/Profile.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Profile } from "./Profile";
+import { themeStorage } from "@/theme/themeStorage";
+
+const mockUserProfile = {
+  id: 1,
+  email: "player@example.com",
+  name: "Test Player",
+  picture: null,
+};
+
+const mockSetPreference = vi.fn();
+
+vi.mock("@/api/generated/endpoints", () => ({
+  useUserRetrieveSuspense: () => ({ data: mockUserProfile }),
+  useUserUpdatePartialUpdate: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  getUserRetrieveQueryKey: () => ["user"],
+}));
+
+vi.mock("@/hooks/useMessaging", () => ({
+  useMessaging: () => ({
+    enableMessaging: vi.fn(),
+    disableMessaging: vi.fn(),
+    enabled: false,
+    permissionDenied: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/auth", () => ({
+  useAuth: () => ({ logout: vi.fn() }),
+}));
+
+vi.mock("@/theme/useTheme", () => ({
+  useTheme: () => ({
+    preference: "system",
+    resolvedTheme: "light",
+    setPreference: mockSetPreference,
+  }),
+}));
+
+// Default matchMedia mock (jsdom doesn't implement it)
+const createMatchMediaMock = (prefersDark = false) =>
+  vi.fn().mockImplementation(
+    (query: string) =>
+      ({
+        matches: query === "(prefers-color-scheme: dark)" ? prefersDark : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList
+  );
+
+const renderProfile = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe("Profile - Appearance section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: createMatchMediaMock(false),
+    });
+    themeStorage.initialize();
+  });
+
+  it("renders the Appearance section heading", async () => {
+    renderProfile();
+    expect(await screen.findByText("Appearance")).toBeInTheDocument();
+  });
+
+  it("renders the theme selector with System as default", async () => {
+    renderProfile();
+    expect(await screen.findByText("System")).toBeInTheDocument();
+  });
+
+  it("renders the Theme label", async () => {
+    renderProfile();
+    expect(await screen.findByText("Theme")).toBeInTheDocument();
+  });
+
+  it("renders the theme select trigger", async () => {
+    renderProfile();
+    expect(await screen.findByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("Appearance section appears before Notifications section", async () => {
+    renderProfile();
+    const headings = await screen.findAllByRole("heading", { level: 2 });
+    const headingTexts = headings.map(h => h.textContent);
+    const appearanceIndex = headingTexts.indexOf("Appearance");
+    const notificationsIndex = headingTexts.indexOf("Notifications");
+    expect(appearanceIndex).toBeGreaterThanOrEqual(0);
+    expect(notificationsIndex).toBeGreaterThanOrEqual(0);
+    expect(appearanceIndex).toBeLessThan(notificationsIndex);
+  });
+});

--- a/packages/web/src/screens/Home/Profile.tsx
+++ b/packages/web/src/screens/Home/Profile.tsx
@@ -9,7 +9,15 @@ import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { useTheme } from "@/theme/useTheme";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   DropdownMenu,
@@ -32,6 +40,8 @@ const Profile: React.FC = () => {
   const queryClient = useQueryClient();
   const { data: userProfile } = useUserRetrieveSuspense();
   const updateProfileMutation = useUserUpdatePartialUpdate();
+
+  const { preference, setPreference } = useTheme();
 
   const {
     enableMessaging,
@@ -153,6 +163,23 @@ const Profile: React.FC = () => {
                 Failed to update name. Please try again.
               </p>
             )}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Appearance</h2>
+          <div className="flex items-center gap-4">
+            <Label htmlFor="theme-select">Theme</Label>
+            <Select value={preference} onValueChange={setPreference}>
+              <SelectTrigger id="theme-select" className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+                <SelectItem value="system">System</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
 

--- a/packages/web/src/theme/themeStorage.test.ts
+++ b/packages/web/src/theme/themeStorage.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// We need to dynamically import themeStorage to reset module state between tests
+// since the module uses module-level variables.
+
+const STORAGE_KEY = "theme-preference";
+
+// Default matchMedia mock (light preference, no-op listeners)
+const createMatchMediaMock = (prefersDark = false) =>
+  vi.fn().mockImplementation(
+    (query: string) =>
+      ({
+        matches:
+          query === "(prefers-color-scheme: dark)" ? prefersDark : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList
+  );
+
+// Helper to reset the DOM and localStorage before each test
+const setupDom = () => {
+  document.documentElement.classList.remove("dark");
+  // Remove any existing theme-color meta
+  const existing = document.querySelector('meta[name="theme-color"]');
+  if (existing) existing.remove();
+  // Add a fresh one
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "theme-color");
+  meta.setAttribute("content", "#ffffff");
+  document.head.appendChild(meta);
+};
+
+describe("themeStorage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    setupDom();
+    // Set up a default matchMedia mock (jsdom doesn't implement it)
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: createMatchMediaMock(false),
+    });
+  });
+
+  describe("initialize()", () => {
+    it("defaults to 'system' preference when localStorage is empty", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(themeStorage.getThemeState().preference).toBe("system");
+    });
+
+    it("reads stored preference from localStorage", async () => {
+      localStorage.setItem(STORAGE_KEY, "dark");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(themeStorage.getThemeState().preference).toBe("dark");
+    });
+
+    it("applies .dark class when preference is 'dark'", async () => {
+      localStorage.setItem(STORAGE_KEY, "dark");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    it("does not apply .dark class when preference is 'light'", async () => {
+      localStorage.setItem(STORAGE_KEY, "light");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("sets theme-color meta to #1a1a1a for dark theme", async () => {
+      localStorage.setItem(STORAGE_KEY, "dark");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute("content")).toBe("#1a1a1a");
+    });
+
+    it("sets theme-color meta to #ffffff for light theme", async () => {
+      localStorage.setItem(STORAGE_KEY, "light");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta?.getAttribute("content")).toBe("#ffffff");
+    });
+
+    it("resolves 'system' preference to 'dark' when OS prefers dark", async () => {
+      window.matchMedia = createMatchMediaMock(true);
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(themeStorage.getThemeState().resolvedTheme).toBe("dark");
+    });
+
+    it("resolves 'system' preference to 'light' when OS prefers light", async () => {
+      window.matchMedia = createMatchMediaMock(false);
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      expect(themeStorage.getThemeState().resolvedTheme).toBe("light");
+    });
+
+    it("creates theme-color meta if it does not exist", async () => {
+      // Remove the meta tag entirely
+      const existing = document.querySelector('meta[name="theme-color"]');
+      if (existing) existing.remove();
+
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const meta = document.querySelector('meta[name="theme-color"]');
+      expect(meta).not.toBeNull();
+    });
+  });
+
+  describe("setPreference()", () => {
+    it("updates the cached state", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("dark");
+      expect(themeStorage.getThemeState().preference).toBe("dark");
+    });
+
+    it("persists preference to localStorage", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("dark");
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+    });
+
+    it("applies .dark class when setting dark preference", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("dark");
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    it("removes .dark class when setting light preference", async () => {
+      localStorage.setItem(STORAGE_KEY, "dark");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("light");
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+
+    it("notifies listeners when preference changes", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const listener = vi.fn();
+      themeStorage.subscribe(listener);
+      themeStorage.setPreference("dark");
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates resolvedTheme to 'dark' when setting dark", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("dark");
+      expect(themeStorage.getThemeState().resolvedTheme).toBe("dark");
+    });
+
+    it("updates resolvedTheme to 'light' when setting light", async () => {
+      localStorage.setItem(STORAGE_KEY, "dark");
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("light");
+      expect(themeStorage.getThemeState().resolvedTheme).toBe("light");
+    });
+  });
+
+  describe("subscribe()", () => {
+    it("returns an unsubscribe function", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const listener = vi.fn();
+      const unsubscribe = themeStorage.subscribe(listener);
+      unsubscribe();
+      themeStorage.setPreference("dark");
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("multiple listeners are all notified", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      themeStorage.subscribe(listener1);
+      themeStorage.subscribe(listener2);
+      themeStorage.setPreference("dark");
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cross-tab sync via storage event", () => {
+    it("updates state and notifies listeners when storage event fires", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const listener = vi.fn();
+      themeStorage.subscribe(listener);
+
+      // Simulate another tab changing the preference
+      localStorage.setItem(STORAGE_KEY, "dark");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_KEY,
+          newValue: "dark",
+          storageArea: localStorage,
+        })
+      );
+
+      expect(themeStorage.getThemeState().preference).toBe("dark");
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores storage events for unrelated keys", async () => {
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      const listener = vi.fn();
+      themeStorage.subscribe(listener);
+
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some-other-key",
+          newValue: "whatever",
+          storageArea: localStorage,
+        })
+      );
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("system preference reactivity", () => {
+    it("attaches matchMedia listener when preference is 'system'", async () => {
+      const addEventListener = vi.fn();
+      window.matchMedia = vi.fn().mockImplementation(
+        (query: string) =>
+          ({
+            matches: false,
+            media: query,
+            addEventListener,
+            removeEventListener: vi.fn(),
+          }) as unknown as MediaQueryList
+      );
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      // preference defaults to 'system', so listener should be attached
+      expect(addEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function)
+      );
+    });
+
+    it("removes matchMedia listener when switching away from 'system'", async () => {
+      const removeEventListener = vi.fn();
+      window.matchMedia = vi.fn().mockImplementation(
+        (query: string) =>
+          ({
+            matches: false,
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener,
+          }) as unknown as MediaQueryList
+      );
+      const { themeStorage } = await import("./themeStorage");
+      themeStorage.initialize();
+      themeStorage.setPreference("dark");
+      expect(removeEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function)
+      );
+    });
+  });
+});

--- a/packages/web/src/theme/themeStorage.ts
+++ b/packages/web/src/theme/themeStorage.ts
@@ -1,0 +1,151 @@
+type ThemePreference = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+type ThemeState = {
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+};
+
+type ThemeChangeListener = () => void;
+
+const STORAGE_KEY = "theme-preference";
+
+const listeners: Set<ThemeChangeListener> = new Set();
+
+let cachedState: ThemeState = {
+  preference: "system",
+  resolvedTheme: "light",
+};
+
+// Holds the current matchMedia listener so it can be removed when switching away from "system"
+let mediaQueryListener: ((e: MediaQueryListEvent) => void) | null = null;
+let mediaQuery: MediaQueryList | null = null;
+
+const getSystemResolvedTheme = (): ResolvedTheme => {
+  try {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  } catch {
+    return "light";
+  }
+};
+
+const resolveTheme = (preference: ThemePreference): ResolvedTheme => {
+  if (preference === "system") {
+    return getSystemResolvedTheme();
+  }
+  return preference;
+};
+
+const applyTheme = (resolvedTheme: ResolvedTheme) => {
+  if (resolvedTheme === "dark") {
+    document.documentElement.classList.add("dark");
+  } else {
+    document.documentElement.classList.remove("dark");
+  }
+
+  const themeColor = resolvedTheme === "dark" ? "#1a1a1a" : "#ffffff";
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.setAttribute("name", "theme-color");
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute("content", themeColor);
+};
+
+const notifyListeners = () => {
+  listeners.forEach(listener => listener());
+};
+
+const updateCachedState = (preference: ThemePreference) => {
+  const resolvedTheme = resolveTheme(preference);
+  cachedState = { preference, resolvedTheme };
+  applyTheme(resolvedTheme);
+};
+
+const detachMediaQueryListener = () => {
+  if (mediaQuery && mediaQueryListener) {
+    mediaQuery.removeEventListener("change", mediaQueryListener);
+    mediaQueryListener = null;
+    mediaQuery = null;
+  }
+};
+
+const attachMediaQueryListener = () => {
+  detachMediaQueryListener();
+  mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  mediaQueryListener = () => {
+    updateCachedState("system");
+    notifyListeners();
+  };
+  mediaQuery.addEventListener("change", mediaQueryListener);
+};
+
+const handleStorageEvent = (event: StorageEvent) => {
+  if (event.key !== STORAGE_KEY || event.storageArea !== localStorage) {
+    return;
+  }
+  const newPreference = (event.newValue as ThemePreference | null) ?? "system";
+  if (newPreference === "system") {
+    attachMediaQueryListener();
+  } else {
+    detachMediaQueryListener();
+  }
+  updateCachedState(newPreference);
+  notifyListeners();
+};
+
+const initialize = () => {
+  let preference: ThemePreference = "system";
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      preference = stored;
+    }
+  } catch {
+    // localStorage unavailable — fall back to "system"
+  }
+
+  if (preference === "system") {
+    attachMediaQueryListener();
+  }
+
+  updateCachedState(preference);
+  window.addEventListener("storage", handleStorageEvent);
+};
+
+const setPreference = (preference: ThemePreference) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, preference);
+  } catch {
+    // localStorage unavailable — still apply in-memory
+  }
+
+  if (preference === "system") {
+    attachMediaQueryListener();
+  } else {
+    detachMediaQueryListener();
+  }
+
+  updateCachedState(preference);
+  notifyListeners();
+};
+
+const getThemeState = (): ThemeState => cachedState;
+
+const subscribe = (listener: ThemeChangeListener) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const themeStorage = {
+  initialize,
+  setPreference,
+  getThemeState,
+  subscribe,
+};
+
+export type { ThemePreference, ResolvedTheme, ThemeState };

--- a/packages/web/src/theme/useTheme.test.ts
+++ b/packages/web/src/theme/useTheme.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { themeStorage } from "./themeStorage";
+import { useTheme } from "./useTheme";
+
+const STORAGE_KEY = "theme-preference";
+
+// Default matchMedia mock (jsdom doesn't implement it)
+const createMatchMediaMock = (prefersDark = false) =>
+  vi.fn().mockImplementation(
+    (query: string) =>
+      ({
+        matches: query === "(prefers-color-scheme: dark)" ? prefersDark : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList
+  );
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: createMatchMediaMock(false),
+    });
+    // Re-initialize themeStorage to a clean state
+    themeStorage.initialize();
+  });
+
+  it("returns the current preference", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.preference).toBe("system");
+  });
+
+  it("returns the resolved theme", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.resolvedTheme).toBe("light");
+  });
+
+  it("exposes setPreference function", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(typeof result.current.setPreference).toBe("function");
+  });
+
+  it("updates preference reactively when setPreference is called", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setPreference("dark");
+    });
+    expect(result.current.preference).toBe("dark");
+  });
+
+  it("updates resolvedTheme reactively when setPreference is called", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setPreference("dark");
+    });
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  it("reflects changes made via themeStorage.setPreference directly", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      themeStorage.setPreference("dark");
+    });
+    expect(result.current.preference).toBe("dark");
+  });
+
+  it("persists the localStorage key when setPreference is called", () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setPreference("dark");
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/packages/web/src/theme/useTheme.ts
+++ b/packages/web/src/theme/useTheme.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from "react";
+import { themeStorage, type ThemePreference } from "./themeStorage";
+
+const useTheme = () => {
+  const { preference, resolvedTheme } = useSyncExternalStore(
+    themeStorage.subscribe,
+    themeStorage.getThemeState
+  );
+
+  return {
+    preference,
+    resolvedTheme,
+    setPreference: (pref: ThemePreference) => themeStorage.setPreference(pref),
+  };
+};
+
+export { useTheme };


### PR DESCRIPTION
## Summary

Diplicity React had complete CSS infrastructure for dark mode (oklch color variables, `.dark` class, `dark:` Tailwind variants on all shadcn/ui components) but no runtime mechanism to activate it. This PR adds a theme preference toggle so users can switch between Light, Dark, and System modes.

## Solution

- **`themeStorage` module** — External store (following the `tokenStorage.ts` pattern) that manages localStorage persistence, `.dark` class on `<html>`, `<meta name="theme-color">` updates, `matchMedia` listener for System mode, and cross-tab sync via `storage` events.
- **`useTheme` hook** — Wraps `useSyncExternalStore` for reactive theme state in React components.
- **Profile screen** — New "Appearance" section with a Select dropdown (Light / Dark / System) between User and Notifications sections.
- **CSS cleanup** — Removed conflicting hardcoded `color`/`background-color` from `:root` and `@media (prefers-color-scheme: light)` block. Theming now fully driven by CSS variables via `@layer base`.
- **Flash prevention** — `themeStorage.initialize()` runs before `createRoot().render()` in `main.tsx`.

## Issues Completed

- [x] Issue 1: Theme storage and initialization (themeStorage, useTheme, main.tsx wiring)
- [x] Issue 2: CSS cleanup (remove conflicting hardcoded colors)
- [x] Issue 3: Profile screen theme selector (Appearance section with Select dropdown)

## Test Plan

- [x] 22 unit tests for `themeStorage` (preference persistence, resolved theme computation, `.dark` class application, meta tag updates, cross-tab sync, matchMedia reactivity)
- [x] 7 unit tests for `useTheme` hook (reactive state, setPreference)
- [x] 5 integration tests for Profile screen (Appearance section renders, default preference, ordering)
- [ ] Manual: Toggle between Light/Dark/System and verify visual theming
- [ ] Manual: Reload page and verify preference persists with no flash
- [ ] Manual: Open two tabs and verify cross-tab sync
- [ ] Manual: Set to System and change OS preference to verify reactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>