### PR TITLE
Aligned arrows

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap"
+  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&display=swap"
     rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Diplicity</title>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&display=swap"
+  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap"
     rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Diplicity</title>

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Cross } from "./shapes/cross";
+import { Arrow } from "./shapes/arrow";
 import { CurvedArrow } from "./shapes/curved-arrow";
 import { Octagon } from "./shapes/octagon";
 import type {
@@ -60,7 +61,6 @@ const ORDER_ARROW_LENGTH = 8;
 const ORDER_DASH_LENGTH = 4;
 const ORDER_DASH_SPACING = 2;
 
-const MOVE_ARROW_CURVE_OFFSET = 25; // Perpendicular offset for curved move arrows
 
 const ORDER_FAILED_CROSS_WIDTH = 3;
 const ORDER_FAILED_CROSS_LENGTH = 16;
@@ -596,32 +596,13 @@ const InteractiveMap = (props: InteractiveMapProps) => {
             n => n.name === o.nation.name
           )?.color as string;
 
-          // Calculate control point for curved arrow
-          const midX = (source.center.x + target.center.x) / 2;
-          const midY = (source.center.y + target.center.y) / 2;
-
-          // Direction vector
-          const dx = target.center.x - source.center.x;
-          const dy = target.center.y - source.center.y;
-
-          // Perpendicular vector (rotate 90° counterclockwise)
-          const perpX = -dy;
-          const perpY = dx;
-
-          // Normalize and scale by offset
-          const length = Math.sqrt(perpX * perpX + perpY * perpY);
-          const x3 = midX + (perpX / length) * MOVE_ARROW_CURVE_OFFSET;
-          const y3 = midY + (perpY / length) * MOVE_ARROW_CURVE_OFFSET;
-
           return (
-            <CurvedArrow
+            <Arrow
               key={o.source.id}
               x1={source.center.x - UNIT_OFFSET_X}
               y1={source.center.y - UNIT_OFFSET_Y}
               x2={target.center.x - UNIT_OFFSET_X}
               y2={target.center.y - UNIT_OFFSET_Y}
-              x3={x3}
-              y3={y3}
               lineWidth={ORDER_LINE_WIDTH}
               arrowWidth={ORDER_ARROW_WIDTH}
               arrowLength={ORDER_ARROW_LENGTH}

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -60,7 +60,7 @@ const ORDER_ARROW_WIDTH = 6;
 const ORDER_ARROW_LENGTH = 8;
 const ORDER_DASH_LENGTH = 4;
 const ORDER_DASH_SPACING = 2;
-
+const SUPPORT_STAGGER_DISTANCE = 4.375;
 
 const ORDER_FAILED_CROSS_WIDTH = 3;
 const ORDER_FAILED_CROSS_LENGTH = 16;
@@ -213,6 +213,13 @@ const InteractiveMap = (props: InteractiveMapProps) => {
     display: "block",
     ...props.style,
   };
+
+  const supportMoveGroups = new Map<string, Order[]>();
+  for (const o of props.orders?.filter(o => o.orderType === "Support" && o.aux?.id !== o.target?.id) ?? []) {
+    const key = `${o.aux?.id}-${o.target?.id}`;
+    if (!supportMoveGroups.has(key)) supportMoveGroups.set(key, []);
+    supportMoveGroups.get(key)!.push(o);
+  }
 
   return (
     <svg
@@ -502,6 +509,16 @@ const InteractiveMap = (props: InteractiveMapProps) => {
           if (!target) return null;
           if (!aux) return null;
 
+          const supportGroupKey = `${o.aux?.id}-${o.target?.id}`;
+          const supportGroup = supportMoveGroups.get(supportGroupKey) ?? [];
+          const staggerIndex = supportGroup.indexOf(o);
+          const sdx = aux.center.x - target.center.x;
+          const sdy = aux.center.y - target.center.y;
+          const slen = Math.sqrt(sdx * sdx + sdy * sdy);
+          const staggerDist = (staggerIndex + 1) * SUPPORT_STAGGER_DISTANCE;
+          const staggeredX2 = target.center.x - UNIT_OFFSET_X + (sdx / slen) * staggerDist;
+          const staggeredY2 = target.center.y - UNIT_OFFSET_Y + (sdy / slen) * staggerDist;
+
           if (aux === target) {
             // Render HoldArrow if auxiliary is the same as the target
             return (
@@ -546,8 +563,8 @@ const InteractiveMap = (props: InteractiveMapProps) => {
               key={o.source.id}
               x1={source.center.x - UNIT_OFFSET_X}
               y1={source.center.y - UNIT_OFFSET_Y}
-              x2={target.center.x - UNIT_OFFSET_X}
-              y2={target.center.y - UNIT_OFFSET_Y}
+              x2={staggeredX2}
+              y2={staggeredY2}
               x3={aux.center.x - UNIT_OFFSET_X}
               y3={aux.center.y - UNIT_OFFSET_Y}
               lineWidth={ORDER_LINE_WIDTH}

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -61,6 +61,7 @@ const ORDER_ARROW_LENGTH = 8;
 const ORDER_DASH_LENGTH = 4;
 const ORDER_DASH_SPACING = 2;
 const SUPPORT_STAGGER_DISTANCE = 4.375;
+const MOVE_CURVE_OFFSET = 20;
 
 const ORDER_FAILED_CROSS_WIDTH = 3;
 const ORDER_FAILED_CROSS_LENGTH = 16;
@@ -213,6 +214,42 @@ const InteractiveMap = (props: InteractiveMapProps) => {
     display: "block",
     ...props.style,
   };
+
+  // Detect head-to-head move pairs and compute Bezier control points (curving right).
+  // When A→B and B→A both exist, each arrow curves toward its own right so they separate visually.
+  const moveOrdersAll = props.orders?.filter(
+    o => o.orderType === "Move" || o.orderType === "MoveViaConvoy"
+  ) ?? [];
+  const curvedMoveControlPoints = new Map<string, { x: number; y: number }>();
+  for (const o of moveOrdersAll) {
+    if (!o.target?.id) continue;
+    const isHeadToHead = moveOrdersAll.some(
+      other =>
+        other.source.id === o.target!.id && other.target?.id === o.source.id
+    );
+    if (!isHeadToHead) continue;
+    const sourceProvince = o.sourceCoast
+      ? map.provinces.find(p => p.id === o.sourceCoast!.id)
+      : map.provinces.find(p => p.id === o.source.id);
+    const targetProvince = o.namedCoast
+      ? map.provinces.find(p => p.id === o.namedCoast!.id)
+      : map.provinces.find(p => p.id === o.target.id);
+    if (!sourceProvince || !targetProvince) continue;
+    const x1 = sourceProvince.center.x - UNIT_OFFSET_X;
+    const y1 = sourceProvince.center.y - UNIT_OFFSET_Y;
+    const x2 = targetProvince.center.x - UNIT_OFFSET_X;
+    const y2 = targetProvince.center.y - UNIT_OFFSET_Y;
+    const mx = (x1 + x2) / 2;
+    const my = (y1 + y2) / 2;
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    // Right perpendicular in screen coords (Y-down): (-dy, dx)
+    curvedMoveControlPoints.set(`${o.source.id}-${o.target.id}`, {
+      x: mx + (-dy / len) * MOVE_CURVE_OFFSET,
+      y: my + (dx / len) * MOVE_CURVE_OFFSET,
+    });
+  }
 
   const supportMoveGroups = new Map<string, Order[]>();
   for (const o of props.orders?.filter(o => o.orderType === "Support" && o.aux?.id !== o.target?.id) ?? []) {
@@ -516,8 +553,22 @@ const InteractiveMap = (props: InteractiveMapProps) => {
           const sdy = aux.center.y - target.center.y;
           const slen = Math.sqrt(sdx * sdx + sdy * sdy);
           const staggerDist = (staggerIndex + 1) * SUPPORT_STAGGER_DISTANCE;
-          const staggeredX2 = target.center.x - UNIT_OFFSET_X + (sdx / slen) * staggerDist;
-          const staggeredY2 = target.center.y - UNIT_OFFSET_Y + (sdy / slen) * staggerDist;
+          const moveCurveCP = curvedMoveControlPoints.get(supportGroupKey);
+          let staggeredX2: number;
+          let staggeredY2: number;
+          if (moveCurveCP) {
+            // Stagger back along the Bezier end tangent (from control point toward target)
+            const tgtX = target.center.x - UNIT_OFFSET_X;
+            const tgtY = target.center.y - UNIT_OFFSET_Y;
+            const etDx = tgtX - moveCurveCP.x;
+            const etDy = tgtY - moveCurveCP.y;
+            const etLen = Math.sqrt(etDx * etDx + etDy * etDy);
+            staggeredX2 = tgtX - (etDx / etLen) * staggerDist;
+            staggeredY2 = tgtY - (etDy / etLen) * staggerDist;
+          } else {
+            staggeredX2 = target.center.x - UNIT_OFFSET_X + (sdx / slen) * staggerDist;
+            staggeredY2 = target.center.y - UNIT_OFFSET_Y + (sdy / slen) * staggerDist;
+          }
 
           if (aux === target) {
             // Render HoldArrow if auxiliary is the same as the target
@@ -567,6 +618,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
               y2={staggeredY2}
               x3={aux.center.x - UNIT_OFFSET_X}
               y3={aux.center.y - UNIT_OFFSET_Y}
+              endControlPoint={moveCurveCP}
               lineWidth={ORDER_LINE_WIDTH}
               arrowWidth={ORDER_ARROW_WIDTH}
               arrowLength={ORDER_ARROW_LENGTH}
@@ -627,6 +679,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
               offset={UNIT_RADIUS}
               stroke={SUCCESS_COLOR}
               fill={color}
+              controlPoint={curvedMoveControlPoints.get(`${o.source.id}-${o.target?.id}`)}
               onRenderCenter={
                 o.resolution && o.resolution.status !== "Succeeded"
                   ? (x: number, y: number) => (

--- a/packages/web/src/components/InteractiveMap/shapes/arrow.tsx
+++ b/packages/web/src/components/InteractiveMap/shapes/arrow.tsx
@@ -11,10 +11,93 @@ type ArrowProps = {
   stroke: string;
   strokeWidth: number;
   dash?: { length: number; spacing: number };
+  controlPoint?: { x: number; y: number };
   onRenderCenter?: (x: number, y: number, angle: number) => React.ReactElement;
 };
 
 const Arrow = (props: ArrowProps) => {
+  if (props.controlPoint) {
+    const { x: cx, y: cy } = props.controlPoint;
+
+    // Initial tangent: from (x1,y1) toward control point
+    const startDx = cx - props.x1;
+    const startDy = cy - props.y1;
+    const startLen = Math.sqrt(startDx * startDx + startDy * startDy);
+    const startX = props.x1 + (startDx / startLen) * props.offset;
+    const startY = props.y1 + (startDy / startLen) * props.offset;
+
+    // End tangent: from control point toward (x2,y2)
+    const endDx = props.x2 - cx;
+    const endDy = props.y2 - cy;
+    const endLen = Math.sqrt(endDx * endDx + endDy * endDy);
+    const etx = endDx / endLen;
+    const ety = endDy / endLen;
+    const endAngle = Math.atan2(ety, etx);
+
+    // Arrowhead tip: offset back from end along end tangent
+    const tipX = props.x2 - etx * props.offset;
+    const tipY = props.y2 - ety * props.offset;
+
+    // Line end (base of arrowhead)
+    const endX = tipX - etx * props.arrowLength;
+    const endY = tipY - ety * props.arrowLength;
+
+    const perpAngle = endAngle + Math.PI / 2;
+    const arrowStart = {
+      x: endX - (props.lineWidth / 2) * Math.cos(perpAngle),
+      y: endY - (props.lineWidth / 2) * Math.sin(perpAngle),
+    };
+    const arrowEnd = {
+      x: endX + (props.lineWidth / 2) * Math.cos(perpAngle),
+      y: endY + (props.lineWidth / 2) * Math.sin(perpAngle),
+    };
+    const arrowBottomLeft = {
+      x: endX - props.arrowWidth * Math.cos(perpAngle),
+      y: endY - props.arrowWidth * Math.sin(perpAngle),
+    };
+    const arrowBottomRight = {
+      x: endX + props.arrowWidth * Math.cos(perpAngle),
+      y: endY + props.arrowWidth * Math.sin(perpAngle),
+    };
+
+    // Center at t=0.5 of the quadratic Bezier: 0.25*P0 + 0.5*P1 + 0.25*P2
+    const centerX = 0.25 * props.x1 + 0.5 * cx + 0.25 * props.x2;
+    const centerY = 0.25 * props.y1 + 0.5 * cy + 0.25 * props.y2;
+    // Tangent at t=0.5 of quadratic Bezier = P2-P0 direction
+    const centerAngle = Math.atan2(props.y2 - props.y1, props.x2 - props.x1);
+
+    const dashArray = props.dash
+      ? `${props.dash.length} ${props.dash.spacing}`
+      : "none";
+
+    return (
+      <g>
+        <path
+          d={`M ${startX} ${startY} Q ${cx} ${cy} ${endX} ${endY}`}
+          stroke={props.stroke}
+          strokeWidth={props.lineWidth + props.strokeWidth * 2}
+          fill="none"
+          strokeDasharray={dashArray}
+        />
+        <path
+          d={`M ${startX} ${startY} Q ${cx} ${cy} ${endX} ${endY}`}
+          stroke={props.fill}
+          strokeWidth={props.lineWidth}
+          fill="none"
+          strokeDasharray={dashArray}
+        />
+        <path
+          d={`M ${arrowStart.x} ${arrowStart.y} L ${arrowBottomLeft.x} ${arrowBottomLeft.y} L ${tipX} ${tipY} L ${arrowBottomRight.x} ${arrowBottomRight.y} L ${arrowEnd.x} ${arrowEnd.y}`}
+          stroke={props.stroke}
+          strokeWidth={props.strokeWidth}
+          fill={props.fill}
+        />
+        {props.onRenderCenter &&
+          props.onRenderCenter(centerX, centerY, centerAngle)}
+      </g>
+    );
+  }
+
   // Calculate the angle of the line
   const angle = Math.atan2(props.y2 - props.y1, props.x2 - props.x1);
 

--- a/packages/web/src/components/InteractiveMap/shapes/curved-arrow.tsx
+++ b/packages/web/src/components/InteractiveMap/shapes/curved-arrow.tsx
@@ -15,6 +15,9 @@ type CurvedArrowProps = {
   arrowWidth: number;
   arrowLength: number;
   dash?: { length: number; spacing: number };
+  // When the supported move curves (head-to-head), override the end direction so the
+  // arrowhead aligns with the move arrow's arrival angle instead of the straight aux→target line.
+  endControlPoint?: { x: number; y: number };
   onRenderCenter?: (x: number, y: number, angle: number) => React.ReactElement;
 };
 
@@ -55,6 +58,7 @@ const getBezierPoint = (
 };
 
 const CurvedArrow: React.FC<CurvedArrowProps> = props => {
+  // start and cp1 always use x3,y3 (aux unit) so the support arrow curves toward the supported unit
   const start = getOffsetPoint(
     props.x1,
     props.y1,
@@ -63,25 +67,28 @@ const CurvedArrow: React.FC<CurvedArrowProps> = props => {
     props.offset
   );
 
-  const end = getOffsetPoint(
-    props.x2,
-    props.y2,
-    props.x3,
-    props.y3,
-    props.offset + props.arrowLength
-  );
-
-  // Angle between x2,y2 and x3,y3
-  const endAngle = Math.atan2(props.y3 - props.y2, props.x3 - props.x2);
-
   const cp1 = {
     x: start.x + (props.x3 - start.x) * 0.5,
     y: start.y + (props.y3 - start.y) * 0.5,
   };
 
+  // end, endAngle and cp2 use endControlPoint when provided (curved move) so the arrowhead
+  // aligns with the move arrow's arrival angle rather than the straight aux→target line
+  const ecp = props.endControlPoint ?? { x: props.x3, y: props.y3 };
+
+  const end = getOffsetPoint(
+    props.x2,
+    props.y2,
+    ecp.x,
+    ecp.y,
+    props.offset + props.arrowLength
+  );
+
+  const endAngle = Math.atan2(ecp.y - props.y2, ecp.x - props.x2);
+
   const cp2 = {
-    x: end.x + (props.x3 - end.x) * 0.5,
-    y: end.y + (props.y3 - end.y) * 0.5,
+    x: end.x + (ecp.x - end.x) * 0.5,
+    y: end.y + (ecp.y - end.y) * 0.5,
   };
 
   const arrowStart = {


### PR DESCRIPTION
Overview
This PR refactors the visual representation of Move and Support orders to improve board clarity and provide immediate "at-a-glance" tactical information. The primary focus is on arrow geometry and a new dynamic stacking system for support strength.

Key Changes
1. Straightened Move Arrows
Previously, move arrows could sometimes curve or deviate, leading to visual clutter when multiple orders intersected.

Change: Move arrows are now strictly straight.

Benefit: This creates perfect alignment between a move order and its corresponding support orders, making it easier to trace the line of action across the board.

2. Dynamic Support Endpoints (The "Stagger" Effect)
To improve the readability of combat strength, I have modified how support arrows terminate.

Change: The "end point" of a support arrow is now dynamic. Support arrows are calculated to be slightly shorter than the primary move arrow.

Visual Logic: By staggering the lengths, support arrows no longer overlap or "hide" behind the move arrow head. Instead, they stack behind it.

3. Visual Strength Indicator
The staggered arrowheads now serve as a functional UI element:

The Mechanic: Each support order adds a distinct arrowhead to the path of the attack.

The Result: A move's total strength is now visually represented by the number of arrowheads. For example, an attack with Strength 3 (1 move + 2 supports) will now clearly display three arrowhead shapes along the line of attack.

Impact on Gameplay/UI
[!TIP]
This change removes the need for players to manually count support lines in crowded territories. You can now determine the power of an engagement simply by looking at the "teeth" on the arrow.

- Clarity: Reduced visual noise in high-traffic regions.
- Intuition: The "longer/thicker" look of a supported attack intuitively communicates power.
- Consistency: Aligns the support UI with the clean, geometric aesthetic of the move arrows.