### PR TITLE
Fix broken screen after creating a chat channel

### DIFF
--- a/packages/web/src/screens/GameDetail/ChannelCreateScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelCreateScreen.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useState } from "react";
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { UserPlus } from "lucide-react";
 import { useRequiredParams } from "@/hooks";
@@ -22,8 +23,10 @@ import {
 import { GameDetailAppBar } from "./AppBar";
 import { Panel } from "../../components/Panel";
 import {
+  getGamesChannelsListQueryKey,
   useGameRetrieveSuspense,
   useGamesChannelsCreateCreate,
+  type Channel,
 } from "@/api/generated/endpoints";
 
 const ChannelCreateScreen: React.FC = () => {
@@ -32,6 +35,7 @@ const ChannelCreateScreen: React.FC = () => {
     phaseId: string;
   }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
 
   const { data: game } = useGameRetrieveSuspense(gameId);
@@ -53,6 +57,10 @@ const ChannelCreateScreen: React.FC = () => {
           memberIds: selectedMembers,
         },
       });
+      queryClient.setQueryData<Channel[]>(
+        getGamesChannelsListQueryKey(gameId),
+        (old) => [...(old ?? []), response]
+      );
       toast.success("Channel created successfully");
       if (response) {
         navigate(`/game/${gameId}/phase/${phaseId}/chat/channel/${response.id}`);


### PR DESCRIPTION
Closes #365.

Channel creation navigates to the new channel before the channels-list cache is updated. `ChannelScreen` looks the channel up via `useGamesChannelsListSuspense(...).find(...)` and throws when missing, which `QueryErrorBoundary` catches — hence the broken screen. A page refresh works because the cache is rebuilt from scratch.

Optimistically appending the create response to `getGamesChannelsListQueryKey(gameId)` before navigating fixes it. The backend's `ChannelSerializer` returns the same shape as list items (`id`, `name`, `private`, `messages: []`, `unreadMessageCount: 0`), so the response slots in directly. Mirrors the orders pattern in `GameMap.tsx`.