### PR TITLE
Stop staging Django before cloning the production database

### DIFF
--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -175,6 +175,50 @@ jobs:
           echo "ERROR: Staging Postgres did not become ready in time."
           exit 1
 
+      - name: Stop staging Django service
+        env:
+          ENV_ID: ${{ steps.create_env.outputs.env_id }}
+        run: |
+          if [ "$ENV_ID" = "$PROD_ENV_ID" ]; then
+            echo "ERROR: ENV_ID matches PROD_ENV_ID — refusing to stop production deployments."
+            exit 1
+          fi
+
+          echo "Querying staging Django deployments..."
+          LIST_PAYLOAD=$(jq -n \
+            --arg projectId "$PROJECT_ID" \
+            --arg envId "$ENV_ID" \
+            --arg serviceId "$DJANGO_SERVICE_ID" \
+            '{
+              query: "query($input: DeploymentListInput!) { deployments(input: $input, first: 20) { edges { node { id status } } } }",
+              variables: { input: { projectId: $projectId, environmentId: $envId, serviceId: $serviceId } }
+            }')
+
+          RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+            -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$LIST_PAYLOAD")
+          echo "Deployments response: $RESULT"
+
+          ACTIVE_IDS=$(echo "$RESULT" | jq -r '.data.deployments.edges[].node | select(.status | IN("REMOVED","REMOVING","FAILED","CRASHED","SKIPPED") | not) | .id')
+
+          if [ -z "$ACTIVE_IDS" ]; then
+            echo "No active Django deployment to stop."
+          else
+            for DEP_ID in $ACTIVE_IDS; do
+              echo "Stopping deployment $DEP_ID..."
+              STOP_PAYLOAD=$(jq -n --arg id "$DEP_ID" \
+                '{query: "mutation($id: String!) { deploymentStop(id: $id) }", variables: {id: $id}}')
+              STOP_RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+                -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "$STOP_PAYLOAD")
+              echo "Stop response: $STOP_RESULT"
+            done
+            echo "Waiting 15s for connections to drain..."
+            sleep 15
+          fi
+
       - name: Clone production database to staging
         env:
           PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
@@ -186,11 +230,15 @@ jobs:
           echo "Dumping production database..."
           $PG_BIN/pg_dump "$PRODUCTION_DATABASE_URL" --no-owner --no-acl --format=custom -f dump.pgdata
 
+          echo "Terminating leftover connections to staging database..."
+          psql "$STAGING_DB_URL" -v ON_ERROR_STOP=1 -c \
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();"
+
           echo "Wiping staging database for clean restore..."
-          psql "$STAGING_DB_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+          psql "$STAGING_DB_URL" -v ON_ERROR_STOP=1 -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
           echo "Restoring to staging database..."
-          $PG_BIN/pg_restore --no-owner --no-acl -d "$STAGING_DB_URL" dump.pgdata
+          $PG_BIN/pg_restore --no-owner --no-acl --clean --if-exists -d "$STAGING_DB_URL" dump.pgdata
 
           rm dump.pgdata
           echo "Database clone complete."

--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -184,40 +184,67 @@ jobs:
             exit 1
           fi
 
-          echo "Querying staging Django deployments..."
           LIST_PAYLOAD=$(jq -n \
             --arg projectId "$PROJECT_ID" \
             --arg envId "$ENV_ID" \
             --arg serviceId "$DJANGO_SERVICE_ID" \
             '{
-              query: "query($input: DeploymentListInput!) { deployments(input: $input, first: 20) { edges { node { id status } } } }",
+              query: "query($input: DeploymentListInput!) { deployments(input: $input, first: 1) { edges { node { id status } } } }",
               variables: { input: { projectId: $projectId, environmentId: $envId, serviceId: $serviceId } }
             }')
 
