### PR TITLE
Refine Fastest Start treatment on Find Games

### DIFF
--- a/packages/web/src/screens/Home/FindGames.test.tsx
+++ b/packages/web/src/screens/Home/FindGames.test.tsx
@@ -134,7 +134,7 @@ describe("FindGames", () => {
     );
   });
 
-  it("renders the Fastest Start header when the top game has at least 3 members", () => {
+  it("renders the Fastest Start and More games headers when the top game has at least 3 members", () => {
     const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
     const buildGame = (id: string, memberCount: number) => ({
       id,
@@ -156,12 +156,36 @@ describe("FindGames", () => {
 
     expect(screen.getByText(/fastest start/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/join to start playing fastest/i)
+      screen.getByText(/join to start playing quickly/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/more games/i)).toBeInTheDocument();
     expect(screen.getAllByTestId("game-card")).toHaveLength(3);
   });
 
-  it("does not render the Fastest Start header when the top game has fewer than 3 members", () => {
+  it("omits the More games header when there is only the Fastest Start game", () => {
+    const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
+    const buildGame = (id: string, memberCount: number) => ({
+      id,
+      variantId: "classical",
+      phases: [1],
+      members: Array.from({ length: memberCount }, (_, i) => buildMember(i + 1)),
+    });
+
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: {
+        pages: [{ results: [buildGame("g1", 4)] }],
+      },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/fastest start/i)).toBeInTheDocument();
+    expect(screen.queryByText(/more games/i)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("game-card")).toHaveLength(1);
+  });
+
+  it("does not render the Fastest Start or More games headers when the top game has fewer than 3 members", () => {
     const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
     const buildGame = (id: string, memberCount: number) => ({
       id,
@@ -182,6 +206,7 @@ describe("FindGames", () => {
     renderFindGames();
 
     expect(screen.queryByText(/fastest start/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/more games/i)).not.toBeInTheDocument();
     expect(screen.getAllByTestId("game-card")).toHaveLength(3);
   });
 });

--- a/packages/web/src/screens/Home/FindGames.tsx
+++ b/packages/web/src/screens/Home/FindGames.tsx
@@ -6,7 +6,6 @@ import { ScreenContainer } from "@/components/ui/screen-container";
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { GameCard } from "@/components/GameCard";
 import { Notice } from "@/components/Notice";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -130,8 +129,9 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
             <>
               <div className="flex items-center gap-2 pt-2">
                 <Zap className="size-4" />
-                <h3 className="text-sm font-semibold">Fastest Start</h3>
-                <Badge>Join to start playing fastest</Badge>
+                <h3 className="text-sm font-semibold">
+                  Fastest Start — Join to start playing quickly
+                </h3>
               </div>
               <GameCard
                 key={knownGames[0].id}
@@ -140,15 +140,20 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
                 phaseId={knownGames[0].phases[0]}
                 map={<div />}
               />
-              {knownGames.slice(1).map(game => (
-                <GameCard
-                  key={game.id}
-                  game={game}
-                  variant={variantMap.get(game.variantId)!}
-                  phaseId={game.phases[0]}
-                  map={<div />}
-                />
-              ))}
+              {knownGames.length > 1 && (
+                <>
+                  <h3 className="text-sm font-semibold pt-2">More games</h3>
+                  {knownGames.slice(1).map(game => (
+                    <GameCard
+                      key={game.id}
+                      game={game}
+                      variant={variantMap.get(game.variantId)!}
+                      phaseId={game.phases[0]}
+                      map={<div />}
+                    />
+                  ))}
+                </>
+              )}
             </>
           ) : (
             knownGames.map(game => (


### PR DESCRIPTION
Follow-up to #346. Folds the tagline into the Fastest Start header (instead of a separate badge), updates the wording to "Join to start playing quickly", and adds a "More games" header above the rest of the list. Both headers only render when a Fastest Start game is present; if the top game has fewer than three members the list still renders flat with no headers.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>