### PR TITLE
Add password support to create_test_user command

### DIFF
--- a/service/login/management/commands/create_test_user.py
+++ b/service/login/management/commands/create_test_user.py
@@ -11,18 +11,25 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--email", type=str, required=True)
         parser.add_argument("--name", type=str, required=True)
+        parser.add_argument("--password", type=str, required=False)
 
     def handle(self, *args, **options):
         email = options["email"]
         name = options["name"]
+        password = options.get("password")
 
-        user, _ = AuthUser.objects.get_or_create(
+        user, created = AuthUser.objects.get_or_create(
             email=email,
             defaults={
                 "username": email.split("@")[0],
-                "password": "unused",
+                "is_active": True,
             },
         )
+
+        if password:
+            user.set_password(password)
+            user.save()
+
         UserProfile.objects.update_or_create(
             user=user,
             defaults={"name": name},


### PR DESCRIPTION
### Why?

The app was rejected by Apple App Store review (Guideline 4.2). To resubmit, we need demo accounts that the reviewer can log into with email+password. The existing `create_test_user` command stored a raw unhashed string as the password, so users created with it couldn't authenticate via the email login endpoint.

### How?

Add an optional `--password` flag that hashes the password via `set_password()`, and explicitly set `is_active=True` on creation so the account can log in without email verification.

<sub>Generated with Claude Code</sub>