### PR TITLE
Add cooldown periods to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       npm-dependencies:
         patterns:
@@ -18,6 +23,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       pip-dependencies:
         patterns:
@@ -30,6 +40,11 @@ updates:
     directory: "/packages/web"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       bundler-dependencies:
         patterns:
@@ -42,6 +57,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       github-actions:
         patterns:
@@ -51,6 +71,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       docker-root:
         patterns:
@@ -63,6 +88,11 @@ updates:
     directory: "/service"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       docker-service:
         patterns:
@@ -75,6 +105,11 @@ updates:
     directory: "/packages/web"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       docker-web:
         patterns:


### PR DESCRIPTION
## Summary

Adds a `cooldown` block to each ecosystem entry in `.github/dependabot.yml`. Differentiated by semver level: 3 days for patches, 7 for minors, 30 for majors (with a 7-day default for non-semver versions like Docker tags).

## Why

Most malicious package versions get caught and yanked within hours to days of publication. A cooldown gives the ecosystem time to react before we adopt a new release. Same logic applies to buggy releases that get a quick patch — better to land the patched version than the broken one.

## What this does *not* delay

Security updates from the GitHub Advisory Database bypass cooldown entirely, so real CVE fixes still arrive promptly. Cooldown only affects the routine version-update flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)