### PR TITLE
Aligned arrows

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -756,7 +756,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
                 fill={color}
                 onRenderCenter={
                   o.resolution && o.resolution.status !== "Succeeded"
-                    ? (x: number, y: number, angle: number) => (
+                    ? (x: number, y: number, _angle: number) => (
                         <Cross
                           x={x}
                           y={y}

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -728,10 +728,6 @@ const InteractiveMap = (props: InteractiveMapProps) => {
               offset={UNIT_RADIUS + UNIT_OFFSET_RADIUS}
               stroke={SUCCESS_COLOR}
               fill={color}
-              dash={{
-                length: ORDER_DASH_LENGTH * 2,
-                spacing: ORDER_DASH_LENGTH,
-              }}
               onRenderCenter={
                 o.resolution && o.resolution.status !== "Succeeded"
                   ? (x: number, y: number) => (

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -10,6 +10,8 @@ import type {
 } from "../../api/generated/endpoints";
 
 import { ConvoyArrow } from "./orders/convoy";
+import { shortestWaypointOrder, bSplineAttachmentPoint } from "./InteractiveMap.utils";
+import { MoveViaConvoyArrow } from "./orders/move-via-convoy";
 import { SupportHoldArrow } from "./orders/support-hold";
 import { Minus } from "./shapes/minus";
 import { useMapData, type MapData } from "../../hooks/useMapData";
@@ -256,6 +258,76 @@ const InteractiveMap = (props: InteractiveMapProps) => {
     const key = `${o.aux?.id}-${o.target?.id}`;
     if (!supportMoveGroups.has(key)) supportMoveGroups.set(key, []);
     supportMoveGroups.get(key)!.push(o);
+  }
+
+  // For each MoveViaConvoy that has matching Convoy orders, build an ordered
+  // route through the participating fleets: [source, ...fleets_greedy_order, destination].
+  // The route is only stored when fleet waypoints exist (otherwise Arrow renders straight).
+  // Key: `${mvcSource.id}-${mvcTarget.id}`
+  type RouteInfo = {
+    waypoints: { x: number; y: number }[];
+    // Maps fleet province id → its B-spline attachment point on the rendered curve
+    attachments: Record<string, { x: number; y: number }>;
+  };
+  const convoyRoutes = new Map<string, RouteInfo>();
+  for (const o of props.orders?.filter(
+    o => o.orderType === "MoveViaConvoy"
+  ) ?? []) {
+    const sourceCoast = o.sourceCoast;
+    const sourceProvince = sourceCoast
+      ? map.provinces.find(p => p.id === sourceCoast.id)
+      : map.provinces.find(p => p.id === o.source.id);
+    const targetProvince = o.namedCoast
+      ? map.provinces.find(p => p.id === o.namedCoast.id)
+      : map.provinces.find(p => p.id === o.target?.id);
+    if (!sourceProvince || !targetProvince) continue;
+
+    const srcPt = {
+      x: sourceProvince.center.x - UNIT_OFFSET_X,
+      y: sourceProvince.center.y - UNIT_OFFSET_Y,
+    };
+    const dstPt = {
+      x: targetProvince.center.x - UNIT_OFFSET_X,
+      y: targetProvince.center.y - UNIT_OFFSET_Y,
+    };
+
+    // Participating fleets: Convoy orders where aux=army province, target=destination
+    // (mirrors the Support order convention: target=destination, aux=the unit being helped)
+    const convoyOrders = (props.orders ?? []).filter(
+      c =>
+        c.orderType === "Convoy" &&
+        c.aux?.id === o.source.id &&
+        c.target?.id === o.target?.id
+    );
+    const fleetProvinces = convoyOrders
+      .map(c => map.provinces.find(p => p.id === c.source.id))
+      .filter((p): p is NonNullable<typeof p> => p !== undefined);
+    const fleetPts = fleetProvinces.map(p => ({
+      x: p.center.x - UNIT_OFFSET_X,
+      y: p.center.y - UNIT_OFFSET_Y,
+    }));
+
+    if (fleetPts.length > 0) {
+      const ordered = shortestWaypointOrder(fleetPts, srcPt, dstPt);
+      const waypoints = [srcPt, ...ordered, dstPt];
+
+      // For each fleet, compute its attachment point on the B-spline curve.
+      // Fleet i in ordered[] sits at index i+1 in waypoints[].
+      const attachments: Record<string, { x: number; y: number }> = {};
+      ordered.forEach((fleetPt, idx) => {
+        // Find which convoy order corresponds to this fleet position
+        const matchingProvince = fleetProvinces.find(
+          p =>
+            p.center.x - UNIT_OFFSET_X === fleetPt.x &&
+            p.center.y - UNIT_OFFSET_Y === fleetPt.y
+        );
+        if (matchingProvince) {
+          attachments[matchingProvince.id] = bSplineAttachmentPoint(waypoints, idx + 1);
+        }
+      });
+
+      convoyRoutes.set(`${o.source.id}-${o.target?.id}`, { waypoints, attachments });
+    }
   }
 
   return (
@@ -665,6 +737,43 @@ const InteractiveMap = (props: InteractiveMapProps) => {
             n => n.name === o.nation.name
           )?.color as string;
 
+          const confirmedRoute =
+            o.orderType === "MoveViaConvoy"
+              ? convoyRoutes.get(`${o.source.id}-${o.target?.id}`)
+              : undefined;
+
+          if (confirmedRoute) {
+            return (
+              <MoveViaConvoyArrow
+                key={o.source.id}
+                waypoints={confirmedRoute.waypoints}
+                lineWidth={ORDER_LINE_WIDTH}
+                arrowWidth={ORDER_ARROW_WIDTH}
+                arrowLength={ORDER_ARROW_LENGTH}
+                strokeWidth={ORDER_STROKE_WIDTH}
+                offset={UNIT_RADIUS}
+                stroke={SUCCESS_COLOR}
+                fill={color}
+                onRenderCenter={
+                  o.resolution && o.resolution.status !== "Succeeded"
+                    ? (x: number, y: number, angle: number) => (
+                        <Cross
+                          x={x}
+                          y={y}
+                          width={ORDER_FAILED_CROSS_WIDTH}
+                          length={ORDER_FAILED_CROSS_LENGTH}
+                          angle={45}
+                          fill={ORDER_FAILED_CROSS_FILL}
+                          stroke={ORDER_FAILED_CROSS_STROKE}
+                          strokeWidth={ORDER_FAILED_CROSS_STROKE_WIDTH}
+                        />
+                      )
+                    : undefined
+                }
+              />
+            );
+          }
+
           return (
             <Arrow
               key={o.source.id}
@@ -713,6 +822,9 @@ const InteractiveMap = (props: InteractiveMapProps) => {
             n => n.name === o.nation.name
           )?.color as string;
 
+          const routeInfo = convoyRoutes.get(`${o.aux?.id}-${o.target?.id}`);
+          const attachmentPoint = routeInfo?.attachments[o.source.id];
+
           return (
             <ConvoyArrow
               x1={source.center.x - UNIT_OFFSET_X}
@@ -728,6 +840,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
               offset={UNIT_RADIUS + UNIT_OFFSET_RADIUS}
               stroke={SUCCESS_COLOR}
               fill={color}
+              attachmentPoint={attachmentPoint}
               onRenderCenter={
                 o.resolution && o.resolution.status !== "Succeeded"
                   ? (x: number, y: number) => (

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.utils.ts
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.utils.ts
@@ -32,4 +32,97 @@ const getClosestPointOnLine = (
   return { x: closestX, y: closestY };
 };
 
-export { getClosestPointOnLine };
+// Closest point on a multi-segment polyline to point (px, py).
+// Each segment is clamped to [0, 1] independently.
+const getClosestPointOnPolyline = (
+  px: number,
+  py: number,
+  points: { x: number; y: number }[]
+) => {
+  let bestDistSq = Infinity;
+  let bestPoint = points[0];
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const dx = p2.x - p1.x;
+    const dy = p2.y - p1.y;
+    const lenSq = dx * dx + dy * dy;
+    const t =
+      lenSq === 0
+        ? 0
+        : Math.max(0, Math.min(1, ((px - p1.x) * dx + (py - p1.y) * dy) / lenSq));
+    const cx = p1.x + t * dx;
+    const cy = p1.y + t * dy;
+    const distSq = (cx - px) ** 2 + (cy - py) ** 2;
+    if (distSq < bestDistSq) {
+      bestDistSq = distSq;
+      bestPoint = { x: cx, y: cy };
+    }
+  }
+  return bestPoint;
+};
+
+type Point = { x: number; y: number };
+
+// Must match ROUTE_TENSION in move-via-convoy.tsx — controls how far the
+// B-spline deviates toward each intermediate fleet waypoint.
+export const ROUTE_TENSION = 0.6;
+
+// For fleet at index `i` in the full waypoints array [src, f1, …, fn, dst],
+// returns the point on the rendered B-spline that is closest to that fleet.
+// This is the t=0.5 point on the fleet's quadratic bezier segment, which is
+// where the curve reaches its closest approach to the (tensioned) control point.
+export const bSplineAttachmentPoint = (pts: Point[], i: number): Point => {
+  const pPrev = pts[i - 1];
+  const p = pts[i];
+  const pNext = pts[i + 1];
+  const mid0 = { x: (pPrev.x + p.x) / 2, y: (pPrev.y + p.y) / 2 };
+  const mid1 = { x: (p.x + pNext.x) / 2, y: (p.y + pNext.y) / 2 };
+  const midOfMids = { x: (mid0.x + mid1.x) / 2, y: (mid0.y + mid1.y) / 2 };
+  const ctrl = {
+    x: midOfMids.x + ROUTE_TENSION * (p.x - midOfMids.x),
+    y: midOfMids.y + ROUTE_TENSION * (p.y - midOfMids.y),
+  };
+  // Quadratic bezier at t=0.5
+  return {
+    x: 0.25 * mid0.x + 0.5 * ctrl.x + 0.25 * mid1.x,
+    y: 0.25 * mid0.y + 0.5 * ctrl.y + 0.25 * mid1.y,
+  };
+};
+
+const euclidean = (a: Point, b: Point) =>
+  Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+
+const permutations = <T>(arr: T[]): T[][] => {
+  if (arr.length <= 1) return [arr];
+  return arr.flatMap((item, i) =>
+    permutations([...arr.slice(0, i), ...arr.slice(i + 1)]).map(rest => [
+      item,
+      ...rest,
+    ])
+  );
+};
+
+// Returns the ordering of `waypoints` that minimises total path length
+// from `src` through all waypoints to `dst`.  Exhaustive for small N (≤ 8).
+const shortestWaypointOrder = (
+  waypoints: Point[],
+  src: Point,
+  dst: Point
+): Point[] => {
+  if (waypoints.length <= 1) return waypoints;
+
+  const pathLen = (perm: Point[]) => {
+    let d = euclidean(src, perm[0]);
+    for (let i = 0; i < perm.length - 1; i++) d += euclidean(perm[i], perm[i + 1]);
+    d += euclidean(perm[perm.length - 1], dst);
+    return d;
+  };
+
+  return permutations(waypoints).reduce((best, perm) =>
+    pathLen(perm) < pathLen(best) ? perm : best
+  );
+};
+
+export { getClosestPointOnLine, getClosestPointOnPolyline, shortestWaypointOrder };

--- a/packages/web/src/components/InteractiveMap/InteractiveMap.utils.ts
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.utils.ts
@@ -15,14 +15,19 @@ const getClosestPointOnLine = (
   const pointVecX = x1 - x2;
   const pointVecY = y1 - y2;
 
-  // Project point onto the line
+  // Project point onto the line segment, clamped to [0, 1]
   const lineLengthSquared = lineVecX * lineVecX + lineVecY * lineVecY;
-  const projection =
-    (pointVecX * lineVecX + pointVecY * lineVecY) / lineLengthSquared;
+  const t = Math.max(
+    0.1,
+    Math.min(
+      0.9,
+      (pointVecX * lineVecX + pointVecY * lineVecY) / lineLengthSquared
+    )
+  );
 
-  // Closest point on the line
-  const closestX = x2 + projection * lineVecX;
-  const closestY = y2 + projection * lineVecY;
+  // Closest point on the segment
+  const closestX = x2 + t * lineVecX;
+  const closestY = y2 + t * lineVecY;
 
   return { x: closestX, y: closestY };
 };

--- a/packages/web/src/components/InteractiveMap/orders/convoy.tsx
+++ b/packages/web/src/components/InteractiveMap/orders/convoy.tsx
@@ -27,7 +27,10 @@ const buildWavyPath = (
   // Round to nearest even number of half-waves (minimum 2) so both
   // endpoints always land on the centre axis.
   const rawHalfWaves = Math.round(len / (WAVE_LENGTH / 2));
-  const numHalfWaves = Math.max(2, rawHalfWaves % 2 === 0 ? rawHalfWaves : rawHalfWaves + 1);
+  const numHalfWaves = Math.max(
+    2,
+    rawHalfWaves % 2 === 0 ? rawHalfWaves : rawHalfWaves + 1
+  );
   const halfWaveLen = len / numHalfWaves;
 
   let path = `M ${x1} ${y1}`;
@@ -40,10 +43,14 @@ const buildWavyPath = (
     const ey = y1 + (i + 1) * halfWaveLen * uy;
 
     // Control points that approximate a sine half-wave using cubic bezier
-    const cp1x = sx + halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
-    const cp1y = sy + halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
-    const cp2x = ex - halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
-    const cp2y = ey - halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
+    const cp1x =
+      sx + halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
+    const cp1y =
+      sy + halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
+    const cp2x =
+      ex - halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
+    const cp2y =
+      ey - halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
 
     path += ` C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${ex} ${ey}`;
   }
@@ -65,24 +72,38 @@ type ConvoyArrowProps = {
   fill: string;
   stroke: string;
   strokeWidth: number;
+  // When provided, the fleet connects to this exact point on the rendered B-spline
+  // instead of computing the closest point on the straight x2→x3 line.
+  attachmentPoint?: { x: number; y: number };
   dash?: { length: number; spacing: number };
   onRenderCenter?: (x: number, y: number, angle: number) => React.ReactElement;
 };
 
 const ConvoyArrow = (props: ConvoyArrowProps) => {
-  // Get the closest point on the MoveViaConvoy segment from the fleet position
-  const closestPoint = getClosestPointOnLine(
-    props.x1,
-    props.y1,
-    props.x2,
-    props.y2,
-    props.x3,
-    props.y3
-  );
+  const closestPoint = props.attachmentPoint
+    ? props.attachmentPoint
+    : getClosestPointOnLine(
+        props.x1,
+        props.y1,
+        props.x2,
+        props.y2,
+        props.x3,
+        props.y3
+      );
 
   const directionX = closestPoint.x - props.x1;
   const directionY = closestPoint.y - props.y1;
-  const magnitude = Math.sqrt(directionX * directionX + directionY * directionY);
+  const magnitude = Math.sqrt(
+    directionX * directionX + directionY * directionY
+  );
+
+  // The attachment point is essentially at the fleet center (collinear route segment).
+  // Skip the wavy line but still render the failure cross so it isn't lost.
+  if (magnitude < 1) {
+    if (!props.onRenderCenter) return null;
+    return <g>{props.onRenderCenter(props.x1, props.y1, 0)}</g>;
+  }
+
   const unitX = directionX / magnitude;
   const unitY = directionY / magnitude;
 

--- a/packages/web/src/components/InteractiveMap/orders/convoy.tsx
+++ b/packages/web/src/components/InteractiveMap/orders/convoy.tsx
@@ -1,5 +1,56 @@
 import { getClosestPointOnLine } from "../InteractiveMap.utils";
 
+const WAVE_AMPLITUDE = 5;
+const WAVE_LENGTH = 30; // pixels per full wave
+const BEZIER_K = 4 / 3; // cubic bezier factor for sine approximation
+
+// Builds a sinusoidal path from (x1,y1) to (x2,y2).
+// Always uses an even number of half-waves so the path starts and ends
+// on the centre axis (zero perpendicular offset at both endpoints).
+const buildWavyPath = (
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number
+): string => {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len === 0) return `M ${x1} ${y1}`;
+
+  const ux = dx / len;
+  const uy = dy / len;
+  // Perpendicular unit vector
+  const px = -uy;
+  const py = ux;
+
+  // Round to nearest even number of half-waves (minimum 2) so both
+  // endpoints always land on the centre axis.
+  const rawHalfWaves = Math.round(len / (WAVE_LENGTH / 2));
+  const numHalfWaves = Math.max(2, rawHalfWaves % 2 === 0 ? rawHalfWaves : rawHalfWaves + 1);
+  const halfWaveLen = len / numHalfWaves;
+
+  let path = `M ${x1} ${y1}`;
+
+  for (let i = 0; i < numHalfWaves; i++) {
+    const sign = i % 2 === 0 ? 1 : -1;
+    const sx = x1 + i * halfWaveLen * ux;
+    const sy = y1 + i * halfWaveLen * uy;
+    const ex = x1 + (i + 1) * halfWaveLen * ux;
+    const ey = y1 + (i + 1) * halfWaveLen * uy;
+
+    // Control points that approximate a sine half-wave using cubic bezier
+    const cp1x = sx + halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
+    const cp1y = sy + halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
+    const cp2x = ex - halfWaveLen * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
+    const cp2y = ey - halfWaveLen * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
+
+    path += ` C ${cp1x} ${cp1y} ${cp2x} ${cp2y} ${ex} ${ey}`;
+  }
+
+  return path;
+};
+
 type ConvoyArrowProps = {
   x1: number;
   y1: number;
@@ -19,7 +70,7 @@ type ConvoyArrowProps = {
 };
 
 const ConvoyArrow = (props: ConvoyArrowProps) => {
-  // Get the closest point on the line from (x1, y1) to the line defined by (x2, y2) -> (x3, y3)
+  // Get the closest point on the MoveViaConvoy segment from the fleet position
   const closestPoint = getClosestPointOnLine(
     props.x1,
     props.y1,
@@ -29,46 +80,39 @@ const ConvoyArrow = (props: ConvoyArrowProps) => {
     props.y3
   );
 
-  // Calculate the direction vector from (x1, y1) to the closest point
   const directionX = closestPoint.x - props.x1;
   const directionY = closestPoint.y - props.y1;
-
-  // Normalize the direction vector
-  const magnitude = Math.sqrt(
-    directionX * directionX + directionY * directionY
-  );
+  const magnitude = Math.sqrt(directionX * directionX + directionY * directionY);
   const unitX = directionX / magnitude;
   const unitY = directionY / magnitude;
 
-  // Apply the offset in the direction of the unit vector
-  const offsetX = props.offset * unitX;
-  const offsetY = props.offset * unitY;
-
-  // Adjust the start and end points by the offset
-  const startX = props.x1 + offsetX;
-  const startY = props.y1 + offsetY;
+  const startX = props.x1 + props.offset * unitX;
+  const startY = props.y1 + props.offset * unitY;
   const endX = closestPoint.x;
   const endY = closestPoint.y;
 
   const angle = Math.atan2(endY - startY, endX - startX);
-
   const centerX = (startX + endX) / 2;
   const centerY = (startY + endY) / 2;
+
+  const wavyPath = buildWavyPath(startX, startY, endX, endY);
 
   return (
     <g>
       <path
-        d={`M ${startX} ${startY} L ${endX} ${endY}`}
+        d={wavyPath}
         stroke={props.stroke}
         strokeWidth={props.lineWidth + props.strokeWidth * 2}
+        fill="none"
         strokeDasharray={
           props.dash ? `${props.dash.length} ${props.dash.spacing}` : "none"
         }
       />
       <path
-        d={`M ${startX} ${startY} L ${endX} ${endY}`}
+        d={wavyPath}
         stroke={props.fill}
         strokeWidth={props.lineWidth}
+        fill="none"
         strokeDasharray={
           props.dash ? `${props.dash.length} ${props.dash.spacing}` : "none"
         }
@@ -77,7 +121,7 @@ const ConvoyArrow = (props: ConvoyArrowProps) => {
       <circle
         cx={endX}
         cy={endY}
-        r={5} // Radius of the circle, can adjust this value
+        r={5}
         fill={"white"}
         stroke={"black"}
         strokeWidth={props.strokeWidth}

--- a/packages/web/src/components/InteractiveMap/orders/move-via-convoy.tsx
+++ b/packages/web/src/components/InteractiveMap/orders/move-via-convoy.tsx
@@ -1,0 +1,149 @@
+type MoveViaConvoyArrowProps = {
+  // Full route: [source_center, ...fleet_centers_in_order, destination_center]
+  waypoints: { x: number; y: number }[];
+  lineWidth: number;
+  arrowWidth: number;
+  arrowLength: number;
+  offset: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  onRenderCenter?: (x: number, y: number, angle: number) => React.ReactElement;
+};
+
+import { ROUTE_TENSION } from "../InteractiveMap.utils";
+
+// Quadratic B-spline path through control points.
+// Fleet positions are used as CONTROL POINTS (attractors), not pass-through points,
+// so the curve bends toward each fleet but keeps natural clearance around its icon.
+// Endpoints (source offset, destination arrowhead base) are clamped exactly.
+const bSplinePath = (points: { x: number; y: number }[]): string => {
+  if (points.length < 2) return "";
+  if (points.length === 2)
+    return `M ${points[0].x} ${points[0].y} L ${points[1].x} ${points[1].y}`;
+
+  // Midpoint between consecutive control points
+  const mid = (i: number) => ({
+    x: (points[i].x + points[i + 1].x) / 2,
+    y: (points[i].y + points[i + 1].y) / 2,
+  });
+
+  // Scale a fleet control point toward the midpoint of its adjacent midpoints
+  // to reduce how far the curve deviates toward the fleet.
+  const ctrl = (i: number) => {
+    const mPrev = mid(i - 1);
+    const mNext = mid(i);
+    const midOfMids = { x: (mPrev.x + mNext.x) / 2, y: (mPrev.y + mNext.y) / 2 };
+    return {
+      x: midOfMids.x + ROUTE_TENSION * (points[i].x - midOfMids.x),
+      y: midOfMids.y + ROUTE_TENSION * (points[i].y - midOfMids.y),
+    };
+  };
+
+  const n = points.length - 1;
+  let d = `M ${points[0].x} ${points[0].y} L ${mid(0).x} ${mid(0).y}`;
+  for (let i = 1; i < n; i++) {
+    const c = ctrl(i);
+    const m = mid(i);
+    d += ` Q ${c.x} ${c.y} ${m.x} ${m.y}`;
+  }
+  d += ` L ${points[n].x} ${points[n].y}`;
+  return d;
+};
+
+const unit = (dx: number, dy: number) => {
+  const len = Math.sqrt(dx * dx + dy * dy);
+  return len === 0 ? { ux: 0, uy: 0 } : { ux: dx / len, uy: dy / len };
+};
+
+const MoveViaConvoyArrow = (props: MoveViaConvoyArrowProps) => {
+  const pts = props.waypoints;
+  if (pts.length < 2) return null;
+
+  // Start: offset from source center toward first fleet (or destination)
+  const { ux: sux, uy: suy } = unit(pts[1].x - pts[0].x, pts[1].y - pts[0].y);
+  const startPt = {
+    x: pts[0].x + sux * props.offset,
+    y: pts[0].y + suy * props.offset,
+  };
+
+  // End tangent: direction of last segment (second-to-last → last)
+  const last = pts[pts.length - 1];
+  const prev = pts[pts.length - 2];
+  const { ux: eux, uy: euy } = unit(last.x - prev.x, last.y - prev.y);
+  const endAngle = Math.atan2(euy, eux);
+
+  // Arrowhead tip: offset back from destination along end tangent
+  const tipX = last.x - eux * props.offset;
+  const tipY = last.y - euy * props.offset;
+
+  // Line ends at base of arrowhead
+  const lineEndPt = {
+    x: tipX - eux * props.arrowLength,
+    y: tipY - euy * props.arrowLength,
+  };
+
+  // Build modified waypoints for the curve: replace first and last with offset points
+  const curvePts = [startPt, ...pts.slice(1, -1), lineEndPt];
+  const pathD = bSplinePath(curvePts);
+
+  // Arrowhead polygon
+  const perpAngle = endAngle + Math.PI / 2;
+  const arrowBottomLeft = {
+    x: lineEndPt.x - props.arrowWidth * Math.cos(perpAngle),
+    y: lineEndPt.y - props.arrowWidth * Math.sin(perpAngle),
+  };
+  const arrowBottomRight = {
+    x: lineEndPt.x + props.arrowWidth * Math.cos(perpAngle),
+    y: lineEndPt.y + props.arrowWidth * Math.sin(perpAngle),
+  };
+  const arrowLineLeft = {
+    x: lineEndPt.x - (props.lineWidth / 2) * Math.cos(perpAngle),
+    y: lineEndPt.y - (props.lineWidth / 2) * Math.sin(perpAngle),
+  };
+  const arrowLineRight = {
+    x: lineEndPt.x + (props.lineWidth / 2) * Math.cos(perpAngle),
+    y: lineEndPt.y + (props.lineWidth / 2) * Math.sin(perpAngle),
+  };
+
+  // The B-spline passes through midpoints between consecutive control points.
+  // Use the middle such midpoint as the cross position — it lies exactly on the curve.
+  const mids = curvePts.slice(0, -1).map((p, i) => ({
+    x: (p.x + curvePts[i + 1].x) / 2,
+    y: (p.y + curvePts[i + 1].y) / 2,
+  }));
+  const midIdx = Math.floor(mids.length / 2);
+  const centerX = mids[midIdx].x;
+  const centerY = mids[midIdx].y;
+  const centerAngle = Math.atan2(
+    curvePts[midIdx + 1].y - curvePts[midIdx].y,
+    curvePts[midIdx + 1].x - curvePts[midIdx].x
+  );
+
+  return (
+    <g>
+      <path
+        d={pathD}
+        stroke={props.stroke}
+        strokeWidth={props.lineWidth + props.strokeWidth * 2}
+        fill="none"
+      />
+      <path
+        d={pathD}
+        stroke={props.fill}
+        strokeWidth={props.lineWidth}
+        fill="none"
+      />
+      <path
+        d={`M ${arrowLineLeft.x} ${arrowLineLeft.y} L ${arrowBottomLeft.x} ${arrowBottomLeft.y} L ${tipX} ${tipY} L ${arrowBottomRight.x} ${arrowBottomRight.y} L ${arrowLineRight.x} ${arrowLineRight.y}`}
+        stroke={props.stroke}
+        strokeWidth={props.strokeWidth}
+        fill={props.fill}
+      />
+      {props.onRenderCenter &&
+        props.onRenderCenter(centerX, centerY, centerAngle)}
+    </g>
+  );
+};
+
+export { MoveViaConvoyArrow };


### PR DESCRIPTION
1. This adjusts arrows of mutually attacking units to be slightly curved and show both arrows. Support arrows align with the new arrow location.

2. MoveViaConvoy orders are now much more complex, but true:
2a. Originally, I made one commit that fixes a bug that moves the Convoy orders on the perpendicular line of the MoveViaConvoy order, but does not change the MoveViaConvoy order itself - if too complex, move up to that commit and keep it at that). 
2b. Convoy orders now look like a squiggly line, similar to Diplomacy rulebook.
2c. MoveViaConvoy orders now make a big line through all the ships that participate in the Convoy
<img width="514" height="696" alt="image" src="https://github.com/user-attachments/assets/be761087-372f-4f1b-824d-e2bb65449a14" />
This means the MoveViaConvoy is a straight line if no Fleets are Convoying, otherwise goes through that fleets.
This means Convoy orders now move between the Fleet and the 'closest point on the MoveViaConvoy' line, so that they seem to be Convoying correctly.