### PR TITLE
Highlight fastest-starting joinable game on Find Games

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Diplicity React - Release Notes
 
+## Find Games: "Fastest Start" highlight (May 5, 2026)
+
+**Release Date:** May 5, 2026
+
+### Improvement: Find Games surfaces the joinable game closest to starting
+
+The Find Games list now sorts joinable games by how close they are to filling, so the staging game with the fewest open slots appears first. When the top game already has at least three players, it's marked with a "Fastest Start" header and badge — a clear signal of where to join if you want to start playing as soon as possible. Filtering by variant or duration still works the same way; the highlight applies within whatever filters you've set.
+
+---
+
 ## Order Wizard Overhaul & Bug Fixes (March 19, 2026)
 
 **Release Date:** March 19, 2026

--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -827,6 +827,9 @@ export type GamesListParams = {
   mine?: boolean;
   /**
    * * `1 hour` - 1 hour
+   * `2 hours` - 2 hours
+   * `4 hours` - 4 hours
+   * `8 hours` - 8 hours
    * `12 hours` - 12 hours
    * `24 hours` - 24 hours
    * `48 hours` - 48 hours
@@ -837,6 +840,7 @@ export type GamesListParams = {
    * @nullable
    */
   movement_phase_duration?: GamesListMovementPhaseDuration;
+  ordering?: string;
   /**
    * A page number within the paginated result set.
    */
@@ -856,13 +860,16 @@ export type GamesListMovementPhaseDuration =
 
 export const GamesListMovementPhaseDuration = {
   "1_hour": "1 hour",
+  "1_week": "1 week",
   "12_hours": "12 hours",
+  "2_hours": "2 hours",
+  "2_weeks": "2 weeks",
   "24_hours": "24 hours",
-  "48_hours": "48 hours",
   "3_days": "3 days",
   "4_days": "4 days",
-  "1_week": "1 week",
-  "2_weeks": "2 weeks",
+  "4_hours": "4 hours",
+  "48_hours": "48 hours",
+  "8_hours": "8 hours",
 } as const;
 
 /**

--- a/packages/web/src/screens/Home/FindGames.test.tsx
+++ b/packages/web/src/screens/Home/FindGames.test.tsx
@@ -39,7 +39,9 @@ vi.mock("@/hooks/useInfiniteScroll", () => ({
 }));
 
 vi.mock("@/components/GameCard", () => ({
-  GameCard: () => <div data-testid="game-card" />,
+  GameCard: ({ game }: { game: { id: string } }) => (
+    <div data-testid="game-card" data-game-id={game.id} />
+  ),
 }));
 
 vi.mock("@/components/UserAvatar", () => ({
@@ -122,5 +124,64 @@ describe("FindGames", () => {
         movement_phase_duration: "24 hours",
       })
     );
+  });
+
+  it("passes ordering=slots_remaining to the games list query", () => {
+    renderFindGames();
+
+    expect(mockUseGamesListInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ ordering: "slots_remaining" })
+    );
+  });
+
+  it("renders the Fastest Start header when the top game has at least 3 members", () => {
+    const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
+    const buildGame = (id: string, memberCount: number) => ({
+      id,
+      variantId: "classical",
+      phases: [1],
+      members: Array.from({ length: memberCount }, (_, i) => buildMember(i + 1)),
+    });
+
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: {
+        pages: [
+          { results: [buildGame("g1", 4), buildGame("g2", 2), buildGame("g3", 1)] },
+        ],
+      },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/fastest start/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/join to start playing fastest/i)
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId("game-card")).toHaveLength(3);
+  });
+
+  it("does not render the Fastest Start header when the top game has fewer than 3 members", () => {
+    const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
+    const buildGame = (id: string, memberCount: number) => ({
+      id,
+      variantId: "classical",
+      phases: [1],
+      members: Array.from({ length: memberCount }, (_, i) => buildMember(i + 1)),
+    });
+
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: {
+        pages: [
+          { results: [buildGame("g1", 2), buildGame("g2", 1), buildGame("g3", 0)] },
+        ],
+      },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.queryByText(/fastest start/i)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("game-card")).toHaveLength(3);
   });
 });

--- a/packages/web/src/screens/Home/FindGames.tsx
+++ b/packages/web/src/screens/Home/FindGames.tsx
@@ -6,6 +6,7 @@ import { ScreenContainer } from "@/components/ui/screen-container";
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { GameCard } from "@/components/GameCard";
 import { Notice } from "@/components/Notice";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -14,7 +15,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Inbox, Loader2, SlidersHorizontal } from "lucide-react";
+import { Inbox, Loader2, SlidersHorizontal, Zap } from "lucide-react";
 import { useVariantsListSuspense } from "@/api/generated/endpoints";
 import type { GamesListMovementPhaseDuration } from "@/api/generated/endpoints";
 import { useGamesListInfinite } from "@/hooks/useGamesListInfinite";
@@ -25,6 +26,7 @@ const VARIANT_PARAM = "variant";
 const DURATION_PARAM = "movement_phase_duration";
 const ALL_VARIANTS_VALUE = "__all__";
 const ANY_DURATION_VALUE = "__any__";
+const EXPRESS_MIN_MEMBERS = 3;
 
 interface FindGamesProps {
   isFilterOpen: boolean;
@@ -43,6 +45,7 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
       can_join: true,
       variant: variantParam,
       movement_phase_duration: durationParam,
+      ordering: "slots_remaining",
     });
   const { data: variants } = useVariantsListSuspense();
 
@@ -123,15 +126,41 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
 
       {knownGames.length > 0 ? (
         <>
-          {knownGames.map(game => (
-            <GameCard
-              key={game.id}
-              game={game}
-              variant={variantMap.get(game.variantId)!}
-              phaseId={game.phases[0]}
-              map={<div />}
-            />
-          ))}
+          {knownGames[0].members.length >= EXPRESS_MIN_MEMBERS ? (
+            <>
+              <div className="flex items-center gap-2 pt-2">
+                <Zap className="size-4" />
+                <h3 className="text-sm font-semibold">Fastest Start</h3>
+                <Badge>Join to start playing fastest</Badge>
+              </div>
+              <GameCard
+                key={knownGames[0].id}
+                game={knownGames[0]}
+                variant={variantMap.get(knownGames[0].variantId)!}
+                phaseId={knownGames[0].phases[0]}
+                map={<div />}
+              />
+              {knownGames.slice(1).map(game => (
+                <GameCard
+                  key={game.id}
+                  game={game}
+                  variant={variantMap.get(game.variantId)!}
+                  phaseId={game.phases[0]}
+                  map={<div />}
+                />
+              ))}
+            </>
+          ) : (
+            knownGames.map(game => (
+              <GameCard
+                key={game.id}
+                game={game}
+                variant={variantMap.get(game.variantId)!}
+                phaseId={game.phases[0]}
+                map={<div />}
+              />
+            ))
+          )}
           {isFetchingNextPage && (
             <div className="flex justify-center py-4">
               <Loader2 className="animate-spin" />

--- a/service/game/filters.py
+++ b/service/game/filters.py
@@ -1,4 +1,6 @@
 import django_filters
+from django.db.models import Count, F
+
 from common.constants import GameStatus, MovementPhaseDuration
 
 from .models import Game
@@ -13,6 +15,7 @@ class GameFilter(django_filters.FilterSet):
     movement_phase_duration = django_filters.ChoiceFilter(
         choices=MovementPhaseDuration.MOVEMENT_PHASE_DURATION_CHOICES
     )
+    ordering = django_filters.CharFilter(method="filter_ordering")
 
     class Meta:
         model = Game
@@ -42,4 +45,15 @@ class GameFilter(django_filters.FilterSet):
         statuses = [s for s in statuses if s in valid]
         if statuses:
             return queryset.filter(status__in=statuses)
+        return queryset
+
+    def filter_ordering(self, queryset, name, value):
+        if value == "slots_remaining":
+            # No kick filter on members: pending games only lose members on
+            # account deletion, so every member row counts toward fill.
+            return queryset.annotate(
+                member_count=Count("members", distinct=True),
+                nation_count=Count("variant__nations", distinct=True),
+                slots_remaining=F("nation_count") - F("member_count"),
+            ).order_by("slots_remaining", "-created_at")
         return queryset

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -752,6 +752,122 @@ class TestGameListViewFilters:
             assert game["can_join"] is True
 
 
+class TestGameListViewOrdering:
+
+    @pytest.mark.django_db
+    def test_ordering_slots_remaining_ascending(
+        self, authenticated_client, classical_variant, base_pending_phase, secondary_user, tertiary_user
+    ):
+        empty_game = Game.objects.create(
+            name="Empty Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(empty_game)
+
+        one_member_game = Game.objects.create(
+            name="One Member Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(one_member_game)
+        one_member_game.members.create(user=secondary_user)
+
+        two_member_game = Game.objects.create(
+            name="Two Member Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(two_member_game)
+        two_member_game.members.create(user=secondary_user)
+        two_member_game.members.create(user=tertiary_user)
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url, {"ordering": "slots_remaining"})
+        assert response.status_code == status.HTTP_200_OK
+
+        ordered_ids = [g["id"] for g in response.data["results"]]
+        two_idx = ordered_ids.index(two_member_game.id)
+        one_idx = ordered_ids.index(one_member_game.id)
+        empty_idx = ordered_ids.index(empty_game.id)
+        assert two_idx < one_idx < empty_idx
+
+    @pytest.mark.django_db
+    def test_ordering_slots_remaining_tiebreaker_created_at_desc(
+        self, authenticated_client, classical_variant, base_pending_phase
+    ):
+        older_game = Game.objects.create(
+            name="Older Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(older_game)
+        newer_game = Game.objects.create(
+            name="Newer Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(newer_game)
+
+        Game.objects.filter(id=older_game.id).update(
+            created_at=timezone.now() - timedelta(days=2)
+        )
+        Game.objects.filter(id=newer_game.id).update(
+            created_at=timezone.now() - timedelta(days=1)
+        )
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url, {"ordering": "slots_remaining"})
+        assert response.status_code == status.HTTP_200_OK
+
+        ordered_ids = [g["id"] for g in response.data["results"]]
+        assert ordered_ids.index(newer_game.id) < ordered_ids.index(older_game.id)
+
+    @pytest.mark.django_db
+    def test_ordering_combined_with_can_join_and_variant(
+        self,
+        authenticated_client,
+        classical_variant,
+        italy_vs_germany_variant,
+        base_pending_phase,
+        secondary_user,
+        tertiary_user,
+    ):
+        classical_full = Game.objects.create(
+            name="Classical Fuller",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(classical_full)
+        classical_full.members.create(user=secondary_user)
+        classical_full.members.create(user=tertiary_user)
+
+        classical_empty = Game.objects.create(
+            name="Classical Empty",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(classical_empty)
+
+        italy_game = Game.objects.create(
+            name="Italy vs Germany",
+            variant=italy_vs_germany_variant,
+            status=GameStatus.PENDING,
+        )
+        base_pending_phase(italy_game)
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(
+            url,
+            {"can_join": "true", "variant": classical_variant.id, "ordering": "slots_remaining"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        ordered_ids = [g["id"] for g in response.data["results"]]
+        assert italy_game.id not in ordered_ids
+        assert ordered_ids.index(classical_full.id) < ordered_ids.index(classical_empty.id)
+
+
 class TestGameListViewQueryPerformance:
 
     @pytest.mark.django_db

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -922,15 +922,21 @@ paths:
           nullable: true
           enum:
           - 1 hour
+          - 1 week
           - 12 hours
+          - 2 hours
+          - 2 weeks
           - 24 hours
-          - 48 hours
           - 3 days
           - 4 days
-          - 1 week
-          - 2 weeks
+          - 4 hours
+          - 48 hours
+          - 8 hours
         description: |-
           * `1 hour` - 1 hour
+          * `2 hours` - 2 hours
+          * `4 hours` - 4 hours
+          * `8 hours` - 8 hours
           * `12 hours` - 12 hours
           * `24 hours` - 24 hours
           * `48 hours` - 48 hours
@@ -938,6 +944,10 @@ paths:
           * `4 days` - 4 days
           * `1 week` - 1 week
           * `2 weeks` - 2 weeks
+      - in: query
+        name: ordering
+        schema:
+          type: string
       - name: page
         required: false
         in: query


### PR DESCRIPTION
Adds an `ordering=slots_remaining` option to the games list endpoint that orders by `nation_count − member_count` ascending, with `-created_at` as the tiebreaker. Find Games passes this and surfaces the top result with a "Fastest Start" header and badge above the existing `GameCard` whenever it has at least three members; otherwise the list renders flat as before. Filters (variant, duration, can_join) compose normally.

Pair issue: #345. Closes #344.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>