### PR TITLE
Shorten toast duration and fix mobile offset to clear app bar

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -75,7 +75,8 @@ function App() {
                 position="top-center"
                 closeButton
                 richColors
-                mobileOffset={{ top: "calc(16px + env(safe-area-inset-top, 0px))" }}
+                duration={1000}
+                mobileOffset={{ top: "calc(72px + env(safe-area-inset-top, 0px))" }}
               />
             </AuthProvider>
           </QueryClientProvider>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
                 position="top-center"
                 closeButton
                 richColors
-                duration={1000}
+                duration={1200}
                 mobileOffset={{ top: "calc(72px + env(safe-area-inset-top, 0px))" }}
               />
             </AuthProvider>


### PR DESCRIPTION
This updates the duration of the notifications - and on mobile, adds an offset to prevent it overlapping the app bar.

There are some instances (e.g. the home screen) where there is no speficic offset, but current behaviour is more than acceptable and simplifies the codebase. 