### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
Bumps the web app version from 1.1.0 to 1.2.0. Merging to main triggers the iOS release workflow, which builds and uploads a 1.2.0 build to TestFlight.

<sub>Generated with Claude Code</sub>