### PR TITLE
Add dSVG normalization and validation tooling

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -26,3 +26,4 @@ opentelemetry-instrumentation-requests>=0.41b0,<1.0
 resend>=2.0.0,<3.0
 jsonschema>=4.0.0,<5.0
 PyYAML>=6.0,<7.0
+lxml>=5.0,<6.0

--- a/service/variant/conftest.py
+++ b/service/variant/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+
+from common.constants import ProvinceType
+from province.models import Province
+from variant.models import Variant
+from variant.utils import DSVG_HIDDEN_LAYERS, DSVG_LAYER_ORDER
+
+
+@pytest.fixture
+def make_dsvg():
+    def _make(layer_ids=None, hidden_layers=DSVG_HIDDEN_LAYERS, province_ids=None, named_coast_ids=None):
+        if layer_ids is None:
+            layer_ids = DSVG_LAYER_ORDER
+
+        def _paths(path_ids):
+            if path_ids is None:
+                return ""
+            return "".join(
+                f'<path id="{path_id}"/>' if path_id is not None else "<path/>"
+                for path_id in path_ids
+            )
+
+        def _layer(layer_id):
+            style = ' style="display:none"' if layer_id in hidden_layers else ""
+            content = ""
+            if layer_id == "provinces":
+                content = _paths(province_ids)
+            elif layer_id == "named-coasts":
+                content = _paths(named_coast_ids)
+            return f'  <g id="{layer_id}"{style}>{content}</g>'
+
+        layers = "\n".join(_layer(layer_id) for layer_id in layer_ids)
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">\n'
+            f"{layers}\n"
+            "</svg>"
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_editor_dsvg():
+    def _make(layer_ids=None):
+        if layer_ids is None:
+            layer_ids = DSVG_LAYER_ORDER
+
+        def _layer(layer_id):
+            style = ' style="display:none"' if layer_id in DSVG_HIDDEN_LAYERS else ""
+            return (
+                f'  <g id="{layer_id}" inkscape:groupmode="layer" '
+                f'inkscape:label="{layer_id}" sodipodi:insensitive="true" '
+                f'i:knockout="Off" data-name="{layer_id}"{style}></g>'
+            )
+
+        layers = "\n".join(_layer(layer_id) for layer_id in layer_ids)
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" '
+            'xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.0.dtd" '
+            'xmlns:i="http://ns.adobe.com/AdobeIllustrator/10.0/" '
+            'viewBox="0 0 100 100">\n'
+            "  <!-- Generator: Adobe Illustrator -->\n"
+            '  <metadata id="metadata1">editor metadata</metadata>\n'
+            '  <sodipodi:namedview id="namedview1"/>\n'
+            f"{layers}\n"
+            "</svg>"
+        )
+
+    return _make
+
+
+@pytest.fixture
+def dsvg_variant(db):
+    variant = Variant.objects.create(
+        id="dsvg-test-variant",
+        name="dSVG Test Variant",
+        description="",
+        author="Test",
+    )
+    france = Province.objects.create(
+        province_id="fra", name="France", type=ProvinceType.COASTAL, variant=variant
+    )
+    Province.objects.create(province_id="ger", name="Germany", type=ProvinceType.LAND, variant=variant)
+    Province.objects.create(
+        province_id="fra/nc",
+        name="France (north coast)",
+        type=ProvinceType.NAMED_COAST,
+        variant=variant,
+        parent=france,
+    )
+    return variant

--- a/service/variant/tests/test_dsvg_normalization.py
+++ b/service/variant/tests/test_dsvg_normalization.py
@@ -1,0 +1,30 @@
+from variant.utils import normalize_dsvg, validate_dsvg
+
+
+def test_normalize_strips_all_foreign_namespaces(make_editor_dsvg):
+    result = normalize_dsvg(make_editor_dsvg())
+
+    for token in ("inkscape", "sodipodi", "AdobeIllustrator", "namedview"):
+        assert token not in result
+
+
+def test_normalize_strips_no_namespace_noise(make_editor_dsvg):
+    result = normalize_dsvg(make_editor_dsvg())
+
+    assert "data-name" not in result
+    assert "<!--" not in result
+    assert "metadata" not in result
+
+
+def test_normalize_is_idempotent(make_editor_dsvg):
+    once = normalize_dsvg(make_editor_dsvg())
+    twice = normalize_dsvg(once)
+
+    assert twice == once
+
+
+def test_normalize_preserves_svg_content(make_editor_dsvg):
+    result = normalize_dsvg(make_editor_dsvg())
+
+    assert "viewBox" in result
+    assert validate_dsvg(result) == []

