### PR TITLE
Navigate to game when notification is tapped 

### DIFF
--- a/packages/web/public/firebase-messaging-sw.js
+++ b/packages/web/public/firebase-messaging-sw.js
@@ -17,3 +17,28 @@ firebase.initializeApp({
 });
 
 const messaging = firebase.messaging();
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const data =
+    event.notification.data?.FCM_MSG?.data || event.notification.data;
+  const gameId = data?.game_id;
+
+  const urlToOpen = gameId
+    ? `${self.location.origin}/game/${gameId}`
+    : self.location.origin;
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if ("focus" in client) {
+            return client.focus().then(() => client.navigate(urlToOpen));
+          }
+        }
+        return clients.openWindow(urlToOpen);
+      })
+  );
+});


### PR DESCRIPTION
This is more of an issue than a PR. It SHOULD work, but I can't test it from here (I have only one login on the development database, so can't "chat" with myself in incognito mode). 

Adds a notificationclick handler to the Firebase service worker so that tapping a push notification opens the relevant game page rather than just focusing the app.

@johnpooch this should also be included for the iOS app. Claude asked me to do it,but since I cna't even begin to test that, I just asked it to provide instructions for you:

  Background                                                                                                                                                                                
                                                                                                                                                                                            
  Push notifications are sent from the Django backend (service/notification/signals.py) via Firebase Cloud Messaging. Every notification includes a data payload with at least game_id — for
   example:                                                                                                                                                                               
                                                                                                                                                                                            
  send_notification_to_users(                                                                                                                                                             
      user_ids=user_ids,
      title="Phase Resolved",                                                                                                                                                               
      body=body,
      notification_type="phase_resolved",                                                                                                                                                   
      data={"game_id": str(instance.game.id)},                                                                                                                                              
  )
                                                                                                                                                                                            
  No backend changes are needed — the game_id is already there.                                                                                                                             
   
  What was done for Android Chrome (web)                                                                                                                                                    
                                                                                                                                                                                          
  On web, Firebase delivers background notifications via a service worker (packages/web/public/firebase-messaging-sw.js). The browser fires a notificationclick event in that service worker
   when the user taps a notification. The service worker was previously initialising Firebase but had no notificationclick handler, so tapping did nothing.
                                                                                                                                                                                            
  The fix adds a handler that reads game_id from the notification data and navigates to /game/${gameId}. The app's existing router handles the redirect from /game/:gameId to the current   
  phase. If the app is already open in a tab it focuses that tab; otherwise it opens a new window.
                                                                                                                                                                                            
  What needs to be done for iOS                                                                                                                                                           

  The iOS app uses @capacitor-firebase/messaging (a Capacitor plugin wrapping Firebase iOS SDK). This library fires two distinct events:                                                    
   
  - notificationReceived — fires when a notification arrives while the app is in the foreground. This is already handled in packages/web/src/messaging-ios.ts /                             
  packages/web/src/hooks/useMessaging.ts, but only calls queryClient.invalidateQueries() (data refresh, no navigation).                                                                   
  - notificationActionPerformed — fires when the user taps a notification (from background or killed state). This event is not yet handled anywhere.                                        
                                                                                                                                                                                            
  The fix is to add an addNotificationActionPerformedListener export to packages/web/src/messaging-ios.ts:                                                                                  
                                                                                                                                                                                            
  export const addNotificationActionPerformedListener = (                                                                                                                                   
    callback: (gameId: string) => void                                                                                                                                                    
  ) => {
    return FirebaseMessaging.addListener(
      "notificationActionPerformed",                                                                                                                                                        
      (event) => {
        const gameId = event.notification.data?.game_id;                                                                                                                                    
        if (gameId) callback(gameId);                                                                                                                                                     
      }                                                                                                                                                                                     
    );
  };                                                                                                                                                                                        
                                                                                                                                                                                          
  Then wire it up in packages/web/src/hooks/useMessaging.ts alongside the existing Effect 4, navigating to /game/${gameId}. The deep link infrastructure (deepLinkStorage) is already in    
  place — you can call deepLinkStorage.setPendingPath(/game/${gameId}) and the existing useDeepLink hook will pick it up and navigate. Or navigate directly if you have access to a navigate
   function in scope.                                                                                                                                                                       
                                                                                                                                                                                          
  One edge case: when the app is killed and the user taps the notification to launch it, notificationActionPerformed still fires but it may fire before the router is mounted. The          
  deepLinkStorage approach handles this correctly because it stores the path and the useDeepLink hook consumes it once the router is ready — the same pattern used for universal links in
  App.tsx.                                        