### PR TITLE
Load map fonts dynamically via injected <link> tag

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&display=swap"
+  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap"
     rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Diplicity</title>

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Cross } from "./shapes/cross";
 import { CurvedArrow } from "./shapes/curved-arrow";
 import { Octagon } from "./shapes/octagon";
@@ -13,6 +13,28 @@ import { SupportHoldArrow } from "./orders/support-hold";
 import { Minus } from "./shapes/minus";
 import { useMapData, type MapData } from "../../hooks/useMapData";
 import { isNativePlatform } from "../../utils/platform";
+
+const useMapFonts = (map: MapData | undefined) => {
+  useEffect(() => {
+    if (!map) return;
+    const fontFamilies = [
+      ...new Set(
+        map.provinces
+          .flatMap(p => p.text ?? [])
+          .map(t => (t.styles.fontFamily as string) ?? "")
+          .filter(Boolean)
+          .map(f => f.replace(/['"]/g, "").trim())
+      ),
+    ];
+    if (fontFamilies.length === 0) return;
+    const href = `https://fonts.googleapis.com/css2?${fontFamilies.map(f => `family=${f.replace(/ /g, "+")}`).join("&")}&display=swap`;
+    if (document.querySelector(`link[href="${href}"]`)) return;
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+  }, [map]);
+};
 
 type VariantForMap = Pick<Variant, "id" | "nations">;
 
@@ -109,6 +131,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
   // If mapData is provided, use it directly; otherwise load internally
   const { data: loadedMap, isLoading, error } = useMapData(props.variant.id);
   const map = props.mapData ?? loadedMap;
+  useMapFonts(map);
 
   // Only show loading/error states if mapData is not provided
   if (!props.mapData) {

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Cross } from "./shapes/cross";
 import { CurvedArrow } from "./shapes/curved-arrow";
 import { Octagon } from "./shapes/octagon";
@@ -13,28 +13,6 @@ import { SupportHoldArrow } from "./orders/support-hold";
 import { Minus } from "./shapes/minus";
 import { useMapData, type MapData } from "../../hooks/useMapData";
 import { isNativePlatform } from "../../utils/platform";
-
-const useMapFonts = (map: MapData | undefined) => {
-  useEffect(() => {
-    if (!map) return;
-    const fontFamilies = [
-      ...new Set(
-        map.provinces
-          .flatMap(p => p.text ?? [])
-          .map(t => (t.styles.fontFamily as string) ?? "")
-          .filter(Boolean)
-          .map(f => f.replace(/['"]/g, "").trim())
-      ),
-    ];
-    if (fontFamilies.length === 0) return;
-    const href = `https://fonts.googleapis.com/css2?${fontFamilies.map(f => `family=${f.replace(/ /g, "+")}`).join("&")}&display=swap`;
-    if (document.querySelector(`link[href="${href}"]`)) return;
-    const link = document.createElement("link");
-    link.rel = "stylesheet";
-    link.href = href;
-    document.head.appendChild(link);
-  }, [map]);
-};
 
 type VariantForMap = Pick<Variant, "id" | "nations">;
 
@@ -131,7 +109,6 @@ const InteractiveMap = (props: InteractiveMapProps) => {
   // If mapData is provided, use it directly; otherwise load internally
   const { data: loadedMap, isLoading, error } = useMapData(props.variant.id);
   const map = props.mapData ?? loadedMap;
-  useMapFonts(map);
 
   // Only show loading/error states if mapData is not provided
   if (!props.mapData) {


### PR DESCRIPTION
On mobile web (Android/Chrome), fonts on the map were not loaded. This should update this - but couldn't test on my Android, so deploying to staging.

Fonts declared in map JSON files are now loaded on demand by injecting a Google Fonts <link> into <head>, fixing rendering on mobile browsers where @import inside SVG <style> is not supported. 