### PR TITLE
Delete empty pending games (#371)

### DIFF
--- a/service/game/migrations/0013_delete_empty_pending_games.py
+++ b/service/game/migrations/0013_delete_empty_pending_games.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+from django.db.models import Count
+
+
+def delete_empty_pending_games(apps, schema_editor):
+    Game = apps.get_model("game", "Game")
+    Game.objects.filter(status="pending").annotate(
+        member_count=Count("members")
+    ).filter(member_count=0).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("game", "0012_add_press_type_field"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_empty_pending_games,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -525,6 +525,12 @@ class Game(BaseModel):
         self.paused_at = None
         self.save()
 
+    def delete_if_empty_pending(self):
+        if self.status == GameStatus.PENDING and not self.members.exists():
+            self.delete()
+            return True
+        return False
+
     def extend_deadline(self, duration):
         if self.status != GameStatus.ACTIVE:
             raise ValueError("Can only extend deadline for an active game")

--- a/service/game/tests/test_game_delete.py
+++ b/service/game/tests/test_game_delete.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from common.constants import GameStatus
 from game.models import Game
 
 delete_viewname = "game-delete"
@@ -67,3 +68,36 @@ class TestGameDeleteView:
         url = reverse(delete_viewname, args=["nonexistent-game"])
         response = authenticated_client.delete(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestDeleteIfEmptyPending:
+
+    @pytest.mark.django_db
+    def test_pending_game_with_no_members_is_deleted(self, base_pending_game_for_primary_user):
+        game = base_pending_game_for_primary_user
+        game_id = game.id
+
+        result = game.delete_if_empty_pending()
+
+        assert result is True
+        assert not Game.objects.filter(id=game_id).exists()
+
+    @pytest.mark.django_db
+    def test_pending_game_with_members_is_not_deleted(self, pending_game_created_by_primary_user):
+        game = pending_game_created_by_primary_user
+
+        result = game.delete_if_empty_pending()
+
+        assert result is False
+        assert Game.objects.filter(id=game.id).exists()
+
+    @pytest.mark.django_db
+    def test_active_game_with_no_members_is_not_deleted(self, base_pending_game_for_primary_user):
+        game = base_pending_game_for_primary_user
+        game.status = GameStatus.ACTIVE
+        game.save()
+
+        result = game.delete_if_empty_pending()
+
+        assert result is False
+        assert Game.objects.filter(id=game.id).exists()

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -237,6 +237,34 @@ def test_leave_game_not_found(authenticated_client):
 
 
 @pytest.mark.django_db
+def test_leave_pending_game_as_sole_member_deletes_game(
+    authenticated_client, pending_game_created_by_primary_user
+):
+    game = pending_game_created_by_primary_user
+    game_id = game.id
+
+    url = reverse(leave_viewname, args=[game_id])
+    response = authenticated_client.delete(url)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Game.objects.filter(id=game_id).exists()
+
+
+@pytest.mark.django_db
+def test_leave_pending_game_with_other_members_preserves_game(
+    authenticated_client, pending_game_created_by_secondary_user_joined_by_primary
+):
+    game = pending_game_created_by_secondary_user_joined_by_primary
+
+    url = reverse(leave_viewname, args=[game.id])
+    response = authenticated_client.delete(url)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Game.objects.filter(id=game.id).exists()
+    assert game.members.count() == 1
+
+
+@pytest.mark.django_db
 def test_join_game_member_is_not_game_master(
     authenticated_client, pending_game_created_by_secondary_user, primary_user
 ):

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions, generics
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 
@@ -30,3 +31,9 @@ class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):
     def get_object(self):
         game = self.get_game()
         return get_object_or_404(Member, game=game, user=self.request.user)
+
+    def perform_destroy(self, instance):
+        game = instance.game
+        with transaction.atomic():
+            super().perform_destroy(instance)
+            game.delete_if_empty_pending()

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -172,6 +172,39 @@ class TestUserAccountDelete:
         assert member.kicked is True
         assert member.user is None
 
+    @pytest.mark.django_db
+    def test_pending_game_with_sole_user_is_deleted(
+        self, delete_user, delete_client, base_pending_game_for_primary_user
+    ):
+        user = delete_user()
+        client = delete_client(user)
+        game = base_pending_game_for_primary_user
+        game.members.create(user=user)
+        game_id = game.id
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        assert not Game.objects.filter(id=game_id).exists()
+
+    @pytest.mark.django_db
+    def test_pending_game_with_other_members_is_preserved(
+        self, delete_user, delete_client, base_pending_game_for_primary_user, secondary_user
+    ):
+        user = delete_user()
+        user_id = user.id
+        client = delete_client(user)
+        game = base_pending_game_for_primary_user
+        game.members.create(user=user)
+        other_member = game.members.create(user=secondary_user)
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        assert Game.objects.filter(id=game.id).exists()
+        assert Member.objects.filter(id=other_member.id).exists()
+        assert not Member.objects.filter(game=game, user_id=user_id).exists()
+
 
 class TestWelcomeSandboxGameCreation:
 

--- a/service/user_profile/views.py
+++ b/service/user_profile/views.py
@@ -1,5 +1,7 @@
 from rest_framework import permissions, generics
+from django.db import transaction
 
+from game.models import Game
 from member.models import Member
 from common.constants import GameStatus
 from .models import UserProfile
@@ -29,9 +31,17 @@ class UserAccountDeleteView(generics.DestroyAPIView):
         return self.request.user
 
     def perform_destroy(self, instance):
-        user_members = Member.objects.filter(user=instance)
-        user_members.filter(game__status=GameStatus.PENDING).delete()
-        user_members.filter(
-            game__status__in=[GameStatus.ACTIVE, GameStatus.COMPLETED]
-        ).update(kicked=True)
-        instance.delete()
+        with transaction.atomic():
+            user_members = Member.objects.filter(user=instance)
+            pending_game_ids = list(
+                user_members.filter(game__status=GameStatus.PENDING).values_list(
+                    "game_id", flat=True
+                )
+            )
+            user_members.filter(game__status=GameStatus.PENDING).delete()
+            user_members.filter(
+                game__status__in=[GameStatus.ACTIVE, GameStatus.COMPLETED]
+            ).update(kicked=True)
+            for game in Game.objects.filter(id__in=pending_game_ids):
+                game.delete_if_empty_pending()
+            instance.delete()


### PR DESCRIPTION
Closes #371.

Pending games with no members were cluttering the forming-games list. Two paths could produce them and neither cleaned up: the leave endpoint deleting the last member, and account deletion deleting the user's pending-game member rows.

`Game.delete_if_empty_pending()` is now called from both `MemberDeleteView.perform_destroy` and `UserAccountDeleteView.perform_destroy` (wrapped in `transaction.atomic`). A one-shot data migration deletes the empty pending games already in production.

Out of scope: GM handoff when the GM leaves a still-populated game, and cleanup of zero-member games in non-pending statuses.

<sub>Generated with Claude Code</sub>