### PR TITLE
Replace solo_victory_sc_count with victoryConditions JSON on Variant

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -680,12 +680,20 @@ export interface UserProfile {
   readonly email: string;
 }
 
+export interface VictoryConditions {
+  soloVictorySupplyCenters: number;
+  /** @nullable */
+  gameEndsYear: number | null;
+  /** @nullable */
+  drawAfterYear: number | null;
+}
+
 export interface Variant {
   id: string;
   name: string;
   description: string;
   author?: string;
-  soloVictoryScCount: number;
+  victoryConditions: VictoryConditions;
   nations: Nation[];
   provinces: Province[];
   templatePhase: PhaseRetrieve;

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -98,7 +98,11 @@ const mockVariant = {
   id: "standard",
   name: "Standard",
   description: "",
-  soloVictoryScCount: 18,
+  victoryConditions: {
+    soloVictorySupplyCenters: 18,
+    gameEndsYear: null,
+    drawAfterYear: null,
+  },
   nations: [england],
   provinces: [lon, nth],
   templatePhase: {},

--- a/packages/web/src/mocks.ts
+++ b/packages/web/src/mocks.ts
@@ -547,7 +547,11 @@ export const mockVariants: Variant[] = [
     author: "Allan B. Calhamer",
     nations: mockNations,
     provinces: mockProvinces,
-    soloVictoryScCount: 18,
+    victoryConditions: {
+      soloVictorySupplyCenters: 18,
+      gameEndsYear: null,
+      drawAfterYear: null,
+    },
     templatePhase: {
       id: 1,
       ordinal: 1,
@@ -571,7 +575,11 @@ export const mockVariants: Variant[] = [
     author: "Unknown",
     nations: [mockNations[4], mockNations[3]],
     provinces: mockProvinces.slice(3, 5),
-    soloVictoryScCount: 4,
+    victoryConditions: {
+      soloVictorySupplyCenters: 4,
+      gameEndsYear: null,
+      drawAfterYear: null,
+    },
     templatePhase: {
       id: 2,
       ordinal: 1,

--- a/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
@@ -46,7 +46,8 @@ const ProposeDrawScreen: React.FC = () => {
   const createProposalMutation = useGamesDrawProposalsCreateCreate();
 
   const variant = variants.find(v => v.id === game.variantId);
-  const victoryThreshold = variant?.soloVictoryScCount ?? 18;
+  const victoryThreshold =
+    variant?.victoryConditions.soloVictorySupplyCenters ?? 18;
 
   const currentMember = game.members.find(m => m.isCurrentUser);
   const activeMembers = game.members.filter(m => !m.eliminated && !m.kicked);

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -81,7 +81,11 @@ const variantsFixture = [
     id: "classical",
     name: "Classical",
     description: "",
-    soloVictoryScCount: 18,
+    victoryConditions: {
+      soloVictorySupplyCenters: 18,
+      gameEndsYear: null,
+      drawAfterYear: null,
+    },
     nations: [
       { id: 1, name: "England" },
       { id: 2, name: "France" },

--- a/service/draw_proposal/conftest.py
+++ b/service/draw_proposal/conftest.py
@@ -58,7 +58,11 @@ def game_factory(db):
 
         variant_solo_victory_sc_count = kwargs.pop("variant__solo_victory_sc_count", None)
         if variant_solo_victory_sc_count is not None:
-            variant.solo_victory_sc_count = variant_solo_victory_sc_count
+            variant.victory_conditions = {
+                "soloVictorySupplyCenters": variant_solo_victory_sc_count,
+                "gameEndsYear": None,
+                "drawAfterYear": None,
+            }
             variant.save()
 
         return Game.objects.create(

--- a/service/draw_proposal/models.py
+++ b/service/draw_proposal/models.py
@@ -116,7 +116,7 @@ class DrawProposal(BaseModel):
 
     @property
     def victory_threshold(self):
-        return self.game.variant.solo_victory_sc_count
+        return self.game.variant.victory_conditions["soloVictorySupplyCenters"]
 
     def process_acceptance(self):
         if self.status != DrawProposalStatus.ACCEPTED:

--- a/service/draw_proposal/serializers.py
+++ b/service/draw_proposal/serializers.py
@@ -85,7 +85,7 @@ class DrawProposalSerializer(serializers.Serializer):
             nation__in=included_nations
         ).count()
 
-        victory_threshold = game.variant.solo_victory_sc_count
+        victory_threshold = game.variant.victory_conditions["soloVictorySupplyCenters"]
         if combined_sc_count < victory_threshold:
             raise serializers.ValidationError(
                 f"Combined SC count ({combined_sc_count}) must be at least "

--- a/service/game/management/commands/setup_draw_test_game.py
+++ b/service/game/management/commands/setup_draw_test_game.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
         italy_scs = phase.supply_centers.filter(nation=italy).count()
         germany_scs = phase.supply_centers.filter(nation=germany).count()
         total_scs = italy_scs + germany_scs
-        threshold = variant.solo_victory_sc_count
+        threshold = variant.victory_conditions["soloVictorySupplyCenters"]
 
         self.stdout.write(self.style.SUCCESS(f"\nGame updated: {game.name}"))
         self.stdout.write(f"URL: http://localhost:5173/game/{game.id}")

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2754,8 +2754,8 @@ components:
           type: string
         author:
           type: string
-        soloVictoryScCount:
-          type: integer
+        victoryConditions:
+          $ref: '#/components/schemas/VictoryConditions'
         nations:
           type: array
           items:
@@ -2772,8 +2772,8 @@ components:
       - name
       - nations
       - provinces
-      - soloVictoryScCount
       - templatePhase
+      - victoryConditions
     VerifyEmail:
       type: object
       properties:
@@ -2818,6 +2818,21 @@ components:
       - members
       - type
       - winningPhaseId
+    VictoryConditions:
+      type: object
+      properties:
+        soloVictorySupplyCenters:
+          type: integer
+        gameEndsYear:
+          type: integer
+          nullable: true
+        drawAfterYear:
+          type: integer
+          nullable: true
+      required:
+      - drawAfterYear
+      - gameEndsYear
+      - soloVictorySupplyCenters
   securitySchemes:
     jwtAuth:
       type: http

--- a/service/variant/migrations/0010_replace_solo_victory_sc_count_with_victory_conditions.py
+++ b/service/variant/migrations/0010_replace_solo_victory_sc_count_with_victory_conditions.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+import variant.models
+
+
+def backfill_victory_conditions(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    variants = list(Variant.objects.all())
+    for variant in variants:
+        variant.victory_conditions = {
+            "soloVictorySupplyCenters": variant.solo_victory_sc_count,
+            "gameEndsYear": None,
+            "drawAfterYear": None,
+        }
+    Variant.objects.bulk_update(variants, ["victory_conditions"])
+
+
+def reverse_victory_conditions(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    variants = list(Variant.objects.all())
+    for variant in variants:
+        variant.solo_victory_sc_count = variant.victory_conditions["soloVictorySupplyCenters"]
+    Variant.objects.bulk_update(variants, ["solo_victory_sc_count"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("variant", "0009_variant_adjudication_modifiers"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="variant",
+            name="victory_conditions",
+            field=models.JSONField(default=variant.models.default_victory_conditions),
+        ),
+        migrations.RunPython(backfill_victory_conditions, reverse_victory_conditions),
+        migrations.RemoveField(
+            model_name="variant",
+            name="solo_victory_sc_count",
+        ),
+    ]

--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -6,6 +6,10 @@ from common.constants import PhaseStatus
 from phase.models import Phase
 
 
+def default_victory_conditions():
+    return {"soloVictorySupplyCenters": 18, "gameEndsYear": None, "drawAfterYear": None}
+
+
 class VariantQuerySet(models.QuerySet):
 
     def with_related_data(self):
@@ -68,7 +72,7 @@ class Variant(BaseModel):
     name = models.CharField(max_length=100)
     description = models.TextField()
     author = models.CharField(max_length=200, blank=True)
-    solo_victory_sc_count = models.IntegerField(default=18)
+    victory_conditions = models.JSONField(default=default_victory_conditions)
     adjudication_modifiers = models.JSONField(default=list)
 
     @property

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -4,12 +4,18 @@ from nation.serializers import NationSerializer
 from phase.serializers import PhaseRetrieveSerializer
 
 
+class VictoryConditionsSerializer(serializers.Serializer):
+    solo_victory_supply_centers = serializers.IntegerField(source="soloVictorySupplyCenters")
+    game_ends_year = serializers.IntegerField(source="gameEndsYear", allow_null=True)
+    draw_after_year = serializers.IntegerField(source="drawAfterYear", allow_null=True)
+
+
 class VariantSerializer(serializers.Serializer):
     id = serializers.CharField()
     name = serializers.CharField()
     description = serializers.CharField()
     author = serializers.CharField(required=False)
-    solo_victory_sc_count = serializers.IntegerField()
+    victory_conditions = VictoryConditionsSerializer()
     nations = NationSerializer(many=True)
     provinces = ProvinceSerializer(many=True)
     template_phase = PhaseRetrieveSerializer()

--- a/service/victory/conftest.py
+++ b/service/victory/conftest.py
@@ -92,7 +92,11 @@ def game_factory(db):
 
         variant_solo_victory_sc_count = kwargs.pop('variant__solo_victory_sc_count', None)
         if variant_solo_victory_sc_count is not None:
-            variant.solo_victory_sc_count = variant_solo_victory_sc_count
+            variant.victory_conditions = {
+                "soloVictorySupplyCenters": variant_solo_victory_sc_count,
+                "gameEndsYear": None,
+                "drawAfterYear": None,
+            }
             variant.save()
 
         return Game.objects.create(

--- a/service/victory/utils.py
+++ b/service/victory/utils.py
@@ -1,5 +1,5 @@
 def check_for_solo_winner(game, phase):
-    required_sc_count = game.variant.solo_victory_sc_count
+    required_sc_count = game.variant.victory_conditions["soloVictorySupplyCenters"]
 
     sc_counts = {}
     for member in game.members.all():


### PR DESCRIPTION
Closes #408 (sub-issue of PRD #247).

Replaces the scalar `solo_victory_sc_count` `IntegerField` on `Variant` with a `victory_conditions` `JSONField` of shape `{ soloVictorySupplyCenters, gameEndsYear, drawAfterYear }`, so the schema can represent variants that end at a fixed year or force a draw. `gameEndsYear` and `drawAfterYear` are `null` for all six in-DB variants today — no behavior change.

Migration `0010` adds the field, backfills `soloVictorySupplyCenters` from the old value, and drops `solo_victory_sc_count` in a single migration. Backfilled values: classical/italy-vs-germany 18, hundred 9, youngstown-redux 28, vietnam-war 13, canton 19.

Consumers updated to read `victory_conditions["soloVictorySupplyCenters"]`: `draw_proposal/models.py`, `draw_proposal/serializers.py`, `victory/utils.py`, and the `setup_draw_test_game` management command.

The variant serializer exposes the new field via a nested `VictoryConditionsSerializer` so the generated TypeScript client gets a typed `VictoryConditions` interface rather than `unknown`. The frontend does consume this value — `ProposeDrawScreen.tsx` reads the solo threshold — so it and the related mocks/test fixtures were updated to the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)