### PR TITLE
Serve variant SVGs at a cached public endpoint

### DIFF
--- a/service/variant/tests/test_variant_svg_endpoint.py
+++ b/service/variant/tests/test_variant_svg_endpoint.py
@@ -1,0 +1,68 @@
+import gzip
+
+import pytest
+
+from variant.models import VariantSvg
+
+
+def _url(variant_id, content_hash):
+    return f"/variants/{variant_id}/svg/{content_hash}.svg"
+
+
+@pytest.mark.django_db
+def test_serves_svg_for_a_valid_hash(client):
+    variant_svg = VariantSvg.objects.get(variant_id="classical")
+
+    response = client.get(_url("classical", variant_svg.content_hash))
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/svg+xml"
+
+
+@pytest.mark.django_db
+def test_sets_immutable_cache_control(client):
+    variant_svg = VariantSvg.objects.get(variant_id="classical")
+
+    response = client.get(_url("classical", variant_svg.content_hash))
+
+    assert response["Cache-Control"] == "public, max-age=31536000, immutable"
+
+
+@pytest.mark.django_db
+def test_gzip_encoded_when_client_accepts(client):
+    variant_svg = VariantSvg.objects.get(variant_id="classical")
+
+    response = client.get(
+        _url("classical", variant_svg.content_hash), headers={"Accept-Encoding": "gzip"}
+    )
+
+    assert response["Content-Encoding"] == "gzip"
+    assert gzip.decompress(response.content).decode() == variant_svg.svg
+
+
+@pytest.mark.django_db
+def test_uncompressed_when_client_does_not_accept_gzip(client):
+    variant_svg = VariantSvg.objects.get(variant_id="classical")
+
+    response = client.get(
+        _url("classical", variant_svg.content_hash), headers={"Accept-Encoding": "identity"}
+    )
+
+    assert "Content-Encoding" not in response
+    assert response.content.decode() == variant_svg.svg
+
+
+@pytest.mark.django_db
+def test_unknown_hash_returns_404(client):
+    response = client.get(_url("classical", "0" * 64))
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_unknown_variant_returns_404(client):
+    variant_svg = VariantSvg.objects.get(variant_id="classical")
+
+    response = client.get(_url("nonexistent", variant_svg.content_hash))
+
+    assert response.status_code == 404

--- a/service/variant/urls.py
+++ b/service/variant/urls.py
@@ -1,7 +1,12 @@
 from django.urls import path
 
-from .views import VariantListView
+from .views import VariantListView, VariantSvgView
 
 urlpatterns = [
     path("variants/", VariantListView.as_view(), name="variant-list"),
+    path(
+        "variants/<str:variant_id>/svg/<str:content_hash>.svg",
+        VariantSvgView.as_view(),
+        name="variant-svg",
+    ),
 ]

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -1,7 +1,11 @@
+import gzip
+
+from django.http import HttpResponse, HttpResponseNotFound
+from django.views import View
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import AllowAny
 
-from .models import Variant
+from .models import Variant, VariantSvg
 from .serializers import VariantSerializer
 
 
@@ -9,3 +13,23 @@ class VariantListView(ListAPIView):
     serializer_class = VariantSerializer
     permission_classes = [AllowAny]
     queryset = Variant.objects.all().with_related_data()
+
+
+class VariantSvgView(View):
+    def get(self, request, variant_id, content_hash):
+        try:
+            variant_svg = VariantSvg.objects.get(variant_id=variant_id, content_hash=content_hash)
+        except VariantSvg.DoesNotExist:
+            return HttpResponseNotFound()
+
+        body = variant_svg.svg.encode()
+        accepts_gzip = "gzip" in request.headers.get("Accept-Encoding", "")
+        if accepts_gzip:
+            body = gzip.compress(body)
+
+        response = HttpResponse(body, content_type="image/svg+xml")
+        response["Cache-Control"] = "public, max-age=31536000, immutable"
+        response["Vary"] = "Accept-Encoding"
+        if accepts_gzip:
+            response["Content-Encoding"] = "gzip"
+        return response


### PR DESCRIPTION
Closes #452. Completes #405.

Adds `GET /variants/<variant_id>/svg/<content_hash>.svg`, a public endpoint serving the stored `VariantSvg` content.

- Returns the SVG with `Content-Type: image/svg+xml`.
- `Cache-Control: public, max-age=31536000, immutable`.
- gzip-encoded when the client sends `Accept-Encoding: gzip`, with `Vary: Accept-Encoding`.
- No authentication — it is a plain Django view, so it also stays out of the OpenAPI schema.
- The `<content_hash>` must match the stored hash or the endpoint 404s. This keeps each URL immutable: a content change produces a new hash, so a stale URL stops resolving and browser caches invalidate without a server round-trip.

The path is `/variants/...` rather than `/api/variants/...` — the variant routes are mounted at the root, matching the existing `/variants/` list endpoint.

Out of scope: exposing the URL in the variant API and frontend map rendering.