--- a/service/variant/tests/test_dsvg_validation.py
+++ b/service/variant/tests/test_dsvg_validation.py
@@ -1,0 +1,114 @@
+import pytest
+
+from variant.utils import DSVG_LAYER_ORDER, validate_dsvg
+
+
+def test_valid_dsvg_has_no_errors(make_dsvg):
+    assert validate_dsvg(make_dsvg()) == []
+
+
+def test_missing_layer_is_reported(make_dsvg):
+    layer_ids = [layer for layer in DSVG_LAYER_ORDER if layer != "foreground"]
+
+    errors = validate_dsvg(make_dsvg(layer_ids=layer_ids))
+
+    assert [error.code for error in errors] == ["MISSING_LAYER"]
+
+
+def test_layers_out_of_order_is_reported(make_dsvg):
+    layer_ids = ["provinces", "background", "named-coasts", "province-names", "borders", "foreground"]
+
+    errors = validate_dsvg(make_dsvg(layer_ids=layer_ids))
+
+    assert any(error.code == "LAYER_OUT_OF_ORDER" for error in errors)
+
+
+def test_unexpected_layer_is_reported(make_dsvg):
+    layer_ids = DSVG_LAYER_ORDER + ["decoration"]
+
+    errors = validate_dsvg(make_dsvg(layer_ids=layer_ids))
+
+    assert [error.code for error in errors] == ["UNEXPECTED_LAYER"]
+
+
+def test_unhidden_provinces_layer_is_reported(make_dsvg):
+    errors = validate_dsvg(make_dsvg(hidden_layers=("named-coasts",)))
+
+    assert [error.code for error in errors] == ["LAYER_NOT_HIDDEN"]
+
+
+def test_unhidden_named_coasts_layer_is_reported(make_dsvg):
+    errors = validate_dsvg(make_dsvg(hidden_layers=("provinces",)))
+
+    assert [error.code for error in errors] == ["LAYER_NOT_HIDDEN"]
+
+
+def test_province_path_without_id_is_reported(make_dsvg):
+    errors = validate_dsvg(make_dsvg(province_ids=["fra", None, "ger"]))
+
+    assert [error.code for error in errors] == ["PROVINCE_MISSING_ID"]
+
+
+def test_named_coast_path_with_invalid_id_is_reported(make_dsvg):
+    errors = validate_dsvg(make_dsvg(named_coast_ids=["stp/nc", "spa"]))
+
+    assert [error.code for error in errors] == ["NAMED_COAST_INVALID_ID"]
+
+
+def test_valid_province_and_named_coast_paths_pass(make_dsvg):
+    errors = validate_dsvg(make_dsvg(province_ids=["fra", "ger"], named_coast_ids=["stp/nc"]))
+
+    assert errors == []
+
+
+@pytest.mark.django_db
+def test_unknown_province_is_reported(make_dsvg, dsvg_variant):
+    errors = validate_dsvg(
+        make_dsvg(province_ids=["fra", "ger", "xyz"], named_coast_ids=["fra/nc"]),
+        variant=dsvg_variant,
+    )
+
+    assert [error.code for error in errors] == ["UNKNOWN_PROVINCE"]
+
+
+@pytest.mark.django_db
+def test_missing_province_is_reported(make_dsvg, dsvg_variant):
+    errors = validate_dsvg(
+        make_dsvg(province_ids=["fra"], named_coast_ids=["fra/nc"]), variant=dsvg_variant
+    )
+
+    assert [error.code for error in errors] == ["MISSING_PROVINCE"]
+
+
+@pytest.mark.django_db
+def test_dsvg_matching_variant_passes(make_dsvg, dsvg_variant):
+    errors = validate_dsvg(
+        make_dsvg(province_ids=["fra", "ger"], named_coast_ids=["fra/nc"]), variant=dsvg_variant
+    )
+
+    assert errors == []
+
+
+@pytest.mark.django_db
+def test_unknown_named_coast_is_reported(make_dsvg, dsvg_variant):
+    errors = validate_dsvg(
+        make_dsvg(province_ids=["fra", "ger"], named_coast_ids=["fra/nc", "xyz/nc"]),
+        variant=dsvg_variant,
+    )
+
+    assert [error.code for error in errors] == ["UNKNOWN_NAMED_COAST"]
+
+
+@pytest.mark.django_db
+def test_missing_named_coast_is_reported(make_dsvg, dsvg_variant):
+    errors = validate_dsvg(
+        make_dsvg(province_ids=["fra", "ger"], named_coast_ids=[]), variant=dsvg_variant
+    )
+
+    assert [error.code for error in errors] == ["MISSING_NAMED_COAST"]
+
+
+def test_malformed_xml_is_reported():
+    errors = validate_dsvg("<svg><g></svg>")
+
+    assert [error.code for error in errors] == ["MALFORMED_XML"]

