### PR TITLE
Add optimistic order creation with immediate arrow display

### DIFF
--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -16,7 +15,7 @@ const {
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
   mockWizardReset: vi.fn(),
-  mockInteractiveMapZoomWrapper: vi.fn(() => <div data-testid="map" />),
+  mockInteractiveMapZoomWrapper: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -24,8 +23,10 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/components/InteractiveMap/InteractiveMapZoomWrapper", () => ({
-  InteractiveMapZoomWrapper: (props: unknown) =>
-    mockInteractiveMapZoomWrapper(props),
+  InteractiveMapZoomWrapper: (props: unknown) => {
+    mockInteractiveMapZoomWrapper(props);
+    return <div data-testid="map" />;
+  },
 }));
 
 // Wizard state is held in a mutable object the mock reads from each render
@@ -178,10 +179,10 @@ function completeWizard() {
 }
 
 function getLastOrdersProp(): Order[] {
-  const calls = mockInteractiveMapZoomWrapper.mock.calls;
-  const last = calls[calls.length - 1];
-  return (last[0] as { interactiveMapProps: { orders: Order[] } })
-    .interactiveMapProps.orders ?? [];
+  const last = mockInteractiveMapZoomWrapper.mock.calls.at(-1);
+  if (!last) return [];
+  const props = (last[0] as unknown) as { interactiveMapProps: { orders: Order[] } };
+  return props.interactiveMapProps.orders ?? [];
 }
 
 // --- Tests ---

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -1,0 +1,381 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { GameMap } from "./GameMap";
+import type { Order } from "@/api/generated/endpoints";
+
+// vi.hoisted ensures these are initialized before vi.mock hoisting runs
+const {
+  mockToastSuccess,
+  mockToastError,
+  mockWizardReset,
+  mockInteractiveMapZoomWrapper,
+} = vi.hoisted(() => ({
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockWizardReset: vi.fn(),
+  mockInteractiveMapZoomWrapper: vi.fn(() => <div data-testid="map" />),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+
+vi.mock("@/components/InteractiveMap/InteractiveMapZoomWrapper", () => ({
+  InteractiveMapZoomWrapper: (props: unknown) =>
+    mockInteractiveMapZoomWrapper(props),
+}));
+
+// Wizard state is held in a mutable object the mock reads from each render
+type WizardState = {
+  isComplete: boolean;
+  selectedArray: string[];
+  resolvedSelections: Record<string, string>;
+  nextField: string | null;
+  choices: never[];
+  selections: Record<string, string>;
+  select: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+};
+
+let mockWizardState: WizardState = buildIdleWizard();
+
+function buildIdleWizard(): WizardState {
+  return {
+    isComplete: false,
+    selectedArray: [],
+    resolvedSelections: {},
+    nextField: "source",
+    choices: [],
+    selections: {},
+    select: vi.fn(),
+    reset: mockWizardReset,
+  };
+}
+
+vi.mock("@/hooks/useOrderWizard", () => ({
+  useOrderWizard: () => mockWizardState,
+}));
+
+let mockMutateAsync = vi.fn();
+let mockExistingOrders: Order[] = [];
+
+vi.mock("@/api/generated/endpoints", () => ({
+  useGameRetrieve: () => ({ data: mockGame }),
+  useVariantsList: () => ({ data: [mockVariant] }),
+  useGamePhaseRetrieve: () => ({ data: mockPhase }),
+  useGameOrdersList: () => ({ data: mockExistingOrders }),
+  useGameOptionsRetrieve: () => ({ data: { orders: [], fieldOrder: {} } }),
+  useGameOrdersCreate: () => ({ mutateAsync: mockMutateAsync }),
+  getGameOrdersListQueryKey: (gameId: string, phaseId: number) => [
+    `/game/${gameId}/orders/${phaseId}`,
+  ],
+}));
+
+vi.mock("@/utils/provinces", () => ({
+  determineRenderableProvinces: () => ["lon", "nth"],
+}));
+
+// --- Fixture data ---
+const england = { name: "England", color: "rgb(255,0,0)" };
+
+const makeProvince = (id: string) => ({
+  id,
+  name: id,
+  type: "land",
+  supplyCenter: false,
+  parentId: null,
+  namedCoastIds: [],
+});
+
+const lon = makeProvince("lon");
+const nth = makeProvince("nth");
+
+const mockVariant = {
+  id: "standard",
+  name: "Standard",
+  description: "",
+  soloVictoryScCount: 18,
+  nations: [england],
+  provinces: [lon, nth],
+  templatePhase: {},
+};
+
+const mockGame = {
+  id: "game-1",
+  variantId: "standard",
+  name: "Test Game",
+  status: "active",
+  createdAt: "",
+  canJoin: false,
+  canLeave: false,
+  canDelete: false,
+  phases: [1],
+  currentPhaseId: 1,
+  members: [],
+  sandbox: false,
+  victory: null,
+  nationAssignment: "random",
+  phaseConfirmed: false,
+  movementPhaseDuration: null,
+  retreatPhaseDuration: null,
+  private: false,
+  anonymous: false,
+  isPaused: false,
+  pausedAt: null,
+  nmrExtensionsAllowed: 0,
+  deadlineMode: "auto",
+  fixedDeadlineTime: null,
+};
+
+const mockPhase = {
+  id: 1,
+  ordinal: 1,
+  season: "Spring",
+  year: 1901,
+  name: "Spring 1901",
+  type: "movement",
+  remainingTime: 0,
+  scheduledResolution: "",
+  status: "active",
+  units: [
+    {
+      type: "Army",
+      nation: england,
+      province: lon,
+      dislodged: false,
+      dislodgedBy: null,
+    },
+  ],
+  supplyCenters: [],
+  previousPhaseId: null,
+  nextPhaseId: null,
+};
+
+// --- Test helpers ---
+const makeQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const gameMapJsx = (queryClient = makeQueryClient()) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={["/game/game-1/phase/1"]}>
+      <Routes>
+        <Route path="/game/:gameId/phase/:phaseId" element={<GameMap />} />
+      </Routes>
+    </MemoryRouter>
+  </QueryClientProvider>
+);
+
+function completeWizard() {
+  mockWizardState = {
+    ...mockWizardState,
+    isComplete: true,
+    selectedArray: ["lon", "Move", "nth"],
+    resolvedSelections: { source: "lon", orderType: "Move", target: "nth" },
+  };
+}
+
+function getLastOrdersProp(): Order[] {
+  const calls = mockInteractiveMapZoomWrapper.mock.calls;
+  const last = calls[calls.length - 1];
+  return (last[0] as { interactiveMapProps: { orders: Order[] } })
+    .interactiveMapProps.orders ?? [];
+}
+
+// --- Tests ---
+describe("GameMap", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync = vi.fn();
+    mockExistingOrders = [];
+    mockWizardState = buildIdleWizard();
+  });
+
+  describe("optimistic order rendering", () => {
+    it("passes pending order to the map immediately when wizard completes", async () => {
+      let resolveOrder!: (order: Order) => void;
+      mockMutateAsync.mockReturnValue(
+        new Promise<Order>((res) => {
+          resolveOrder = res;
+        })
+      );
+
+      const { rerender } = render(gameMapJsx());
+
+      completeWizard();
+      rerender(gameMapJsx());
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalled();
+      });
+
+      const orders = getLastOrdersProp();
+      expect(orders).toHaveLength(1);
+      expect(orders[0].source.id).toBe("lon");
+      expect(orders[0].target.id).toBe("nth");
+      expect(orders[0].orderType).toBe("Move");
+
+      // Resolve so the promise doesn't leave unhandled rejection
+      resolveOrder({ title: "Army London → North Sea" } as unknown as Order);
+    });
+
+    it("shows success toast after mutation resolves and clears pending order", async () => {
+      mockMutateAsync.mockResolvedValue({
+        title: "Army London → North Sea",
+      } as unknown as Order);
+
+      const { rerender } = render(gameMapJsx());
+
+      completeWizard();
+      rerender(gameMapJsx());
+
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          "Army London → North Sea"
+        );
+      });
+
+      expect(mockWizardReset).toHaveBeenCalled();
+
+      // After success the pending order must be gone from the displayed list
+      const orders = getLastOrdersProp();
+      expect(
+        orders.some((o) => o.source?.id === "lon" && o.orderType === "Move")
+      ).toBe(false);
+    });
+
+    it("hides the old order for the same source while the pending order is shown", async () => {
+      const existingHoldOrder = {
+        source: lon,
+        target: lon,
+        aux: lon,
+        namedCoast: lon,
+        sourceCoast: null,
+        orderType: "Hold",
+        unitType: "Army",
+        nation: england,
+        resolution: { status: "Succeeded", by: null },
+        options: [],
+        complete: null,
+        step: null,
+        title: "Army London hold",
+        summary: null,
+      } as unknown as Order;
+
+      mockExistingOrders = [existingHoldOrder];
+
+      let resolveOrder!: (order: Order) => void;
+      mockMutateAsync.mockReturnValue(
+        new Promise<Order>((res) => {
+          resolveOrder = res;
+        })
+      );
+
+      const { rerender } = render(gameMapJsx());
+
+      completeWizard();
+      rerender(gameMapJsx());
+
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+
+      // During the pending mutation, only the new pending order should be shown
+      // for the "lon" source — the old Hold order must be hidden
+      const ordersWhilePending = getLastOrdersProp();
+      const lonOrders = ordersWhilePending.filter((o) => o.source.id === "lon");
+      expect(lonOrders).toHaveLength(1);
+      expect(lonOrders[0].orderType).toBe("Move");
+
+      resolveOrder({ title: "Army London → North Sea" } as unknown as Order);
+    });
+
+    it("replaces the old order in the cache when mutation succeeds", async () => {
+      const existingHoldOrder = {
+        source: lon,
+        target: lon,
+        aux: lon,
+        namedCoast: lon,
+        sourceCoast: null,
+        orderType: "Hold",
+        unitType: "Army",
+        nation: england,
+        resolution: { status: "Succeeded", by: null },
+        options: [],
+        complete: null,
+        step: null,
+        title: "Army London hold",
+        summary: null,
+      } as unknown as Order;
+
+      mockExistingOrders = [existingHoldOrder];
+
+      const realNewOrder = {
+        ...existingHoldOrder,
+        orderType: "Move",
+        target: nth,
+        title: "Army London → North Sea",
+      } as unknown as Order;
+
+      mockMutateAsync.mockResolvedValue(realNewOrder);
+
+      const queryClient = makeQueryClient();
+      queryClient.setQueryData(
+        ["/game/game-1/orders/1"],
+        mockExistingOrders
+      );
+
+      const { rerender } = render(gameMapJsx(queryClient));
+
+      completeWizard();
+      rerender(gameMapJsx(queryClient));
+
+      await waitFor(() =>
+        expect(mockToastSuccess).toHaveBeenCalledWith("Army London → North Sea")
+      );
+
+      const cached = queryClient.getQueryData<Order[]>([
+        "/game/game-1/orders/1",
+      ]);
+      expect(cached).toHaveLength(1);
+      expect(cached![0].orderType).toBe("Move");
+    });
+
+    it("shows error toast and removes pending order when mutation rejects", async () => {
+      mockMutateAsync.mockRejectedValue(new Error("Network error"));
+
+      const { rerender } = render(gameMapJsx());
+
+      completeWizard();
+      rerender(gameMapJsx());
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("Failed to create order");
+      });
+
+      expect(mockWizardReset).toHaveBeenCalled();
+
+      // After failure the pending order must be gone
+      const orders = getLastOrdersProp();
+      expect(
+        orders.some((o) => o.source?.id === "lon" && o.orderType === "Move")
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -3,6 +3,7 @@ import { useRef, useMemo, useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { determineRenderableProvinces } from "../utils/provinces";
+import { buildOptimisticOrder } from "../utils/buildOptimisticOrder";
 import { InteractiveMapZoomWrapper } from "./InteractiveMap/InteractiveMapZoomWrapper";
 import { FloatingMenu, FloatingMenuItem } from "./FloatingMenu";
 import {
@@ -13,6 +14,7 @@ import {
   useGameOrdersCreate,
   getGameOrdersListQueryKey,
   useGameOptionsRetrieve,
+  type Order,
 } from "../api/generated/endpoints";
 import { useOrderWizard } from "../hooks/useOrderWizard";
 
@@ -36,6 +38,7 @@ const GameMap: React.FC = () => {
     x: number;
     y: number;
   } | null>(null);
+  const [pendingOrder, setPendingOrder] = useState<Order | null>(null);
   const createOrderMutation = useGameOrdersCreate();
 
   const wizard = useOrderWizard(
@@ -65,20 +68,31 @@ const GameMap: React.FC = () => {
 
   useEffect(() => {
     if (!wizard.isComplete || wizard.selectedArray.length === 0) return;
+    if (variant && phase) {
+      setPendingOrder(
+        buildOptimisticOrder(wizard.resolvedSelections, variant, phase)
+      );
+    }
     createOrderMutation
       .mutateAsync({
         gameId,
         data: { selected: wizard.selectedArray },
       })
       .then((order) => {
+        queryClient.setQueryData<Order[]>(
+          getGameOrdersListQueryKey(gameId, selectedPhase),
+          (old) => [
+            ...(old ?? []).filter((o) => o.source.id !== order.source.id),
+            order,
+          ]
+        );
+        setPendingOrder(null);
         toast.success(order.title ?? "Order created");
         wizard.reset();
         setMenuPosition(null);
-        queryClient.invalidateQueries({
-          queryKey: getGameOrdersListQueryKey(gameId, selectedPhase),
-        });
       })
       .catch(() => {
+        setPendingOrder(null);
         toast.error("Failed to create order");
         wizard.reset();
         setMenuPosition(null);
@@ -141,6 +155,15 @@ const GameMap: React.FC = () => {
       wizard.nextField === "namedCoast") &&
     menuPosition !== null;
 
+  const displayOrders = pendingOrder
+    ? [
+        ...(orders ?? []).filter(
+          (o) => o.source.id !== pendingOrder.source.id
+        ),
+        pendingOrder,
+      ]
+    : orders;
+
   return (
     <div ref={containerRef} className="relative w-full h-full">
       {game && variant && phase && orders && (
@@ -150,7 +173,7 @@ const GameMap: React.FC = () => {
               interactive: true,
               variant: variant,
               phase: phase,
-              orders: orders,
+              orders: displayOrders,
               selected: wizard.selectedArray,
               onClickProvince: handleProvinceClick,
               renderableProvinces: renderableProvinces,

--- a/packages/web/src/utils/buildOptimisticOrder.test.ts
+++ b/packages/web/src/utils/buildOptimisticOrder.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { buildOptimisticOrder } from "./buildOptimisticOrder";
+import type { Province, Nation, Variant, PhaseRetrieve } from "../api/generated/endpoints";
+
+const makeProvince = (id: string): Province => ({
+  id,
+  name: id,
+  type: "land",
+  supplyCenter: false,
+  parentId: null,
+  namedCoastIds: [],
+});
+
+const england: Nation = { name: "England", color: "rgb(255,0,0)" };
+const france: Nation = { name: "France", color: "rgb(0,0,255)" };
+
+const lon = makeProvince("lon");
+const nth = makeProvince("nth");
+const bre = makeProvince("bre");
+const par = makeProvince("par");
+
+const variant: Pick<Variant, "provinces"> = {
+  provinces: [lon, nth, bre, par],
+};
+
+const phaseWithUnit = (provinceId: string, nation: Nation): Pick<PhaseRetrieve, "units" | "supplyCenters"> => ({
+  units: [
+    {
+      type: "Army",
+      nation,
+      province: makeProvince(provinceId),
+      dislodged: false,
+      dislodgedBy: null,
+    },
+  ],
+  supplyCenters: [],
+});
+
+const phaseWithSupplyCenter = (provinceId: string, nation: Nation): Pick<PhaseRetrieve, "units" | "supplyCenters"> => ({
+  units: [],
+  supplyCenters: [{ province: makeProvince(provinceId), nation }],
+});
+
+describe("buildOptimisticOrder", () => {
+  it("builds a Move order with correct source, target, and nation", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Move", target: "nth" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.source.id).toBe("lon");
+    expect(result!.target.id).toBe("nth");
+    expect(result!.orderType).toBe("Move");
+    expect(result!.nation).toEqual(england);
+  });
+
+  it("builds a Hold order with target falling back to source", () => {
+    const result = buildOptimisticOrder(
+      { source: "par", orderType: "Hold" },
+      variant,
+      phaseWithUnit("par", france)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.source.id).toBe("par");
+    expect(result!.target.id).toBe("par");
+    expect(result!.orderType).toBe("Hold");
+  });
+
+  it("builds a Support order with correct aux and target", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Support", aux: "bre", target: "par" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.aux.id).toBe("bre");
+    expect(result!.target.id).toBe("par");
+  });
+
+  it("resolves nation from phase.supplyCenters for Build orders", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Build", unitType: "Army" },
+      variant,
+      phaseWithSupplyCenter("lon", england)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.nation).toEqual(england);
+    expect(result!.unitType).toBe("Army");
+  });
+
+  it("sets resolution to Succeeded to prevent failure cross rendering", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Move", target: "nth" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result!.resolution.status).toBe("Succeeded");
+    expect(result!.resolution.by).toBeNull();
+  });
+
+  it("returns null when source province is not in variant.provinces", () => {
+    const result = buildOptimisticOrder(
+      { source: "unknown", orderType: "Hold" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no unit or supply center found at source", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Move", target: "nth" },
+      variant,
+      { units: [], supplyCenters: [] }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when resolvedSelections is missing source", () => {
+    const result = buildOptimisticOrder(
+      { orderType: "Hold" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when resolvedSelections is missing orderType", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("aux falls back to source when not in selections", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Support", target: "par" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.aux.id).toBe("lon");
+  });
+
+  it("defaults unitType to Army when not in selections", () => {
+    const result = buildOptimisticOrder(
+      { source: "lon", orderType: "Move", target: "nth" },
+      variant,
+      phaseWithUnit("lon", england)
+    );
+
+    expect(result!.unitType).toBe("Army");
+  });
+});

--- a/packages/web/src/utils/buildOptimisticOrder.ts
+++ b/packages/web/src/utils/buildOptimisticOrder.ts
@@ -1,0 +1,52 @@
+import type {
+  Order,
+  Province,
+  Variant,
+  PhaseRetrieve,
+} from "../api/generated/endpoints";
+
+function buildOptimisticOrder(
+  resolvedSelections: Record<string, string>,
+  variant: Pick<Variant, "provinces">,
+  phase: Pick<PhaseRetrieve, "units" | "supplyCenters">
+): Order | null {
+  const sourceId = resolvedSelections["source"];
+  const orderType = resolvedSelections["orderType"];
+  if (!sourceId || !orderType) return null;
+
+  const findProvince = (id: string | undefined): Province | null =>
+    id ? (variant.provinces.find((p) => p.id === id) ?? null) : null;
+
+  const source = findProvince(sourceId);
+  if (!source) return null;
+
+  const unit = phase.units.find((u) => u.province.id === sourceId);
+  const nation =
+    unit?.nation ??
+    phase.supplyCenters.find((sc) => sc.province.id === sourceId)?.nation;
+  if (!nation) return null;
+
+  const target = findProvince(resolvedSelections["target"]) ?? source;
+  const aux = findProvince(resolvedSelections["aux"]) ?? source;
+  const namedCoast = findProvince(resolvedSelections["namedCoast"]) ?? source;
+
+  return {
+    source,
+    sourceCoast: null,
+    target,
+    aux,
+    namedCoast,
+    // "Succeeded" prevents the failure cross from rendering on the pending order
+    resolution: { status: "Succeeded", by: null },
+    options: [],
+    orderType: orderType as Order["orderType"],
+    unitType: (resolvedSelections["unitType"] as Order["unitType"]) ?? "Army",
+    nation,
+    complete: null,
+    step: null,
+    title: null,
+    summary: null,
+  };
+}
+
+export { buildOptimisticOrder };


### PR DESCRIPTION
Show the order arrow as soon as the wizard completes rather than waiting for the server response. On success the real order is written directly into the query cache (no refetch) so the arrow stays visible without a gap. On error the pending arrow is removed and an error toast is shown. Handles order replacement by filtering out the existing order for the same source before adding the new one.

I've added new tests for this using claude that pass - maybe we should add them to the automatic testing?