### PR TITLE
Fix share link using capacitor://localhost on iOS

### DIFF
--- a/packages/web/src/components/GameDropdownMenu.tsx
+++ b/packages/web/src/components/GameDropdownMenu.tsx
@@ -292,7 +292,7 @@ export function GameDropdownMenu({
         <DropdownMenuItem
           onClick={() => {
             navigator.clipboard.writeText(
-              `${window.location.origin}/game/${game.id}`
+              `https://diplicity.com/game/${game.id}`
             );
             toast.success("Link copied to clipboard");
           }}


### PR DESCRIPTION
window.location.origin returns "capacitor://localhost" inside the Capacitor iOS app, so shared links were unusable by recipients. Hardcode the production URL instead.

https://www.reddit.com/r/diplomacy/comments/1t94yj3/diplicity_game_links/
This user reported this issue. This is not an issue on web, but in the iOS app it will use localhost. Now hardcoded the URL, which should be savable and prevent this issue.