### PR TITLE
Bump iOS marketing version and select Xcode 26 in CI

### DIFF
--- a/.github/workflows/ios-pr-build.yml
+++ b/.github/workflows/ios-pr-build.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Select latest Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)
+          echo "DEVELOPER_DIR=$XCODE/Contents/Developer" >> "$GITHUB_ENV"
+
       - name: Fetch PR info and checkout PR branch
         run: |
           PR_INFO=$(gh pr view ${{ inputs.pr_number }} --json headRefName,title)

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Select latest Xcode 26
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)
+          echo "DEVELOPER_DIR=$XCODE/Contents/Developer" >> "$GITHUB_ENV"
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
### Why?

The iOS release workflow fails on every run: App Store Connect rejects uploads under `CFBundleShortVersionString` 1.0.0 (the 1.0 train is closed for new submissions) and rejects builds compiled with the iOS 18.5 SDK now that Apple requires iOS 26 SDK or newer.

### How?

Bumps the marketing version (read by Fastlane from `package.json` at build time) and points `DEVELOPER_DIR` at the latest Xcode 26 already installed on the `macos-15` runner. Applied to both `ios-release.yml` and `ios-pr-build.yml`.

<sub>Generated with Claude Code</sub>