### PR TITLE
Hide Chat tab for sandbox games

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -43,7 +43,10 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
   });
 
   const navItems = useMemo(() => {
-    return navigationItems.map(item => {
+    const items = game?.sandbox
+      ? navigationItems.filter(item => item.label !== "Chat")
+      : navigationItems;
+    return items.map(item => {
       const path = item.path
         .replace(":gameId", gameId)
         .replace(":phaseId", phaseId);
@@ -60,7 +63,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount]);
+  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(


### PR DESCRIPTION
### Why?

The App Store reviewer navigated to the Chat tab in a sandbox game and saw a "not available" notice, which triggered a Guideline 2.1(a) rejection for inaccessible features. Rather than showing a disabled feature, the tab should not appear at all.

### How?

Filter the Chat navigation item out of the game detail layout when the game is a sandbox.

<sub>Generated with Claude Code</sub>