### PR TITLE
Add nation_id field to Nation model

### DIFF
--- a/service/nation/migrations/0009_add_nation_id.py
+++ b/service/nation/migrations/0009_add_nation_id.py
@@ -1,0 +1,39 @@
+from django.db import migrations, models
+from django.utils.text import slugify
+
+
+def backfill_nation_id(apps, schema_editor):
+    Nation = apps.get_model("nation", "Nation")
+    nations = list(Nation.objects.all())
+    for nation in nations:
+        nation.nation_id = slugify(nation.name)
+    Nation.objects.bulk_update(nations, ["nation_id"])
+
+
+def clear_nation_id(apps, schema_editor):
+    Nation = apps.get_model("nation", "Nation")
+    Nation.objects.update(nation_id="")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nation", "0008_update_canton_nation_colors"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nation",
+            name="nation_id",
+            field=models.CharField(default="", max_length=50),
+            preserve_default=False,
+        ),
+        migrations.RunPython(
+            backfill_nation_id,
+            clear_nation_id,
+        ),
+        migrations.AlterUniqueTogether(
+            name="nation",
+            unique_together={("name", "variant"), ("nation_id", "variant")},
+        ),
+    ]

--- a/service/nation/models.py
+++ b/service/nation/models.py
@@ -2,13 +2,14 @@ from django.db import models
 
 
 class Nation(models.Model):
+    nation_id = models.CharField(max_length=50)
     name = models.CharField(max_length=50)
     color = models.CharField(max_length=7)
     variant = models.ForeignKey("variant.Variant", on_delete=models.CASCADE, related_name="nations")
 
     class Meta:
         ordering = ["name"]
-        unique_together = ["name", "variant"]
+        unique_together = [["name", "variant"], ["nation_id", "variant"]]
 
     def __str__(self):
         return f"{self.name} ({self.variant.name})"


### PR DESCRIPTION
Adds a stable per-variant identifier to `Nation`, mirroring the `id` field each nation has in the canonical variant schema (`variant.schema.yaml`). Sub-issue 1 of PRD #247.

The schema calls the field `id`, but Django forbids a non-primary-key field named `id` (`models.E004`) and `Nation` already has an integer auto-PK. The codebase already solved this for provinces with `Province.province_id`, so the new field follows that convention and is named `nation_id`, with a `(nation_id, variant)` unique constraint mirroring the existing `(name, variant)` one.

Migration `0009_add_nation_id` adds the column, backfills existing rows by slugifying `name`, then applies the unique constraint. The change is additive — the integer PK and existing `.nation.name` join paths are untouched, and no consumers read `nation_id` yet (that's later PRD work at the schema/adjudicator boundary).

Verified: migration applies cleanly, `makemigrations --check` reports no changes, and all 34 nation rows backfilled to kebab-case ids (e.g. `North Vietnam` → `north-vietnam`).

Closes #406.