### PR TITLE
Expose svg_url on the variant API

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -695,6 +695,8 @@ export interface Variant {
   author?: string;
   rules: string;
   victoryConditions: VictoryConditions;
+  /** @nullable */
+  readonly svgUrl: string | null;
   nations: Nation[];
   provinces: Province[];
   templatePhase: PhaseRetrieve;

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2758,6 +2758,10 @@ components:
           type: string
         victoryConditions:
           $ref: '#/components/schemas/VictoryConditions'
+        svgUrl:
+          type: string
+          nullable: true
+          readOnly: true
         nations:
           type: array
           items:
@@ -2775,6 +2779,7 @@ components:
       - nations
       - provinces
       - rules
+      - svgUrl
       - templatePhase
       - victoryConditions
     VerifyEmail:

--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -48,7 +48,7 @@ class VariantQuerySet(models.QuerySet):
             to_attr="template_phases",
         )
 
-        return self.prefetch_related(
+        return self.select_related("svg").defer("svg__svg").prefetch_related(
             # Variant data with optimized template phase
             "provinces__parent",
             "provinces__named_coasts",

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -1,7 +1,12 @@
+from typing import Optional
+
+from django.urls import reverse
 from rest_framework import serializers
 from province.serializers import ProvinceSerializer
 from nation.serializers import NationSerializer
 from phase.serializers import PhaseRetrieveSerializer
+
+from .models import VariantSvg
 
 
 class VictoryConditionsSerializer(serializers.Serializer):
@@ -17,9 +22,22 @@ class VariantSerializer(serializers.Serializer):
     author = serializers.CharField(required=False)
     rules = serializers.CharField(allow_blank=True)
     victory_conditions = VictoryConditionsSerializer()
+    svg_url = serializers.SerializerMethodField()
     nations = NationSerializer(many=True)
     provinces = ProvinceSerializer(many=True)
     template_phase = PhaseRetrieveSerializer()
+
+    def get_svg_url(self, variant) -> Optional[str]:
+        try:
+            variant_svg = variant.svg
+        except VariantSvg.DoesNotExist:
+            return None
+        path = reverse(
+            "variant-svg",
+            kwargs={"variant_id": variant.id, "content_hash": variant_svg.content_hash},
+        )
+        request = self.context.get("request")
+        return request.build_absolute_uri(path) if request else path
 
 
 class GameListVariantSerializer(serializers.Serializer):

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -51,6 +51,26 @@ def test_list_variants_unauthenticated(unauthenticated_client):
     assert len(response.data) >= 1
 
 
+@pytest.mark.django_db
+def test_list_variants_includes_svg_url(authenticated_client):
+    response = authenticated_client.get(reverse(viewname))
+
+    classical = {v["id"]: v for v in response.data}["classical"]
+    assert classical["svg_url"] is not None
+    assert "/variants/classical/svg/" in classical["svg_url"]
+    assert classical["svg_url"].endswith(".svg")
+
+
+@pytest.mark.django_db
+def test_svg_url_is_null_when_variant_has_no_svg(authenticated_client):
+    Variant.objects.create(id="no-svg", name="No SVG", description="", author="")
+
+    response = authenticated_client.get(reverse(viewname))
+
+    no_svg = {v["id"]: v for v in response.data}["no-svg"]
+    assert no_svg["svg_url"] is None
+
+
 class TestVariantListViewQueryPerformance:
 
     @pytest.mark.django_db


### PR DESCRIPTION
Closes #454. Part of #405.

Adds an `svg_url` field to `VariantSerializer` resolving to the absolute URL of the variant's SVG endpoint, or null when the variant has no `VariantSvg`. Without this, the endpoint from #452 is unreachable — nothing returned the content hash needed to build the URL.

The variant queryset `select_related`s `svg` with the large `svg` text column deferred, so the list endpoint stays at a single query (the existing query-count test still passes at 16).

Regenerates the OpenAPI schema and the generated frontend client.

Stacked on #453 (the serving endpoint) — it should merge after #453. The base will need retargeting to main once #453 lands.