### PR TITLE
Add phaseProgression JSON field on Variant

### DIFF
--- a/service/variant/migrations/0011_variant_phase_progression.py
+++ b/service/variant/migrations/0011_variant_phase_progression.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+import variant.models
+
+
+HUNDRED_PHASE_PROGRESSION = {
+    "seasons": ["Year"],
+    "transitions": [
+        {"from": {"season": "Year", "type": "Movement"},
+         "to": {"season": "Year", "type": "Retreat", "yearDelta": 0}},
+        {"from": {"season": "Year", "type": "Retreat"},
+         "to": {"season": "Year", "type": "Adjustment", "yearDelta": 0}},
+        {"from": {"season": "Year", "type": "Adjustment"},
+         "to": {"season": "Year", "type": "Movement", "yearDelta": 5}},
+    ],
+}
+
+
+def backfill_hundred_phase_progression(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    Variant.objects.filter(id="hundred").update(phase_progression=HUNDRED_PHASE_PROGRESSION)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("variant", "0010_replace_solo_victory_sc_count_with_victory_conditions"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="variant",
+            name="phase_progression",
+            field=models.JSONField(default=variant.models.default_phase_progression),
+        ),
+        migrations.RunPython(backfill_hundred_phase_progression, migrations.RunPython.noop),
+    ]

--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -10,6 +10,24 @@ def default_victory_conditions():
     return {"soloVictorySupplyCenters": 18, "gameEndsYear": None, "drawAfterYear": None}
 
 
+def default_phase_progression():
+    return {
+        "seasons": ["Spring", "Fall"],
+        "transitions": [
+            {"from": {"season": "Spring", "type": "Movement"},
+             "to": {"season": "Spring", "type": "Retreat", "yearDelta": 0}},
+            {"from": {"season": "Spring", "type": "Retreat"},
+             "to": {"season": "Fall", "type": "Movement", "yearDelta": 0}},
+            {"from": {"season": "Fall", "type": "Movement"},
+             "to": {"season": "Fall", "type": "Retreat", "yearDelta": 0}},
+            {"from": {"season": "Fall", "type": "Retreat"},
+             "to": {"season": "Fall", "type": "Adjustment", "yearDelta": 0}},
+            {"from": {"season": "Fall", "type": "Adjustment"},
+             "to": {"season": "Spring", "type": "Movement", "yearDelta": 1}},
+        ],
+    }
+
+
 class VariantQuerySet(models.QuerySet):
 
     def with_related_data(self):
@@ -74,6 +92,7 @@ class Variant(BaseModel):
     author = models.CharField(max_length=200, blank=True)
     victory_conditions = models.JSONField(default=default_victory_conditions)
     adjudication_modifiers = models.JSONField(default=list)
+    phase_progression = models.JSONField(default=default_phase_progression)
 
     @property
     def template_phase(self):

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.db import connection
 from rest_framework import status
 
-from variant.models import Variant
+from variant.models import Variant, default_phase_progression
 
 viewname = "variant-list"
 
@@ -101,3 +101,29 @@ class TestVariantListViewQueryPerformance:
         # due to prefetch_related optimization
         query_count = len(connection.queries)
         assert query_count == 16
+
+
+class TestPhaseProgressionBackfill:
+
+    @pytest.mark.django_db
+    def test_classical_phase_progression(self, classical_variant):
+        assert classical_variant.phase_progression == default_phase_progression()
+
+    @pytest.mark.django_db
+    def test_hundred_phase_progression(self, hundred_variant):
+        progression = hundred_variant.phase_progression
+        assert progression["seasons"] == ["Year"]
+
+        adjustment_to_movement = next(
+            t for t in progression["transitions"]
+            if t["from"]["type"] == "Adjustment"
+        )
+        assert adjustment_to_movement["to"]["type"] == "Movement"
+        assert adjustment_to_movement["to"]["yearDelta"] == 5
+
+    @pytest.mark.django_db
+    def test_every_variant_has_phase_progression(self, classical_variant):
+        assert not Variant.objects.filter(phase_progression={}).exists()
+        for variant in Variant.objects.all():
+            assert variant.phase_progression["seasons"]
+            assert variant.phase_progression["transitions"]


### PR DESCRIPTION
Adds a `phase_progression` JSONField on `Variant` holding the phase state machine (`seasons` list and `transitions` list) from the canonical variant schema. Sub-issue 5 of #247.

Migration 0011 backfills the classical Spring/Fall shape (yearDelta 1 on Fall Adjustment → Spring Movement) on all variants, then overwrites `hundred` with its single `"Year"` season and a 5-year yearDelta on the Adjustment → Movement transition. The hundred season name matches its existing template phase (`season="Year"`).

The field is backend-only, intended for the in-progress Python adjudicator (which already deserializes this shape). It is not exposed through `VariantSerializer` or the OpenAPI schema, matching the `adjudication_modifiers` precedent.

Stacked on #432 — migration 0011 depends on that PR's migration 0010. Base should be retargeted to `main` once #432 merges.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)