### PR TITLE
Align adjudicator with rendering-free variant schema

### DIFF
--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Dict, List, Optional, Tuple
+from typing import ClassVar, Dict, List, Optional, Tuple, Union
 
 
 class Pass:
@@ -83,15 +83,41 @@ class DominanceRule:
     dependencies: Tuple[DominanceDependency, ...]
 
 
+class VictoryConditionType:
+    SUPPLY_CENTER_MAJORITY: ClassVar[str] = "supply-center-majority"
+    TIMED_RESOLUTION: ClassVar[str] = "timed-resolution"
+    PROVINCE_CONTROL: ClassVar[str] = "province-control"
+
+
+@dataclass(frozen=True)
+class SupplyCenterMajorityVictory:
+    supply_centers: int
+
+
+@dataclass(frozen=True)
+class TimedResolutionVictory:
+    year: int
+    resolution: str
+
+
+@dataclass(frozen=True)
+class ProvinceControlVictory:
+    provinces: Tuple[str, ...]
+    year: Optional[int]
+
+
+VictoryCondition = Union[
+    SupplyCenterMajorityVictory, TimedResolutionVictory, ProvinceControlVictory
+]
+
+
 @dataclass(frozen=True)
 class Variant:
     id: str
     name: str
     description: str
     author: str
-    solo_victory_supply_centers: int
-    game_ends_year: Optional[int]
-    draw_after_year: Optional[int]
+    victory_conditions: Tuple[VictoryCondition, ...]
     rules: Optional[str]
     adjudication_modifiers: Tuple[str, ...]
     phase_progression: PhaseProgression

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -20,11 +20,16 @@ from .domain import (
     PhaseProgression,
     PhaseTransition,
     Province,
+    ProvinceControlVictory,
     Resolution,
     State,
     SupplyCenter,
+    SupplyCenterMajorityVictory,
+    TimedResolutionVictory,
     Unit,
     Variant,
+    VictoryCondition,
+    VictoryConditionType,
 )
 
 
@@ -104,6 +109,19 @@ def _validate_adjacency_symmetry(
                     f"Adjacency {named_coast.id} -> {adjacency.to} ({adjacency.pass_}) "
                     f"is not mirrored on the other side"
                 )
+
+
+def _deserialize_victory_condition(data: Dict[str, Any]) -> VictoryCondition:
+    type_ = data["type"]
+    if type_ == VictoryConditionType.SUPPLY_CENTER_MAJORITY:
+        return SupplyCenterMajorityVictory(supply_centers=data["supplyCenters"])
+    if type_ == VictoryConditionType.TIMED_RESOLUTION:
+        return TimedResolutionVictory(year=data["year"], resolution=data["resolution"])
+    if type_ == VictoryConditionType.PROVINCE_CONTROL:
+        return ProvinceControlVictory(
+            provinces=tuple(data["provinces"]), year=data.get("year")
+        )
+    raise VariantValidationError(f"Unknown victory condition type: {type_!r}")
 
 
 def deserialize_variant(data: Dict[str, Any]) -> Variant:
@@ -194,9 +212,9 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
         name=data["name"],
         description=data["description"],
         author=data["author"],
-        solo_victory_supply_centers=data["soloVictorySupplyCenters"],
-        game_ends_year=data.get("gameEndsYear"),
-        draw_after_year=data.get("drawAfterYear"),
+        victory_conditions=tuple(
+            _deserialize_victory_condition(vc) for vc in data["victoryConditions"]
+        ),
         rules=data.get("rules"),
         adjudication_modifiers=modifiers,
         phase_progression=phase_progression,

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -32,6 +32,7 @@ from .domain import (
     Resolution,
     State,
     SupplyCenter,
+    SupplyCenterMajorityVictory,
     Unit,
     Variant,
 )
@@ -112,15 +113,6 @@ def _datc_classical_phase_progression() -> Dict[str, Any]:
     }
 
 