-          RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
-            -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$LIST_PAYLOAD")
-          echo "Deployments response: $RESULT"
+          # Railway refuses to stop a deployment that is still building, so wait
+          # for the forked Django deployment to finish and reach SUCCESS, then
+          # stop it. Once stopped it stays down until the explicit deploy step,
+          # so the clone runs against an idle database.
+          echo "Waiting for the staging Django deployment to become stoppable..."
+          for i in $(seq 1 60); do
+            RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$LIST_PAYLOAD")
+            STATUS=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.status // empty')
+            DEP_ID=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.id // empty')
 
-          ACTIVE_IDS=$(echo "$RESULT" | jq -r '.data.deployments.edges[].node | select(.status | IN("REMOVED","REMOVING","FAILED","CRASHED","SKIPPED") | not) | .id')
+            case "$STATUS" in
+              SUCCESS)
+                echo "Deployment $DEP_ID is running. Stopping it..."
+                STOP_PAYLOAD=$(jq -n --arg id "$DEP_ID" \
+                  '{query: "mutation($id: String!) { deploymentStop(id: $id) }", variables: {id: $id}}')
+                STOP_RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+                  -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  -d "$STOP_PAYLOAD")
+                echo "Stop response: $STOP_RESULT"
+                if [ "$(echo "$STOP_RESULT" | jq -r '.data.deploymentStop // empty')" = "true" ]; then
+                  echo "Django deployment stopped."
+                  STOPPED=true
+                  break
+                fi
+                echo "Attempt $i/60: stop not accepted yet, retrying in 10s..."
+                ;;
+              CRASHED|FAILED|REMOVED|REMOVING|SKIPPED|SLEEPING)
+                echo "Deployment status is $STATUS — Django is not running, nothing to stop."
+                STOPPED=true
+                break
+                ;;
+              "")
+                echo "Attempt $i/60: no Django deployment yet, waiting 10s..."
+                ;;
+              *)
+                echo "Attempt $i/60: deployment status is $STATUS, waiting 10s..."
+                ;;
+            esac
+            sleep 10
+          done
 
-          if [ -z "$ACTIVE_IDS" ]; then
-            echo "No active Django deployment to stop."
-          else
-            for DEP_ID in $ACTIVE_IDS; do
-              echo "Stopping deployment $DEP_ID..."
-              STOP_PAYLOAD=$(jq -n --arg id "$DEP_ID" \
-                '{query: "mutation($id: String!) { deploymentStop(id: $id) }", variables: {id: $id}}')
-              STOP_RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
-                -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
-                -H "Content-Type: application/json" \
-                -d "$STOP_PAYLOAD")
-              echo "Stop response: $STOP_RESULT"
-            done
-            echo "Waiting 15s for connections to drain..."
-            sleep 15
+          if [ "$STOPPED" != "true" ]; then
+            echo "ERROR: Django deployment never reached a stoppable state — aborting before the clone."
+            exit 1
           fi
+
+          echo "Waiting 20s for the container to terminate and release connections..."
+          sleep 20
 
       - name: Clone production database to staging
         env:


### PR DESCRIPTION
The PR staging "Clone production database to staging" step fails intermittently (~9 of the last ~100 runs). The staging environment is created as a Railway fork of production, so the fork brings up a staging Django service already connected to the staging Postgres. `DROP SCHEMA` and `pg_restore` race that live service, causing deadlocks and restores into a non-empty database.

This adds a step that stops the staging environment's Django deployments before the wipe, and hardens the clone:

- New "Stop staging Django service" step queries `deployments` scoped to the `staging-pr-<number>` environment and calls `deploymentStop` on each active deployment. It asserts `ENV_ID != PROD_ENV_ID` first, since `DJANGO_SERVICE_ID` is shared across environments.
- The clone step now terminates leftover connections with `pg_terminate_backend`, runs the wipe with `ON_ERROR_STOP=1` so a failed wipe aborts loudly, and restores with `pg_restore --clean --if-exists`.

The existing "Deploy PR branch to staging" step already redeploys Django after the clone, so it stays down only through the clone window.

CI-only; verify by labeling a PR `deploy-to-staging` and confirming the stop step runs and the clone succeeds, including the reused-environment path.

Closes #449