### PR TITLE
Unhide game options

### DIFF
--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -242,6 +242,14 @@ const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
                             </Suspense>
                           ),
                         },
+                        {
+                          path: "game",
+                          element: (
+                            <Suspense fallback={<RouteFallback />}>
+                              <GameDetail.GameScreen />
+                            </Suspense>
+                          ),
+                        },
                       ],
                     },
                   ],

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
-import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
+import { ArrowLeft, Map, Gavel, MessageCircle, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Sidebar,
@@ -20,6 +20,7 @@ const navigationItems = [
   { label: "Map", icon: Map, path: "/game/:gameId/phase/:phaseId" },
   { label: "Orders", icon: Gavel, path: "/game/:gameId/phase/:phaseId/orders" },
   { label: "Chat", icon: MessageCircle, path: "/game/:gameId/phase/:phaseId/chat" },
+  { label: "Game", icon: Settings, path: "/game/:gameId/phase/:phaseId/game" },
 ];
 
 interface GameDetailLayoutProps {

--- a/packages/web/src/components/HomeLayout.tsx
+++ b/packages/web/src/components/HomeLayout.tsx
@@ -64,6 +64,9 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, className }) => {
     isActive: location.pathname === item.path,
   }));
 
+  const mainPaths = ["/", "/find-games", "/create-game", "/community"];
+  const showLearnToPlay = mainPaths.includes(location.pathname);
+
   const bottomClasses = cn("border-t bg-background", "block md:hidden");
 
   return (
@@ -95,16 +98,18 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, className }) => {
               />
             </SidebarContent>
             <SidebarFooter>
-              <SidebarMenu>
-                <SidebarMenuItem>
-                  <SidebarMenuButton asChild tooltip="Learn how to play">
-                    <Link to="/learn-to-play">
-                      <CircleHelp />
-                      <span>Learn how to play</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              </SidebarMenu>
+              {showLearnToPlay && (
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild tooltip="Learn how to play">
+                      <Link to="/learn-to-play">
+                        <CircleHelp />
+                        <span>Learn how to play</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              )}
               <Suspense fallback={null}>
                 <SidebarUserArea />
               </Suspense>

--- a/packages/web/src/components/ui/screen-header.tsx
+++ b/packages/web/src/components/ui/screen-header.tsx
@@ -11,14 +11,15 @@ interface ScreenHeaderProps {
 
 function ScreenHeader({ title, actions }: ScreenHeaderProps) {
   const { pathname } = useLocation();
-  const onLearnToPlay = pathname.endsWith("/learn-to-play");
+  const mainPaths = ["/", "/find-games", "/create-game", "/community"];
+  const showLearnToPlay = mainPaths.includes(pathname);
 
   return (
     <div className="flex items-center justify-between gap-3">
       <h1 className="text-2xl font-bold">{title}</h1>
       <div className="flex items-center gap-6">
         {actions}
-        {!onLearnToPlay && (
+        {showLearnToPlay && (
           <Link
             to="/learn-to-play"
             className="md:hidden flex items-center justify-center size-8 text-foreground hover:text-foreground transition-colors"

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -247,17 +247,16 @@ const DrawProposalsScreen: React.FC = () => {
         title="Draw Proposals"
         variant="secondary"
         onNavigateBack={handleBack}
-        rightButton={
-          canProposeDraw ? (
-            <Button variant="outline" size="icon" onClick={handleProposeDraw}>
-              <Plus />
-            </Button>
-          ) : undefined
-        }
       />
       <div className="flex-1 overflow-y-auto">
         <Panel>
           <Panel.Content>
+            {canProposeDraw && (
+              <Button variant="outline" className="w-full mb-4" onClick={handleProposeDraw}>
+                <Plus className="size-4" />
+                Propose draw
+              </Button>
+            )}
             <Tabs value={tab} onValueChange={value => setTab(value as TabValue)}>
               <TabsList className="w-full">
                 <TabsTrigger value="active" className="flex-1">

--- a/packages/web/src/screens/GameDetail/GameScreen.tsx
+++ b/packages/web/src/screens/GameDetail/GameScreen.tsx
@@ -1,0 +1,490 @@
+import React, { Suspense, useState } from "react";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Info,
+  Users,
+  Share,
+  Copy,
+  Clock,
+  Pause,
+  Play,
+  Vote,
+  LogOut,
+  Trash2,
+  ChevronRight,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Item,
+  ItemContent,
+  ItemTitle,
+  ItemGroup,
+  ItemSeparator,
+  ItemActions,
+} from "@/components/ui/item";
+import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
+import { GameDetailAppBar } from "./AppBar";
+import { Panel } from "@/components/Panel";
+import { useRequiredParams } from "@/hooks";
+import {
+  useGameRetrieveSuspense,
+  useGameLeaveDestroy,
+  useGameDeleteDestroy,
+  useGameCloneToSandboxCreate,
+  useGameExtendDeadlineUpdate,
+  useGamePauseUpdate,
+  useGameUnpausePartialUpdate,
+  useGamesDrawProposalsListSuspense,
+  getGamesListQueryKey,
+  getGameRetrieveQueryKey,
+  getGamePhasesListQueryKey,
+  getGamePhaseRetrieveQueryKey,
+  DrawProposal,
+  DurationEnum,
+} from "@/api/generated/endpoints";
+import { EXTEND_DURATION_OPTIONS } from "@/constants";
+
+interface DrawProposalBadgeProps {
+  gameId: string;
+  currentMemberId?: number;
+}
+
+const getPendingVotesCount = (
+  proposals: DrawProposal[],
+  currentMemberId?: number
+) => {
+  return proposals.filter(p => {
+    if (p.status !== "pending") return false;
+    const userVote = p.votes.find(v => v.member.id === currentMemberId);
+    return userVote && userVote.accepted === null;
+  }).length;
+};
+
+const DrawProposalBadge: React.FC<DrawProposalBadgeProps> = ({
+  gameId,
+  currentMemberId,
+}) => {
+  const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
+  const pendingVotesCount = getPendingVotesCount(proposals, currentMemberId);
+
+  if (pendingVotesCount === 0) return null;
+
+  return (
+    <Badge variant="destructive" className="ml-auto h-5 w-5 p-0 justify-center">
+      {pendingVotesCount}
+    </Badge>
+  );
+};
+
+const GameScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { gameId, phaseId } = useRequiredParams<{
+    gameId: string;
+    phaseId: string;
+  }>();
+
+  const { data: game } = useGameRetrieveSuspense(gameId);
+
+  const [showCloneConfirmation, setShowCloneConfirmation] = useState(false);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [showExtendDeadlineDialog, setShowExtendDeadlineDialog] = useState(false);
+  const [selectedDuration, setSelectedDuration] = useState<DurationEnum>(
+    DurationEnum["24_hours"]
+  );
+
+  const leaveGameMutation = useGameLeaveDestroy();
+  const deleteGameMutation = useGameDeleteDestroy();
+  const cloneToSandboxMutation = useGameCloneToSandboxCreate();
+  const extendDeadlineMutation = useGameExtendDeadlineUpdate();
+  const pauseGameMutation = useGamePauseUpdate();
+  const unpauseGameMutation = useGameUnpausePartialUpdate();
+
+  const currentMember = game.members?.find(m => m.isCurrentUser);
+  const isActiveGame = game.status === "active";
+  const isCurrentUserGameMaster = currentMember?.isGameMaster ?? false;
+  const canExtendDeadline =
+    isCurrentUserGameMaster && isActiveGame && !game.isPaused;
+  const canPauseGame =
+    isCurrentUserGameMaster && isActiveGame && !game.isPaused;
+  const canUnpauseGame =
+    isCurrentUserGameMaster && isActiveGame && game.isPaused;
+  const isActiveOrFinishedGame =
+    game.status === "active" ||
+    game.status === "completed" ||
+    game.status === "abandoned";
+  const canViewDrawProposals = !game.sandbox && isActiveOrFinishedGame;
+
+  const handleShare = () => {
+    navigator.clipboard.writeText(
+      `${window.location.origin}/game/${game.id}`
+    );
+    toast.success("Link copied to clipboard");
+  };
+
+  const handleLeaveGame = async () => {
+    try {
+      await leaveGameMutation.mutateAsync({ gameId: game.id });
+      toast.success("Successfully left game");
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+    } catch {
+      toast.error("Failed to leave game");
+    }
+  };
+
+  const handleDeleteGame = async () => {
+    setShowDeleteConfirmation(false);
+    try {
+      await deleteGameMutation.mutateAsync({ gameId: game.id });
+      toast.success("Game deleted");
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+      navigate("/");
+    } catch {
+      toast.error("Failed to delete game");
+    }
+  };
+
+  const handleClone = async () => {
+    setShowCloneConfirmation(false);
+    try {
+      const result = await cloneToSandboxMutation.mutateAsync({
+        gameId: game.id,
+        data: {},
+      });
+      toast.success("Sandbox created");
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+      navigate(`/game/${result.id}`);
+    } catch {
+      toast.error("Failed to create sandbox");
+    }
+  };
+
+  const handleExtendDeadlineDialogChange = (open: boolean) => {
+    setShowExtendDeadlineDialog(open);
+    if (!open) {
+      setSelectedDuration(DurationEnum["24_hours"]);
+    }
+  };
+
+  const handleExtendDeadline = async () => {
+    setShowExtendDeadlineDialog(false);
+    try {
+      await extendDeadlineMutation.mutateAsync({
+        gameId: game.id,
+        data: { duration: selectedDuration },
+      });
+      toast.success("Deadline extended");
+      queryClient.invalidateQueries({
+        queryKey: getGameRetrieveQueryKey(game.id),
+      });
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+      queryClient.invalidateQueries({
+        queryKey: getGamePhasesListQueryKey(game.id),
+      });
+      queryClient.invalidateQueries({
+        queryKey: getGamePhaseRetrieveQueryKey(game.id, Number(phaseId)),
+      });
+    } catch {
+      toast.error("Failed to extend deadline");
+    }
+  };
+
+  const handlePauseGame = async () => {
+    try {
+      await pauseGameMutation.mutateAsync({ gameId: game.id });
+      toast.success("Game paused");
+      queryClient.invalidateQueries({
+        queryKey: getGameRetrieveQueryKey(game.id),
+      });
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+    } catch {
+      toast.error("Failed to pause game");
+    }
+  };
+
+  const handleUnpauseGame = async () => {
+    try {
+      await unpauseGameMutation.mutateAsync({ gameId: game.id });
+      toast.success("Game resumed");
+      queryClient.invalidateQueries({
+        queryKey: getGameRetrieveQueryKey(game.id),
+      });
+      queryClient.invalidateQueries({ queryKey: getGamesListQueryKey() });
+    } catch {
+      toast.error("Failed to resume game");
+    }
+  };
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <GameDetailAppBar
+        title="Game"
+        onNavigateBack={() => navigate(-1)}
+        variant="secondary"
+      />
+      <div className="flex-1 overflow-y-auto">
+        <Panel>
+          <Panel.Content>
+            <ItemGroup>
+              <Item
+                className="cursor-pointer hover:bg-accent/50"
+                onClick={() =>
+                  navigate(`/game/${gameId}/phase/${phaseId}/game-info`)
+                }
+              >
+                <Info className="size-4 shrink-0" />
+                <ItemContent>
+                  <ItemTitle>Game info</ItemTitle>
+                </ItemContent>
+                <ItemActions>
+                  <ChevronRight className="size-4 text-muted-foreground" />
+                </ItemActions>
+              </Item>
+              <ItemSeparator />
+              <Item
+                className="cursor-pointer hover:bg-accent/50"
+                onClick={() =>
+                  navigate(`/game/${gameId}/phase/${phaseId}/player-info`)
+                }
+              >
+                <Users className="size-4 shrink-0" />
+                <ItemContent>
+                  <ItemTitle>Player info</ItemTitle>
+                </ItemContent>
+                <ItemActions>
+                  <ChevronRight className="size-4 text-muted-foreground" />
+                </ItemActions>
+              </Item>
+              <ItemSeparator />
+              <Item
+                className="cursor-pointer hover:bg-accent/50"
+                onClick={handleShare}
+              >
+                <Share className="size-4 shrink-0" />
+                <ItemContent>
+                  <ItemTitle>Share</ItemTitle>
+                </ItemContent>
+              </Item>
+              {!game.sandbox && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={() => setShowCloneConfirmation(true)}
+                  >
+                    <Copy className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Clone to sandbox</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+              {canExtendDeadline && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={() => handleExtendDeadlineDialogChange(true)}
+                  >
+                    <Clock className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Extend deadline</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+              {canPauseGame && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={handlePauseGame}
+                  >
+                    <Pause className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Pause game</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+              {canUnpauseGame && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={handleUnpauseGame}
+                  >
+                    <Play className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Resume game</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+              {canViewDrawProposals && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={() =>
+                      navigate(`/game/${gameId}/phase/${phaseId}/draw-proposals`)
+                    }
+                  >
+                    <Vote className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Draw proposals</ItemTitle>
+                    </ItemContent>
+                    <ItemActions>
+                      <Suspense fallback={null}>
+                        <DrawProposalBadge
+                          gameId={game.id}
+                          currentMemberId={currentMember?.id}
+                        />
+                      </Suspense>
+                      <ChevronRight className="size-4 text-muted-foreground" />
+                    </ItemActions>
+                  </Item>
+                </>
+              )}
+              {game.canLeave && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={handleLeaveGame}
+                  >
+                    <LogOut className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Leave game</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+              {game.canDelete && (
+                <>
+                  <ItemSeparator />
+                  <Item
+                    className="cursor-pointer hover:bg-accent/50"
+                    onClick={() => setShowDeleteConfirmation(true)}
+                  >
+                    <Trash2 className="size-4 shrink-0" />
+                    <ItemContent>
+                      <ItemTitle>Delete game</ItemTitle>
+                    </ItemContent>
+                  </Item>
+                </>
+              )}
+            </ItemGroup>
+          </Panel.Content>
+        </Panel>
+      </div>
+
+      <AlertDialog
+        open={showDeleteConfirmation}
+        onOpenChange={setShowDeleteConfirmation}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete sandbox game</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this sandbox game and all its data.
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteGame}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={showCloneConfirmation}
+        onOpenChange={setShowCloneConfirmation}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clone to sandbox</AlertDialogTitle>
+            <AlertDialogDescription>
+              A sandbox copy of this game will be created at the current phase.
+              You can use it to explore different strategies. If you already
+              have 3 sandbox games, your oldest one will be deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleClone}>
+              Create sandbox
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={showExtendDeadlineDialog}
+        onOpenChange={handleExtendDeadlineDialogChange}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Extend deadline</AlertDialogTitle>
+            <AlertDialogDescription className="text-left">
+              Select how long to extend the current phase deadline.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Select
+            value={selectedDuration}
+            onValueChange={value => setSelectedDuration(value as DurationEnum)}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EXTEND_DURATION_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleExtendDeadline}>
+              Extend
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+};
+
+const GameScreenSuspense: React.FC = () => (
+  <QueryErrorBoundary>
+    <Suspense fallback={<div></div>}>
+      <GameScreen />
+    </Suspense>
+  </QueryErrorBoundary>
+);
+
+export { GameScreenSuspense as GameScreen };

--- a/packages/web/src/screens/GameDetail/MapScreen.tsx
+++ b/packages/web/src/screens/GameDetail/MapScreen.tsx
@@ -6,42 +6,19 @@ import { Panel } from "@/components/Panel";
 import { PhaseSelect } from "@/components/PhaseSelect";
 import { PhaseGuidance } from "@/components/PhaseGuidance";
 import { GameMap } from "@/components/GameMap";
-import { GameDropdownMenu } from "@/components/GameDropdownMenu";
-import { useGameRetrieveSuspense } from "../../api/generated/endpoints";
-import { useRequiredParams } from "../../hooks";
 
 const MapScreen: React.FC = () => {
   const navigate = useNavigate();
-  const { gameId, phaseId } = useRequiredParams<{
-    gameId: string;
-    phaseId: string;
-  }>();
-  const { data: game } = useGameRetrieveSuspense(gameId);
-
-  const handleNavigateToGameInfo = () => {
-    navigate(`/game/${gameId}/phase/${phaseId}/game-info`);
-  };
-
-  const handleNavigateToPlayerInfo = () => {
-    navigate(`/game/${gameId}/phase/${phaseId}/player-info`);
-  };
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <GameDetailAppBar
         title={
-          <div className="flex items-center gap-2">
-            <div className="flex-1 flex flex-col items-center gap-0.5">
-              <PhaseSelect />
-              <Suspense fallback={null}>
-                <PhaseGuidance />
-              </Suspense>
-            </div>
-            <GameDropdownMenu
-              game={game}
-              onNavigateToGameInfo={handleNavigateToGameInfo}
-              onNavigateToPlayerInfo={handleNavigateToPlayerInfo}
-            />
+          <div className="flex flex-col items-center gap-0.5">
+            <PhaseSelect />
+            <Suspense fallback={null}>
+              <PhaseGuidance />
+            </Suspense>
           </div>
         }
         onNavigateBack={() => navigate("/")}

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -9,6 +9,7 @@ import {
   Inbox,
   SearchX,
   Star,
+  Vote,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -32,7 +33,6 @@ import {
 } from "@/components/ui/item";
 import { Notice } from "@/components/Notice";
 import { NationFlag } from "@/components/NationFlag";
-import { GameDropdownMenu } from "@/components/GameDropdownMenu";
 import { GameDetailAppBar } from "./AppBar";
 import { Panel } from "@/components/Panel";
 import { PhaseSelect } from "@/components/PhaseSelect";
@@ -190,14 +190,6 @@ const OrdersScreen: React.FC = () => {
     }
   };
 
-  const handleNavigateToGameInfo = () => {
-    navigate(`/game/${gameId}/phase/${phaseId}/game-info`);
-  };
-
-  const handleNavigateToPlayerInfo = () => {
-    navigate(`/game/${gameId}/phase/${phaseId}/player-info`);
-  };
-
   const nationGroups = buildNationGroups(
     isActivePhase,
     phaseStates,
@@ -223,18 +215,11 @@ const OrdersScreen: React.FC = () => {
     <div className="flex flex-col flex-1 min-h-0">
       <GameDetailAppBar
         title={
-          <div className="flex items-center gap-2">
-            <div className="flex-1 flex flex-col items-center gap-0.5">
-              <PhaseSelect />
-              <Suspense fallback={null}>
-                <PhaseGuidance />
-              </Suspense>
-            </div>
-            <GameDropdownMenu
-              game={game}
-              onNavigateToGameInfo={handleNavigateToGameInfo}
-              onNavigateToPlayerInfo={handleNavigateToPlayerInfo}
-            />
+          <div className="flex flex-col items-center gap-0.5">
+            <PhaseSelect />
+            <Suspense fallback={null}>
+              <PhaseGuidance />
+            </Suspense>
           </div>
         }
         onNavigateBack={() => navigate("/")}
@@ -334,39 +319,56 @@ const OrdersScreen: React.FC = () => {
             <>
               <Separator />
               <Panel.Footer>
-                <div className="flex gap-2 justify-end w-full">
-                  {game.sandbox ? (
-                    <Button
-                      disabled={resolvePhaseMutation.isPending}
-                      onClick={handleResolvePhase}
-                    >
-                      <Play className="size-4" />
-                      Resolve phase
-                    </Button>
-                  ) : (
-                    <>
-                      {hasContent ? (
-                        <Button
-                          disabled={confirmOrdersMutation.isPending}
-                          onClick={handleConfirmOrders}
-                        >
-                          {game.phaseConfirmed ? (
+                <div className="flex gap-2 justify-between w-full">
+                  <div>
+                    {!game.sandbox && game.status === "active" && (
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          navigate(
+                            `/game/${gameId}/phase/${phaseId}/draw-proposals`
+                          )
+                        }
+                      >
+                        <Vote className="size-4" />
+                        Draw proposals
+                      </Button>
+                    )}
+                  </div>
+                  <div>
+                    {game.sandbox ? (
+                      <Button
+                        disabled={resolvePhaseMutation.isPending}
+                        onClick={handleResolvePhase}
+                      >
+                        <Play className="size-4" />
+                        Resolve phase
+                      </Button>
+                    ) : (
+                      <>
+                        {hasContent ? (
+                          <Button
+                            disabled={confirmOrdersMutation.isPending}
+                            onClick={handleConfirmOrders}
+                          >
+                            {game.phaseConfirmed ? (
+                              <CheckSquare className="size-4" />
+                            ) : (
+                              <Square className="size-4" />
+                            )}
+                            {game.phaseConfirmed
+                              ? "Orders confirmed"
+                              : "Confirm orders"}
+                          </Button>
+                        ) : (
+                          <Button disabled>
                             <CheckSquare className="size-4" />
-                          ) : (
-                            <Square className="size-4" />
-                          )}
-                          {game.phaseConfirmed
-                            ? "Orders confirmed"
-                            : "Confirm orders"}
-                        </Button>
-                      ) : (
-                        <Button disabled>
-                          <CheckSquare className="size-4" />
-                          Orders confirmed
-                        </Button>
-                      )}
-                    </>
-                  )}
+                            Orders confirmed
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
                 </div>
               </Panel.Footer>
             </>

--- a/packages/web/src/screens/GameDetail/index.ts
+++ b/packages/web/src/screens/GameDetail/index.ts
@@ -34,4 +34,7 @@ export const GameDetail = {
       default: m.DrawProposalsScreen,
     }))
   ),
+  GameScreen: lazy(() =>
+    import("./GameScreen").then((m) => ({ default: m.GameScreen }))
+  ),
 };


### PR DESCRIPTION
95% of users do not see game options. 

- I moved it into a new 'game' screen/tab that sits at the same hierarchy as the map - inviting users to see it. 
- I moved the 'accept proposals' away from this game screen, and into the 'orders' screen. It now sits next to the 'confirm orders'. 
- I made the logic so the 'proposals' is it's own screen, with a deeper link to 'create proposal'. That ensures players will always see the proposals state before making them, knowing the order and hierarchy. 

- In a side note, I removed the (?) from any screen except our key home screens, so you don't invoke it from within a game at any weird time - it does not fit the context. 