### PR TITLE
Move logout and delete account out of profile overflow menu

### DIFF
--- a/packages/web/src/screens/Home/Profile.tsx
+++ b/packages/web/src/screens/Home/Profile.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from "react";
-import { Check, X, Pencil, MoreHorizontal } from "lucide-react";
+import { Check, X, Pencil } from "lucide-react";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -19,13 +19,6 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { useTheme } from "@/theme/useTheme";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useAuth } from "@/auth";
 import { useNavigate } from "react-router";
 import { useMessaging } from "@/hooks/useMessaging";
@@ -38,6 +31,8 @@ import { useQueryClient } from "@tanstack/react-query";
 
 const Profile: React.FC = () => {
   const queryClient = useQueryClient();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
   const { data: userProfile } = useUserRetrieveSuspense();
   const updateProfileMutation = useUserUpdatePartialUpdate();
 
@@ -94,7 +89,16 @@ const Profile: React.FC = () => {
   return (
     <ScreenCard>
       <ScreenCardContent className="space-y-4">
-        <h2 className="text-lg font-semibold">User</h2>
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">User</h2>
+          <Button
+            variant="outline"
+            onClick={logout}
+            className="hidden sm:inline-flex"
+          >
+            Log out
+          </Button>
+        </div>
         <div className="flex items-center gap-4">
           <div>
             <Avatar className="size-12">
@@ -165,6 +169,13 @@ const Profile: React.FC = () => {
             )}
           </div>
         </div>
+        <Button
+          variant="outline"
+          onClick={logout}
+          className="sm:hidden"
+        >
+          Log out
+        </Button>
 
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">Appearance</h2>
@@ -210,43 +221,24 @@ const Profile: React.FC = () => {
             </div>
           </div>
         </div>
+
+        <div className="pt-4 border-t">
+          <Button
+            variant="destructive"
+            onClick={() => navigate("/delete-account")}
+          >
+            Delete Account
+          </Button>
+        </div>
       </ScreenCardContent>
     </ScreenCard>
   );
 };
 
 const ProfileSuspense: React.FC = () => {
-  const { logout } = useAuth();
-  const navigate = useNavigate();
-
-  const handleLogout = () => {
-    logout();
-  };
-
   return (
     <ScreenContainer>
-      <ScreenHeader
-        title="Profile"
-        actions={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" aria-label="Menu">
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleLogout}>Logout</DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className="text-destructive"
-                onClick={() => navigate("/delete-account")}
-              >
-                Delete Account
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
+      <ScreenHeader title="Profile" />
       <QueryErrorBoundary>
         <Suspense fallback={<div></div>}>
           <Profile />


### PR DESCRIPTION
- Currently, on the profile screen,  logout/delete account are hidden behind a small overflow menu. Not easy to see. 
- Secondly, on the overflow menu, log out (common action) and delete account (destructive action) are very close. While there is a confirm page, this creates 'stress' that the user needs to press the right button or delete their account.

I removed the overflow menu, and pasted both the log out as well as delete account menu into the user profile - while at the same time separating their distance and making the delete account functionality stand out more. 

Log out is now a button next to the User heading (desktop) or below the user info block (mobile). Delete Account is a destructive button at the bottom of the profile screen. The overflow menu is removed.