### PR TITLE
Route forming-game shared links to game-info, not active game UI

### DIFF
--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -20,7 +20,7 @@ import { GameDetailLayout } from "./components/GameDetailLayout";
 import { GamePhaseRedirect } from "./components/GamePhaseRedirect";
 import { getVariantsListQueryOptions } from "./api/generated/endpoints";
 import * as Sentry from "@sentry/react";
-import { useDeepLink } from "./deepLink";
+import { deepLinkStorage, useDeepLink } from "./deepLink";
 
 const RouteFallback: React.FC = () => (
   <div className="flex-1 flex items-center justify-center">
@@ -268,7 +268,14 @@ const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
             },
             {
               path: "*",
-              loader: () => redirect("/"),
+              loader: ({ request }) => {
+                const url = new URL(request.url);
+                const path = `${url.pathname}${url.search}${url.hash}`;
+                if (url.pathname !== "/") {
+                  deepLinkStorage.setPendingPath(path);
+                }
+                return redirect("/");
+              },
             },
           ]),
     [loggedIn, queryClient]

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -1,9 +1,31 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GameCard } from "./GameCard";
-import { mockGames, mockSandboxGames, mockPhaseMovement } from "@/mocks";
+import {
+  mockGames,
+  mockSandboxGames,
+  mockPhaseMovement,
+  mockPendingGames,
+  mockActiveGames,
+} from "@/mocks";
+
+const mockNavigate = vi.fn();
+const mockUseIsMobile = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}));
 
 vi.mock("@/api/generated/endpoints", async () => {
   const actual = await vi.importActual("@/api/generated/endpoints");
@@ -38,6 +60,56 @@ const defaultProps = {
 };
 
 describe("GameCard", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockUseIsMobile.mockReset();
+    mockUseIsMobile.mockReturnValue(false);
+  });
+
+  describe("click navigation", () => {
+    it("navigates pending games to game-info on desktop", async () => {
+      mockUseIsMobile.mockReturnValue(false);
+      renderGameCard({ game: mockPendingGames[0], ...defaultProps });
+      await userEvent.click(
+        screen.getByRole("button", { name: mockPendingGames[0].name })
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/game-info/${mockPendingGames[0].id}`
+      );
+    });
+
+    it("navigates pending games to game-info on mobile", async () => {
+      mockUseIsMobile.mockReturnValue(true);
+      renderGameCard({ game: mockPendingGames[0], ...defaultProps });
+      await userEvent.click(
+        screen.getByRole("button", { name: mockPendingGames[0].name })
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/game-info/${mockPendingGames[0].id}`
+      );
+    });
+
+    it("navigates active games on mobile to the phase index", async () => {
+      mockUseIsMobile.mockReturnValue(true);
+      const game = mockActiveGames[0];
+      renderGameCard({ game, ...defaultProps });
+      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/game/${game.id}/phase/${game.currentPhaseId}`
+      );
+    });
+
+    it("navigates active games on desktop to the orders sub-route", async () => {
+      mockUseIsMobile.mockReturnValue(false);
+      const game = mockActiveGames[0];
+      renderGameCard({ game, ...defaultProps });
+      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/game/${game.id}/phase/${game.currentPhaseId}/orders`
+      );
+    });
+  });
+
   describe("sandbox visual treatment", () => {
     it("displays a Sandbox badge when game.sandbox is true", () => {
       renderGameCard({

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -22,9 +22,10 @@ import {
   useGamePhaseRetrieve,
   getGamesListQueryKey,
 } from "../api/generated/endpoints";
-import { formatTimeAgo } from "../util";
+import { formatTimeAgo, getGameLandingPath } from "../util";
 import { Skeleton } from "./ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export interface GameCardProps {
   game: GameList;
@@ -37,15 +38,12 @@ export interface GameCardProps {
 const GameCard: React.FC<GameCardProps> = ({ game, variant, phaseId, map }) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
   const { data: phase } = useGamePhaseRetrieve(game.id, phaseId);
   const joinGameMutation = useGameJoinCreate();
 
   const handleClickGame = () => {
-    if (game.status === "pending") {
-      navigate(`/game-info/${game.id}`);
-    } else {
-      navigate(`/game/${game.id}`);
-    }
+    navigate(getGameLandingPath(game, isMobile));
   };
 
   const handleClickGameInfo = () => {

--- a/packages/web/src/components/GamePhaseRedirect.test.tsx
+++ b/packages/web/src/components/GamePhaseRedirect.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GamePhaseRedirect } from "./GamePhaseRedirect";
+
+const mockUseGameRetrieveSuspense = vi.fn();
+const mockUseIsMobile = vi.fn();
+
+vi.mock("@/api/generated/endpoints", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/api/generated/endpoints")>();
+  return {
+    ...actual,
+    useGameRetrieveSuspense: (gameId: string) =>
+      mockUseGameRetrieveSuspense(gameId),
+  };
+});
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}));
+
+const LocationProbe: React.FC = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+const renderAtGameRoute = (gameId: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/game/${gameId}`]}>
+      <Routes>
+        <Route path="/game/:gameId" element={<GamePhaseRedirect />} />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("GamePhaseRedirect", () => {
+  beforeEach(() => {
+    mockUseGameRetrieveSuspense.mockReset();
+    mockUseIsMobile.mockReset();
+  });
+
+  it("redirects forming games to the game-info screen", () => {
+    mockUseGameRetrieveSuspense.mockReturnValue({
+      data: { id: "abc-1", status: "pending", currentPhaseId: 5 },
+    });
+    mockUseIsMobile.mockReturnValue(false);
+
+    renderAtGameRoute("abc-1");
+
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/game-info/abc-1"
+    );
+  });
+
+  it("redirects forming games to game-info on mobile too", () => {
+    mockUseGameRetrieveSuspense.mockReturnValue({
+      data: { id: "abc-2", status: "pending", currentPhaseId: null },
+    });
+    mockUseIsMobile.mockReturnValue(true);
+
+    renderAtGameRoute("abc-2");
+
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/game-info/abc-2"
+    );
+  });
+
+  it("redirects active games on mobile to the phase index", () => {
+    mockUseGameRetrieveSuspense.mockReturnValue({
+      data: { id: "abc-3", status: "active", currentPhaseId: 7 },
+    });
+    mockUseIsMobile.mockReturnValue(true);
+
+    renderAtGameRoute("abc-3");
+
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/game/abc-3/phase/7"
+    );
+  });
+
+  it("redirects active games on desktop to the orders sub-route", () => {
+    mockUseGameRetrieveSuspense.mockReturnValue({
+      data: { id: "abc-3", status: "active", currentPhaseId: 7 },
+    });
+    mockUseIsMobile.mockReturnValue(false);
+
+    renderAtGameRoute("abc-3");
+
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/game/abc-3/phase/7/orders"
+    );
+  });
+
+  it("redirects active games with no current phase back to home", () => {
+    mockUseGameRetrieveSuspense.mockReturnValue({
+      data: { id: "abc-4", status: "active", currentPhaseId: null },
+    });
+    mockUseIsMobile.mockReturnValue(false);
+
+    renderAtGameRoute("abc-4");
+
+    expect(screen.getByTestId("location")).toHaveTextContent("/");
+  });
+});

--- a/packages/web/src/components/GamePhaseRedirect.tsx
+++ b/packages/web/src/components/GamePhaseRedirect.tsx
@@ -3,20 +3,14 @@ import { Navigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useGameRetrieveSuspense } from "@/api/generated/endpoints";
+import { getGameLandingPath } from "@/util";
 
 const GamePhaseRedirectInner: React.FC = () => {
   const { gameId } = useRequiredParams<{ gameId: string }>();
   const { data: game } = useGameRetrieveSuspense(gameId);
   const isMobile = useIsMobile();
 
-  if (!game.currentPhaseId) {
-    return <Navigate to="/" replace />;
-  }
-
-  const basePath = `/game/${gameId}/phase/${game.currentPhaseId}`;
-  const redirectPath = isMobile ? basePath : `${basePath}/orders`;
-
-  return <Navigate to={redirectPath} replace />;
+  return <Navigate to={getGameLandingPath(game, isMobile)} replace />;
 };
 
 export const GamePhaseRedirect: React.FC = () => (

--- a/packages/web/src/util.test.ts
+++ b/packages/web/src/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatRemainingTime } from "./util";
+import { formatRemainingTime, getGameLandingPath } from "./util";
 
 describe("formatRemainingTime", () => {
   it("returns 'Deadline passed' for 0 seconds", () => {
@@ -34,5 +34,41 @@ describe("formatRemainingTime", () => {
     expect(formatRemainingTime(90000)).toBe("1d 1h remaining");
     expect(formatRemainingTime(172800)).toBe("2d 0h remaining");
     expect(formatRemainingTime(259200)).toBe("3d 0h remaining");
+  });
+});
+
+describe("getGameLandingPath", () => {
+  it("routes pending games to game-info regardless of viewport", () => {
+    const game = { id: "abc-1", status: "pending", currentPhaseId: 5 };
+    expect(getGameLandingPath(game, true)).toBe("/game-info/abc-1");
+    expect(getGameLandingPath(game, false)).toBe("/game-info/abc-1");
+  });
+
+  it("routes pending games to game-info even when currentPhaseId is null", () => {
+    const game = { id: "abc-2", status: "pending", currentPhaseId: null };
+    expect(getGameLandingPath(game, true)).toBe("/game-info/abc-2");
+    expect(getGameLandingPath(game, false)).toBe("/game-info/abc-2");
+  });
+
+  it("routes active games on mobile to the phase index", () => {
+    const game = { id: "abc-3", status: "active", currentPhaseId: 7 };
+    expect(getGameLandingPath(game, true)).toBe("/game/abc-3/phase/7");
+  });
+
+  it("routes active games on desktop to the orders sub-route", () => {
+    const game = { id: "abc-3", status: "active", currentPhaseId: 7 };
+    expect(getGameLandingPath(game, false)).toBe("/game/abc-3/phase/7/orders");
+  });
+
+  it("routes active games with no currentPhaseId back to home", () => {
+    const game = { id: "abc-4", status: "active", currentPhaseId: null };
+    expect(getGameLandingPath(game, true)).toBe("/");
+    expect(getGameLandingPath(game, false)).toBe("/");
+  });
+
+  it("routes completed games like active ones", () => {
+    const game = { id: "abc-5", status: "completed", currentPhaseId: 12 };
+    expect(getGameLandingPath(game, true)).toBe("/game/abc-5/phase/12");
+    expect(getGameLandingPath(game, false)).toBe("/game/abc-5/phase/12/orders");
   });
 });

--- a/packages/web/src/util.ts
+++ b/packages/web/src/util.ts
@@ -1,4 +1,4 @@
-import { GameRetrieve } from "./api/generated/endpoints";
+import { GameRetrieve, StatusEnum } from "./api/generated/endpoints";
 import { adjectives, conflictSynonyms, nouns } from "./terms";
 
 function capitalize(s: string) {
@@ -11,6 +11,16 @@ function randomOf(ary: string[]) {
 
 const getCurrentPhaseId = (game: GameRetrieve) => {
   return game.phases[game.phases.length - 1];
+};
+
+const getGameLandingPath = (
+  game: { id: string; status: string; currentPhaseId: number | null },
+  isMobile: boolean
+): string => {
+  if (game.status === StatusEnum.pending) return `/game-info/${game.id}`;
+  if (!game.currentPhaseId) return "/";
+  const base = `/game/${game.id}/phase/${game.currentPhaseId}`;
+  return isMobile ? base : `${base}/orders`;
 };
 
 function dziemba_levenshtein(a: string, b: string) {
@@ -181,4 +191,4 @@ function formatTimeAgo(djangoDatetime: string): string {
   return rtf.format(-diffYears, "year");
 }
 
-export { formatOrderText, formatDateTime, formatRemainingTime, formatTimeAgo, getCurrentPhaseId };
+export { formatOrderText, formatDateTime, formatRemainingTime, formatTimeAgo, getCurrentPhaseId, getGameLandingPath };


### PR DESCRIPTION
Fixes #357.

When a user opened a shared `/game/:gameId` link for a forming (status `pending`) game, the app routed them into the active-game UI (`GameDetailLayout` + `OrdersScreen`/`MapScreen`) instead of the lobby. The status-aware "go to /game-info if pending, otherwise /game/..." rule existed only in `GameCard.handleClickGame`, so the bug only surfaced via shared links — not via card clicks.

- Add `getGameLandingPath(game, isMobile)` in `util.ts` using `StatusEnum.pending`, and use it from both `GamePhaseRedirect` and `GameCard.handleClickGame` so the rule lives in one place.
- Capture the original path in the unauthenticated wildcard `loader` via `deepLinkStorage.setPendingPath` before redirecting to `/`. The existing `useDeepLink` hook in `AuthenticatedRoot` consumes the path post-login, so logged-out web visitors now land on the intended destination after signing in instead of having to copy the link again.

<details>
<summary>Implementation Plan</summary>

# Fix shared-link routing for forming games (issue #357)

## Context

GitHub issue [#357](https://github.com/johnpooch/diplicity-react/issues/357) reports two related problems with shared links to *forming* (status = `pending`) games:

1. **Primary** — When a logged-in user opens a shared `/game/:gameId` link for a forming game, the app routes them into the active-game UI (`GameDetailLayout` + `OrdersScreen`/`MapScreen`/`ChannelListScreen`) instead of the lobby/info screen. Symptoms: "Game in Progress" shell shown for a non-started game, Orders/Chat tabs crash querying phase/channel data that doesn't exist or is forbidden for non-members of a private game, and there is no visible Join/Leave action.

2. **Secondary** — When a logged-out web visitor opens a shared link, the unauthenticated wildcard route discards the path and redirects them to `/` (login). After signing in they land on the home screen and have to copy the link again.

### Why the primary bug exists

The "is the game forming? → go to lobby; otherwise → go to phase view" rule lives only in `GameCard.handleClickGame` (`packages/web/src/components/GameCard.tsx:43-49`). The shared-link entry point is `GamePhaseRedirect` (`packages/web/src/components/GamePhaseRedirect.tsx:7-20`), which only checks `game.currentPhaseId` and never `game.status`. Forming games still have a `currentPhaseId` because the backend creates a `PhaseStatus.PENDING` Phase row at game creation and `current_phase` returns the latest phase regardless of status. So `GamePhaseRedirect` happily forwards the visitor into the active-game shell.

### Why the secondary bug exists

The logged-out router ends with `{ path: "*", loader: () => redirect("/") }`, which throws away the original path. The `deepLinkStorage` / `useDeepLink` mechanism that *would* replay an intended path post-login is wired only for native (Capacitor) launches in `App.tsx` — not for web visitors arriving via a browser link.

### Intended outcome

A user who opens a shared `/game/:gameId` link — logged in or not, public or private game, forming or active — lands on the right screen on the first try, with Join/Leave actions present when appropriate.

## Approach

1. **Centralize the landing-path rule in a shared helper.** Add `getGameLandingPath` to `packages/web/src/util.ts` and call it from both `GamePhaseRedirect` and `GameCard`. This eliminates the duplication that caused the bug.
2. **Use the helper in `GamePhaseRedirect`.** Replace the inline phase-id check with `<Navigate to={getGameLandingPath(game, isMobile)} replace />`.
3. **Use the helper in `GameCard`.** `handleClickGame` currently only branches on `pending` vs everything-else and ignores `isMobile`. Replace with the helper so its desktop behavior (orders sub-route) matches `GamePhaseRedirect`.
4. **Capture the intended path on logged-out web entry.** The `deepLinkStorage` abstraction already exists and works — it just needs a web hook. Replace the unauthenticated wildcard's plain redirect with a loader that captures the current path before redirecting. After the user logs in, `AuthenticatedRoot` calls `useDeepLink()`, which consumes the pending path and navigates to it. From there, `GamePhaseRedirect` (now status-aware) routes the visitor correctly.

## Existing utilities reused

- `StatusEnum` from `packages/web/src/api/generated/endpoints.ts` — the generated enum for `game.status`.
- `useIsMobile` from `packages/web/src/hooks/use-mobile.ts` — already used in `GamePhaseRedirect`.
- `deepLinkStorage` (`setPendingPath`, `consumePendingPath`) and `useDeepLink` from `packages/web/src/deepLink/` — already wired into `AuthenticatedRoot`; no changes needed in this layer.

## Verification

End-to-end manual test (the only way to truly cover both bugs together):

1. **Setup** — `docker compose up`. Create a *private* forming game, copy the share link `/game/:gameId`.
2. **Logged-in primary path** — In a different browser tab as the same user, paste the link. Expect: lands on `/game-info/:gameId` with Join/Leave button visible. No console errors.
3. **Active-game regression check** — Repeat with a regular started game. Expect: lands on `/game/:gameId/phase/:phaseId/orders` (desktop) or `/game/:gameId/phase/:phaseId` (mobile).
4. **Logged-out replay path** — Open the same private-game link in an incognito/private window (no session). Sign in via the email/password form. Expect: after auth, lands directly on `/game-info/:gameId`.
5. **Native deep-link regression check** — Build the iOS app and open `diplicity://game/<id>`. Expect: existing native deep-link replay still works.

</details>

<sub>Generated with Claude Code</sub>