### PR TITLE
Backfill VariantSvg rows for the six in-DB variants

### DIFF
--- a/service/variant/migrations/0014_backfill_variant_svgs.py
+++ b/service/variant/migrations/0014_backfill_variant_svgs.py
@@ -1,0 +1,43 @@
+import hashlib
+from pathlib import Path
+
+from django.db import migrations
+
+SVG_DIR = Path(__file__).resolve().parent.parent / "data" / "svg"
+
+VARIANT_SVG_FILES = {
+    "classical": "classical.d.svg",
+    "italy-vs-germany": "classical.d.svg",
+    "hundred": "hundred.d.svg",
+    "vietnam-war": "vietnam-war.d.svg",
+    "canton": "canton.d.svg",
+    "youngstown-redux": "youngstown-redux.d.svg",
+}
+
+
+def create_variant_svgs(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    VariantSvg = apps.get_model("variant", "VariantSvg")
+    for variant_id, filename in VARIANT_SVG_FILES.items():
+        svg = (SVG_DIR / filename).read_text()
+        VariantSvg.objects.create(
+            variant=Variant.objects.get(id=variant_id),
+            svg=svg,
+            content_hash=hashlib.sha256(svg.encode()).hexdigest(),
+        )
+
+
+def remove_variant_svgs(apps, schema_editor):
+    VariantSvg = apps.get_model("variant", "VariantSvg")
+    VariantSvg.objects.filter(variant_id__in=VARIANT_SVG_FILES).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('variant', '0013_variantsvg'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_variant_svgs, remove_variant_svgs),
+    ]

--- a/service/variant/tests/test_variant_svg.py
+++ b/service/variant/tests/test_variant_svg.py
@@ -6,7 +6,7 @@ from django.db import IntegrityError
 
 from variant.admin import VariantSvgAdminForm
 from variant.models import Variant, VariantSvg
-from variant.utils import normalize_dsvg
+from variant.utils import normalize_dsvg, validate_dsvg
 
 
 def _upload(svg):
@@ -92,3 +92,24 @@ def test_admin_form_normalizes_uploaded_svg(make_editor_dsvg):
     instance = form.save()
     assert "inkscape" not in instance.svg
     assert "<!--" not in instance.svg
+
+
+@pytest.mark.django_db
+def test_backfill_creates_an_svg_for_each_in_db_variant():
+    expected = {"classical", "italy-vs-germany", "hundred", "vietnam-war", "canton", "youngstown-redux"}
+
+    assert set(VariantSvg.objects.values_list("variant_id", flat=True)) == expected
+
+
+@pytest.mark.django_db
+def test_backfilled_svgs_validate_against_their_variant():
+    for variant_svg in VariantSvg.objects.select_related("variant"):
+        assert validate_dsvg(variant_svg.svg, variant_svg.variant) == []
+
+
+@pytest.mark.django_db
+def test_italy_vs_germany_reuses_the_classical_svg():
+    classical = VariantSvg.objects.get(variant_id="classical")
+    italy_vs_germany = VariantSvg.objects.get(variant_id="italy-vs-germany")
+
+    assert italy_vs_germany.content_hash == classical.content_hash


### PR DESCRIPTION
Closes #425. Part of #405.

Adds a data migration that creates a `VariantSvg` row for each of the six in-DB variants.

The migration reads the committed dSVG files in `service/variant/data/svg/` and creates one row per variant, computing the SHA-256 content hash. `italy-vs-germany` reuses `classical.d.svg` since the two share a province set.

Reading the committed files at migrate time keeps the rows reproducible in every environment — CI, local dev, fresh clones — rather than depending on a manual admin upload to prod. The admin upload path added in #447 remains for editing and future variants.

Tests confirm the backfill creates a row per variant, that each stored SVG validates against its variant, and that italy-vs-germany and classical share a content hash.