-def _datc_stub_geometry() -> Dict[str, Any]:
-    return {
-        "path": "M 0 0 L 1 0 L 1 1 L 0 1 Z",
-        "labels": [],
-        "unitPosition": {"x": 0, "y": 0},
-        "dislodgedUnitPosition": {"x": 0, "y": 0},
-    }
-
-
 def _datc_province(
     province_id: str,
     name: str,
@@ -135,12 +127,9 @@ def _datc_province(
         "type": type_,
         "supplyCenter": supply_center,
         "adjacencies": adjacencies,
-        **_datc_stub_geometry(),
     }
     if home_nation is not None:
         p["homeNation"] = home_nation
-    if supply_center:
-        p["supplyCenterPosition"] = {"x": 0, "y": 0}
     return p
 
 
@@ -152,9 +141,6 @@ def _datc_named_coast(
         "name": name,
         "parentProvince": parent,
         "adjacencies": adjacencies,
-        "path": "M 0 0 L 1 0 L 1 1 Z",
-        "unitPosition": {"x": 0, "y": 0},
-        "dislodgedUnitPosition": {"x": 0, "y": 0},
     }
 
 
@@ -562,7 +548,9 @@ def _datc_classical_variant() -> Dict[str, Any]:
         "name": "Classical",
         "description": "The original game of Diplomacy.",
         "author": "Allan B. Calhamer",
-        "soloVictorySupplyCenters": 18,
+        "victoryConditions": [
+            {"type": "supply-center-majority", "supplyCenters": 18}
+        ],
         "phaseProgression": _datc_classical_phase_progression(),
         "nations": [
             {"id": "austria", "name": "Austria", "color": "#F44336"},
@@ -626,8 +614,6 @@ def _datc_classical_variant() -> Dict[str, Any]:
                 {"nation": "turkey", "province": "smy"},
             ],
         },
-        "dimensions": {"width": 1000, "height": 1000},
-        "decorativeElements": [],
     }
 
 
@@ -5040,9 +5026,7 @@ def make_variant(*, allow_non_home: bool = False) -> Variant:
         name="Test",
         description="",
         author="",
-        solo_victory_supply_centers=99,
-        game_ends_year=None,
-        draw_after_year=None,
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
         adjudication_modifiers=(
             ("allow-builds-in-non-home-centers",) if allow_non_home else ()
@@ -7112,9 +7096,7 @@ def _c2_make_chain_variant() -> Variant:
         name="Chain",
         description="",
         author="",
-        solo_victory_supply_centers=99,
-        game_ends_year=None,
-        draw_after_year=None,
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
         adjudication_modifiers=(),
         phase_progression=progression,
@@ -7479,9 +7461,7 @@ def _res_make_variant() -> Variant:
         name="Resolution Test",
         description="",
         author="",
-        solo_victory_supply_centers=99,
-        game_ends_year=None,
-        draw_after_year=None,
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
         adjudication_modifiers=(),
         phase_progression=progression,
@@ -7766,9 +7746,7 @@ def _res_make_convoy_variant() -> Variant:
         name="Convoy Test",
         description="",
         author="",
-        solo_victory_supply_centers=99,
-        game_ends_year=None,
-        draw_after_year=None,
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
         adjudication_modifiers=(),
         phase_progression=progression,
@@ -8668,9 +8646,7 @@ def _cv_path_variant(provinces) -> Variant:
         name="Path Test",
         description="",
         author="",
-        solo_victory_supply_centers=99,
-        game_ends_year=None,
-        draw_after_year=None,
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
         adjudication_modifiers=(),
         phase_progression=progression,


### PR DESCRIPTION
`main` is broken — `test-service` fails because 168 adjudicator tests hit a schema validation error on every variant deserialization.

PR #404 rewrote `variant.schema.yaml` to drop rendering fields and replace `soloVictorySupplyCenters`/`gameEndsYear`/`drawAfterYear` with a `victoryConditions` discriminated union. The schema's root has `additionalProperties: false`, but the adjudicator still produced variant dicts in the old shape — carrying `decorativeElements`, `dimensions`, `soloVictorySupplyCenters` — and read the removed keys in `deserialize_variant`. #404's own description names this as a required follow-up; it is sub-issue 3 of PRD #247.

This change:

- Replaces the three victory scalars on the `Variant` domain object with a `victory_conditions` tuple, and adds `SupplyCenterMajorityVictory`, `TimedResolutionVictory`, and `ProvinceControlVictory` domain types mirroring the schema's `VictoryCondition` union.
- Deserializes `victoryConditions` in `serializers.py`.
- Updates the DATC test fixtures to emit the new schema: rendering stubs (`dimensions`, `decorativeElements`, province/coast geometry) removed, `soloVictorySupplyCenters` replaced with a `victoryConditions` array.

`docker compose run --rm service python3 -m pytest -q` passes (1073 tests).