### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,84 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/packages/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "pip"
+    directory: "/service"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "bundler"
+    directory: "/packages/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-root:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "docker"
+    directory: "/service"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-service:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "docker"
+    directory: "/packages/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-web:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` covering 7 ecosystem entries: npm (`packages/web`), pip (`service`), bundler (`packages/web` for fastlane), github-actions, and docker (root, service, web).

Each ecosystem opens **one weekly PR per ecosystem** containing all minor/patch updates grouped together, and ignores major version bumps. This keeps PR volume manageable for a hobby project — expect ~1–7 PRs/week steady state, dropping to near-zero once everything is current.

## What this does *not* configure

- **Security updates** are a separate Dependabot feature enabled via repo Settings → Code security & analysis → "Dependabot security updates". They fire independently of this YAML and aren't grouped — each CVE gets its own PR. Worth turning on given GitHub flagged 36 existing vulnerabilities.
- **Major version bumps** are ignored by config. When you want React 19→20 or Django 4→5, do those manually.

## Caveats to verify after first run

- `service/dev_requirements.txt` uses a non-standard filename. The pip ecosystem typically picks up `requirements*.txt`. If after the first weekly run you don't see updates for `pytest` or `pytest-django`, we'll need to rename it to `requirements-dev.txt`.
- The `bundler` entry in `packages/web` will track the `Gemfile`/`Gemfile.lock` used by fastlane. If those iOS deps churn too much, we can drop the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)