### PR TITLE
Add rules TextField on Variant

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -693,6 +693,7 @@ export interface Variant {
   name: string;
   description: string;
   author?: string;
+  rules: string;
   victoryConditions: VictoryConditions;
   nations: Nation[];
   provinces: Province[];

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -98,6 +98,7 @@ const mockVariant = {
   id: "standard",
   name: "Standard",
   description: "",
+  rules: "",
   victoryConditions: {
     soloVictorySupplyCenters: 18,
     gameEndsYear: null,

--- a/packages/web/src/mocks.ts
+++ b/packages/web/src/mocks.ts
@@ -545,6 +545,7 @@ export const mockVariants: Variant[] = [
     name: "Classical Diplomacy",
     description: "The original Diplomacy game",
     author: "Allan B. Calhamer",
+    rules: "The first to 18 Supply Centers (SC) is the winner.",
     nations: mockNations,
     provinces: mockProvinces,
     victoryConditions: {
@@ -573,6 +574,7 @@ export const mockVariants: Variant[] = [
     name: "Italy vs Germany",
     description: "A 2-player variant",
     author: "Unknown",
+    rules: "The first to 18 supply centers is the winner.",
     nations: [mockNations[4], mockNations[3]],
     provinces: mockProvinces.slice(3, 5),
     victoryConditions: {

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -81,6 +81,7 @@ const variantsFixture = [
     id: "classical",
     name: "Classical",
     description: "",
+    rules: "",
     victoryConditions: {
       soloVictorySupplyCenters: 18,
       gameEndsYear: null,

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2754,6 +2754,8 @@ components:
           type: string
         author:
           type: string
+        rules:
+          type: string
         victoryConditions:
           $ref: '#/components/schemas/VictoryConditions'
         nations:
@@ -2772,6 +2774,7 @@ components:
       - name
       - nations
       - provinces
+      - rules
       - templatePhase
       - victoryConditions
     VerifyEmail:

--- a/service/variant/migrations/0012_variant_rules.py
+++ b/service/variant/migrations/0012_variant_rules.py
@@ -1,0 +1,68 @@
+from django.db import migrations, models
+
+
+RULES = {
+    "classical": (
+        "The first to 18 Supply Centers (SC) is the winner.\n"
+        "Kiel and Constantinople have a canal, so fleets can exit on either side.\n"
+        "Armies can move from Denmark to Kiel."
+    ),
+    "italy-vs-germany": (
+        "The first to 18 supply centers is the winner.\n"
+        "The game only has two nations: Italy and Germany."
+    ),
+    "hundred": (
+        "First to 9 Supply Centers (SC) is the winner.\n"
+        "Units may be built on any owned SC.\n"
+        "France starts with 5 units and 4 SCs, so needs to disband unless they "
+        "gain a center before 1430.\n"
+        "Yearly cycles of Spring & Fall are renamed to decade cycles with years "
+        "ending with 5 and 0 respectively.\n"
+        "Armies & fleets can move between London & Calais.\n"
+        "Two provinces have dual coasts: Northumbria and Aragon."
+    ),
+    "youngstown-redux": (
+        "First to 28 Supply Centers (SC) wins. If two nations have 28 SCs, the "
+        "one with most wins. If drawn, the game continues an extra year.\n"
+        "Fleets can move around the world via box sea regions, which are "
+        "connected to the other ones in the same row and column.\n"
+        "Six provinces have dual coasts: Spain, St. Petersburg, Levant, Arabia, "
+        "Hebei, and Thailand.\n"
+        "The Arctic region is impassable (Omsk & Siberia are land regions).\n"
+        "This variant is based on the Youngstown variant by Rod Walker, "
+        "A. Phillips, Ken Lowe and Jon Monsarret."
+    ),
+    "vietnam-war": (
+        "First to 15 Supply Centers (SC) wins.\n"
+        "All provinces connected to the Mekong river are coastal: Xuyen, Mekong, "
+        "Pakxe and Ubon (e.g. Laos can build fleets in Pakxe).\n"
+        "Two provinces have dual coasts: Xuyen and Mekong (South coast and River)."
+    ),
+    "canton": (
+        "First to 19 Supply Centers (SC) is the winner.\n"
+        "Constantinople and Egypt have a canal (similar to Kiel in Classic).\n"
+        "Four provinces have dual coasts: Damascus, Bulgaria, Siam and Canton."
+    ),
+}
+
+
+def backfill_rules(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    for variant_id, rules in RULES.items():
+        Variant.objects.filter(id=variant_id).update(rules=rules)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("variant", "0011_variant_phase_progression"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="variant",
+            name="rules",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.RunPython(backfill_rules, migrations.RunPython.noop),
+    ]

--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -93,6 +93,7 @@ class Variant(BaseModel):
     victory_conditions = models.JSONField(default=default_victory_conditions)
     adjudication_modifiers = models.JSONField(default=list)
     phase_progression = models.JSONField(default=default_phase_progression)
+    rules = models.TextField(blank=True, default="")
 
     @property
     def template_phase(self):

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -15,6 +15,7 @@ class VariantSerializer(serializers.Serializer):
     name = serializers.CharField()
     description = serializers.CharField()
     author = serializers.CharField(required=False)
+    rules = serializers.CharField(allow_blank=True)
     victory_conditions = VictoryConditionsSerializer()
     nations = NationSerializer(many=True)
     provinces = ProvinceSerializer(many=True)

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -17,13 +17,15 @@ def test_list_variants_success(authenticated_client, classical_variant):
     response = authenticated_client.get(url)
     assert response.status_code == status.HTTP_200_OK
     assert len(response.data) == 6
-    assert response.data[0]["id"] == classical_variant.id
-    assert response.data[0]["name"] == classical_variant.name
-    assert response.data[1]["id"] == "italy-vs-germany"
-    assert response.data[1]["name"] == "Italy vs Germany"
 
-    classical_variant_data = next((v for v in response.data if v["id"] == classical_variant.id), None)
-    assert classical_variant_data is not None
+    variants_by_id = {v["id"]: v for v in response.data}
+    assert variants_by_id[classical_variant.id]["name"] == classical_variant.name
+    assert variants_by_id["italy-vs-germany"]["name"] == "Italy vs Germany"
+
+    classical_variant_data = variants_by_id[classical_variant.id]
+
+    assert "rules" in classical_variant_data
+    assert classical_variant_data["rules"].startswith("The first to 18 Supply Centers")
 
     assert "template_phase" in classical_variant_data
     template_phase = classical_variant_data["template_phase"]
@@ -127,3 +129,29 @@ class TestPhaseProgressionBackfill:
         for variant in Variant.objects.all():
             assert variant.phase_progression["seasons"]
             assert variant.phase_progression["transitions"]
+
+
+class TestRulesBackfill:
+
+    @pytest.mark.django_db
+    def test_classical_rules(self, classical_variant):
+        assert classical_variant.rules == (
+            "The first to 18 Supply Centers (SC) is the winner.\n"
+            "Kiel and Constantinople have a canal, so fleets can exit on either side.\n"
+            "Armies can move from Denmark to Kiel."
+        )
+
+    @pytest.mark.django_db
+    def test_hundred_rules(self, hundred_variant):
+        assert hundred_variant.rules.startswith(
+            "First to 9 Supply Centers (SC) is the winner."
+        )
+
+    @pytest.mark.django_db
+    def test_every_in_db_variant_has_rules(self, classical_variant):
+        in_db_ids = {
+            "classical", "italy-vs-germany", "hundred",
+            "youngstown-redux", "vietnam-war", "canton",
+        }
+        for variant in Variant.objects.filter(id__in=in_db_ids):
+            assert variant.rules


### PR DESCRIPTION
Adds a `rules` TextField on `Variant` holding plain-text variant rules. Sub-issue 6 of #247.

Migration 0012 backfills each of the six in-DB variants with rules text copied verbatim from the corresponding godip variant (win condition plus variant-specific notes). The field is exposed through `VariantSerializer` and the regenerated OpenAPI schema, ready for the variant detail page.

`test_list_variants_success` previously asserted variant order by list index; it relied on implicit DB row order, which the backfill's row updates disturb. Reworked those assertions to look variants up by id — the list endpoint has no ordering guarantee.

Stacked on #433 — migration 0012 depends on that PR's migration 0011. Base should be retargeted to `main` once #433 merges.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)