### PR TITLE
Fix province colour to reflect SC owner, not occupying unit

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -192,8 +192,7 @@ const InteractiveMap = (props: InteractiveMapProps) => {
 
     // For supply centers with nation colors
     if (supplyCenter) {
-      const unit = props.phase.units.find(u => u.province.id === provinceId);
-      const nationName = unit ? unit.nation.name : supplyCenter.nation.name;
+      const nationName = supplyCenter.nation.name;
       const color = props.variant.nations.find(
         n => n.name === nationName
       )?.color;


### PR DESCRIPTION
Closes #397.

Hotfix - I used the wrong way to look up owner, reverted to 'const nationName = supplyCenter.nation.name' instead of '      195 -      const unit = props.phase.units.find(u => u.province.id === provinceId);                                                                                                  
      196 -      const nationName = unit ? unit.nation.name : supplyCenter.nation.name;                                                                                                    ;                                                                                                                             

