### PR TITLE
Fix confirm orders button scrolling off screen

### DIFF
--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -262,7 +262,7 @@ const OrdersScreen: React.FC = () => {
         }
         onNavigateBack={() => navigate("/")}
       />
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 min-h-0">
         <Panel>
           <Panel.Content>
             {!hasContent ? (


### PR DESCRIPTION
Outer wrapper used overflow-y-auto, making the entire Panel (including footer) scroll as one block. Switching to min-h-0 lets Panel handle its own internal scroll via Panel.Content, keeping the footer pinned.

https://github.com/johnpooch/diplicity-react/issues/399