--- a/service/variant/utils.py
+++ b/service/variant/utils.py
@@ -1,0 +1,187 @@
+import xml.etree.ElementTree as ElementTree
+from dataclasses import dataclass
+
+from lxml import etree
+
+
+DSVG_LAYER_ORDER = [
+    "background",
+    "provinces",
+    "named-coasts",
+    "province-names",
+    "borders",
+    "foreground",
+]
+
+DSVG_HIDDEN_LAYERS = ("provinces", "named-coasts")
+
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+_ALLOWED_ATTRIBUTE_NAMESPACES = (SVG_NAMESPACE, XLINK_NAMESPACE)
+
+
+def _namespace(tag):
+    if isinstance(tag, str) and tag.startswith("{"):
+        return tag[1:].split("}", 1)[0]
+    return None
+
+
+def normalize_dsvg(svg):
+    root = etree.fromstring(svg.encode())
+
+    foreign_elements = [
+        element for element in root.iter() if _namespace(element.tag) not in (None, SVG_NAMESPACE)
+    ]
+    for element in foreign_elements:
+        parent = element.getparent()
+        if parent is not None:
+            parent.remove(element)
+
+    etree.strip_elements(root, etree.Comment, with_tail=False)
+    etree.strip_elements(root, f"{{{SVG_NAMESPACE}}}metadata", with_tail=False)
+
+    for element in root.iter():
+        for name in list(element.attrib):
+            attribute_namespace = _namespace(name)
+            if attribute_namespace is not None and attribute_namespace not in _ALLOWED_ATTRIBUTE_NAMESPACES:
+                del element.attrib[name]
+            elif attribute_namespace is None and name.startswith("data-"):
+                del element.attrib[name]
+
+    etree.cleanup_namespaces(root)
+    return etree.tostring(root).decode()
+
+
+@dataclass(frozen=True)
+class DsvgValidationError:
+    code: str
+    message: str
+
+
+def _local_name(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def _is_hidden(element):
+    if element.get("display") == "none":
+        return True
+    for declaration in element.get("style", "").split(";"):
+        prop, _, value = declaration.partition(":")
+        if prop.strip().lower() == "display" and value.strip().lower() == "none":
+            return True
+    return False
+
+
+def validate_dsvg(svg, variant=None):
+    try:
+        root = ElementTree.fromstring(svg)
+    except ElementTree.ParseError as exc:
+        return [DsvgValidationError("MALFORMED_XML", f"SVG is not well-formed XML: {exc}.")]
+
+    errors = []
+    layer_elements = [child for child in root if _local_name(child.tag) == "g"]
+    layer_ids = [element.get("id") for element in layer_elements]
+
+    for layer in DSVG_LAYER_ORDER:
+        if layer not in layer_ids:
+            errors.append(DsvgValidationError("MISSING_LAYER", f"Required layer '{layer}' is missing."))
+
+    for layer_id in layer_ids:
+        if layer_id not in DSVG_LAYER_ORDER:
+            errors.append(
+                DsvgValidationError("UNEXPECTED_LAYER", f"Unexpected top-level layer '{layer_id}'.")
+            )
+
+    present = [layer_id for layer_id in layer_ids if layer_id in DSVG_LAYER_ORDER]
+    expected = [layer for layer in DSVG_LAYER_ORDER if layer in present]
+    if present != expected:
+        errors.append(
+            DsvgValidationError(
+                "LAYER_OUT_OF_ORDER",
+                "Layers must appear in this order: " + ", ".join(DSVG_LAYER_ORDER) + ".",
+            )
+        )
+
+    layers_by_id = {element.get("id"): element for element in layer_elements}
+    for layer_id in DSVG_HIDDEN_LAYERS:
+        element = layers_by_id.get(layer_id)
+        if element is not None and not _is_hidden(element):
+            errors.append(
+                DsvgValidationError(
+                    "LAYER_NOT_HIDDEN", f"Layer '{layer_id}' must be hidden with display:none."
+                )
+            )
+
+    provinces_layer = layers_by_id.get("provinces")
+    if provinces_layer is not None:
+        for element in provinces_layer.iter():
+            if _local_name(element.tag) == "path" and not element.get("id"):
+                errors.append(
+                    DsvgValidationError(
+                        "PROVINCE_MISSING_ID", "A path in the 'provinces' layer is missing an id."
+                    )
+                )
+
+    named_coasts_layer = layers_by_id.get("named-coasts")
+    if named_coasts_layer is not None:
+        for element in named_coasts_layer.iter():
+            if _local_name(element.tag) != "path":
+                continue
+            parent, separator, coast = (element.get("id") or "").partition("/")
+            if not (separator and parent and coast):
+                errors.append(
+                    DsvgValidationError(
+                        "NAMED_COAST_INVALID_ID",
+                        f"Named-coast path id '{element.get('id') or ''}' must use the form 'parent/coast'.",
+                    )
+                )
+
+    if variant is not None and provinces_layer is not None:
+        svg_province_ids = {
+            element.get("id")
+            for element in provinces_layer.iter()
+            if _local_name(element.tag) == "path" and element.get("id")
+        }
+        variant_province_ids = set(
+            variant.provinces.filter(parent__isnull=True).values_list("province_id", flat=True)
+        )
+        for province_id in sorted(svg_province_ids - variant_province_ids):
+            errors.append(
+                DsvgValidationError(
+                    "UNKNOWN_PROVINCE",
+                    f"Province '{province_id}' is not a province of variant '{variant.id}'.",
+                )
+            )
+        for province_id in sorted(variant_province_ids - svg_province_ids):
+            errors.append(
+                DsvgValidationError(
+                    "MISSING_PROVINCE",
+                    f"Variant province '{province_id}' has no path in the 'provinces' layer.",
+                )
+            )
+
+    if variant is not None and named_coasts_layer is not None:
+        svg_named_coast_ids = {
+            element.get("id")
+            for element in named_coasts_layer.iter()
+            if _local_name(element.tag) == "path" and element.get("id")
+        }
+        variant_named_coast_ids = set(
+            variant.provinces.filter(parent__isnull=False).values_list("province_id", flat=True)
+        )
+        for named_coast_id in sorted(svg_named_coast_ids - variant_named_coast_ids):
+            errors.append(
+                DsvgValidationError(
+                    "UNKNOWN_NAMED_COAST",
+                    f"Named coast '{named_coast_id}' is not a named coast of variant '{variant.id}'.",
+                )
+            )
+        for named_coast_id in sorted(variant_named_coast_ids - svg_named_coast_ids):
+            errors.append(
+                DsvgValidationError(
+                    "MISSING_NAMED_COAST",
+                    f"Variant named coast '{named_coast_id}' has no path in the 'named-coasts' layer.",
+                )
+            )
+
+    return errors


### PR DESCRIPTION
Adds the first piece of dSVG (Diplicity SVG) tooling for variant maps: `normalize_dsvg` and `validate_dsvg` in `service/variant/utils.py`. Part of #405.

`normalize_dsvg` reduces an editor-exported SVG to canonical standard SVG. It whitelists by namespace — keeping only SVG-namespace elements and unprefixed/`xlink` attributes — and strips XML comments, `<metadata>`, and `data-*` attributes. This drops Inkscape, Illustrator, and Figma metadata without per-editor logic, and is idempotent.

`validate_dsvg` checks an SVG conforms to the dSVG schema, collecting all problems as coded `DsvgValidationError`s rather than failing on the first. Structural checks always run; referential checks run when a `Variant` is passed:

- the six layers (`background`, `provinces`, `named-coasts`, `province-names`, `borders`, `foreground`) are present, in order, with no extras
- `provinces` and `named-coasts` are hidden with `display:none`
- province paths carry ids, and named-coast ids use `parent/coast` form
- province and named-coast ids match the variant's province sets, both directions

Adds `lxml` for namespace-aware normalization. The godip-map converter in #442 builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)