### PR TITLE
Recompute supply-center ownership in the prototype adjudicator

### DIFF
--- a/packages/web/src/mocks.ts
+++ b/packages/web/src/mocks.ts
@@ -553,6 +553,7 @@ export const mockVariants: Variant[] = [
       gameEndsYear: null,
       drawAfterYear: null,
     },
+    svgUrl: null,
     templatePhase: {
       id: 1,
       ordinal: 1,
@@ -582,6 +583,7 @@ export const mockVariants: Variant[] = [
       gameEndsYear: null,
       drawAfterYear: null,
     },
+    svgUrl: null,
     templatePhase: {
       id: 2,
       ordinal: 1,

--- a/service/adjudicator/engine.py
+++ b/service/adjudicator/engine.py
@@ -9,6 +9,7 @@ from .domain import (
     Phase,
     Resolution,
     State,
+    SupplyCenter,
     Unit,
 )
 from .resolution import resolve_strengths_and_cuts
@@ -178,6 +179,17 @@ class Actions:
         """Compute the Retreat-phase post-resolution units list: standing
         units kept, successful retreats relocated, all other dislodged
         units removed, dislodged flags cleared."""
+
+    @dataclass(frozen=True)
+    class UpdateSupplyCenterOwnership(Action):
+        """Retreat-phase: recompute supply-center ownership for the next
+        phase. When the next phase is an Adjustment phase, ownership is
+        recounted from the post-retreat unit positions — every
+        supply-center province occupied by a unit transfers to that
+        unit's nation, and unoccupied supply centers keep their current
+        owner. When the next phase is not an Adjustment phase, current
+        ownership is carried through unchanged. Writes
+        next_supply_centers."""
 
     @dataclass(frozen=True)
     class ApplyAdjustmentOutcomes(Action):
@@ -997,6 +1009,45 @@ class ApplyRetreatOutcomesReducer(Reducer):
         return state.replace(next_units=tuple(next_units))
 
 
+class UpdateSupplyCenterOwnershipReducer(Reducer):
+    """Recompute supply-center ownership for the next phase. When the
+    next phase is an Adjustment phase, ownership is recounted from the
+    post-retreat unit positions (next_units): every supply-center
+    province occupied by a unit transfers to that unit's nation, and
+    unoccupied supply centers keep their current owner. When the next
+    phase is not an Adjustment phase, current ownership is carried
+    through unchanged. Writes next_supply_centers."""
+
+    ACTION = Actions.UpdateSupplyCenterOwnership
+
+    @classmethod
+    def reduce(cls, state: StateView, action: Action) -> StateView:
+        next_phase = state.next_phase()
+        if next_phase is None or next_phase.type != Phase.ADJUSTMENT:
+            return state.replace(next_supply_centers=state.supply_centers())
+        variant = state.variant()
+        occupant_by_province: Dict[str, str] = {}
+        for unit in state.next_units():
+            occupant_by_province[variant.parent_of(unit.location)] = unit.nation
+        current_by_province = {sc.province: sc for sc in state.supply_centers()}
+        updated: List[SupplyCenter] = []
+        for province_id, province in sorted(variant.provinces.items()):
+            if not province.supply_center:
+                continue
+            occupant = occupant_by_province.get(province_id)
+            current = current_by_province.get(province_id)
+            if occupant is None:
+                if current is not None:
+                    updated.append(current)
+            elif current is None:
+                updated.append(SupplyCenter(nation=occupant, province=province_id))
+            elif current.nation == occupant:
+                updated.append(current)
+            else:
+                updated.append(replace(current, nation=occupant))
+        return state.replace(next_supply_centers=tuple(updated))
+
+
 class ApplyAdjustmentOutcomesReducer(Reducer):
     """Compute the Adjustment-phase post-resolution units list. First,
     drop units removed this phase — both those explicitly disbanded by
@@ -1148,7 +1199,12 @@ class RetreatPhaseResolver(PhaseResolver):
     2. ApplyLegalityChecks     — reachable / unoccupied / not-attacker / not-contested.
     3. ResolveRetreatBounces   — standoffs mark all competitors BOUNCE.
     4. FinalizeStatuses        — remaining undecided -> OK.
-    5. ApplyRetreatOutcomes    — relocate or remove dislodged units."""
+    5. ApplyRetreatOutcomes    — relocate or remove dislodged units.
+    6. UpdateSupplyCenterOwnership
+                               — recompute supply-center ownership from
+                                 the post-retreat positions when the next
+                                 phase is Adjustment; carry it through
+                                 unchanged otherwise."""
 
     PHASE_TYPE = Phase.RETREAT
 
@@ -1158,6 +1214,7 @@ class RetreatPhaseResolver(PhaseResolver):
         Actions.ResolveRetreatBounces,
         Actions.FinalizeStatuses,
         Actions.ApplyRetreatOutcomes,
+        Actions.UpdateSupplyCenterOwnership,
     )
 
 
@@ -1258,7 +1315,10 @@ class Engine:
     ) -> List[State]:
         """Build the resolved State from `adj` (resolutions populated,
         units replaced with next_units) and, if applicable, a fresh
-        next-phase State carrying those units forward."""
+        next-phase State carrying those units forward. The next-phase
+        State takes its supply-center ownership from next_supply_centers
+        when a reducer recomputed it (Retreat phase), otherwise the
+        input ownership is carried through unchanged."""
         resolutions: List[Resolution] = []
         for order, resolution in zip(adj.parsed_orders, adj.resolutions):
             resolutions.append(
@@ -1294,7 +1354,7 @@ class Engine:
             variant=original.variant,
             phase=nxt,
             units=list(adj.next_units),
-            supply_centers=list(original.supply_centers),
+            supply_centers=list(adj.next_supply_centers or original.supply_centers),
             orders=[],
             resolutions=None,
             skipped=False,

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -41,6 +41,7 @@ from .engine import (
     Engine,
     MovementPhaseResolver,
     Status,
+    UpdateSupplyCenterOwnershipReducer,
 )
 from .resolution import resolve_strengths_and_cuts
 from .serializers import (
@@ -6896,6 +6897,88 @@ def test_adjustment_phase_mixes_builds_explicit_disbands_and_civil_disorder():
     assert _unit_at(result, "rhs") is not None
     assert _unit_at(result, "mid") is None
     assert _unit_at(result, "iso") is None
+
+
+# === Supply-center ownership ===
+
+
+def test_supply_center_ownership_recomputes_into_adjustment_phase():
+    """In the Retreat -> Adjustment transition, a supply center occupied
+    by a unit transfers to that unit's nation while an unoccupied supply
+    center keeps its current owner."""
+    state = AdjudicationState(
+        variant=make_variant(),
+        phase=Phase(season="Spring", year=1901, type=Phase.RETREAT),
+        units=(),
+        supply_centers=(
+            SupplyCenter(nation=SOUTH, province="rhs"),
+            SupplyCenter(nation=SOUTH, province="mid"),
+        ),
+        raw_orders=(),
+        contested_provinces=(),
+        next_units=(Unit(nation=NORTH, type=Unit.ARMY, location="rhs"),),
+    )
+
+    result = UpdateSupplyCenterOwnershipReducer.reduce(
+        StateView(state), Actions.UpdateSupplyCenterOwnership()
+    )
+
+    owners = {sc.province: sc.nation for sc in result.next_supply_centers()}
+    assert owners == {"rhs": NORTH, "mid": SOUTH}
+
+
+def test_supply_center_ownership_passes_through_when_next_phase_not_adjustment():
+    """Outside the transition into an Adjustment phase, ownership is
+    carried through unchanged even when a unit stands on a supply center
+    it does not own."""
+    state = AdjudicationState(
+        variant=make_variant(),
+        phase=Phase(season="Spring", year=1901, type=Phase.MOVEMENT),
+        units=(),
+        supply_centers=(SupplyCenter(nation=SOUTH, province="rhs"),),
+        raw_orders=(),
+        contested_provinces=(),
+        next_units=(Unit(nation=NORTH, type=Unit.ARMY, location="rhs"),),
+    )
+
+    result = UpdateSupplyCenterOwnershipReducer.reduce(
+        StateView(state), Actions.UpdateSupplyCenterOwnership()
+    )
+
+    owners = {sc.province: sc.nation for sc in result.next_supply_centers()}
+    assert owners == {"rhs": SOUTH}
+
+
+def test_retreat_into_supply_center_transfers_ownership_to_next_phase():
+    """A unit that retreats into a supply center owns it in the
+    Adjustment phase that follows; the resolved Retreat state keeps the
+    pre-resolution ownership."""
+    variant = make_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.RETREAT,
+        units=[
+            Unit(
+                nation=NORTH,
+                type=Unit.ARMY,
+                location="mid",
+                dislodged=True,
+                dislodged_from="lhs",
+            ),
+        ],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+        orders=[
+            RawOrder(nation=NORTH, source="mid", order_type="Retreat", target="rhs"),
+        ],
+    )
+
+    resolved, next_state = Engine().adjudicate(state)
+
+    resolved_owners = {sc.province: sc.nation for sc in resolved.supply_centers}
+    next_owners = {sc.province: sc.nation for sc in next_state.supply_centers}
+    assert next_state.phase.type == Phase.ADJUSTMENT
+    assert resolved_owners == {"rhs": SOUTH}
+    assert next_owners == {"rhs": NORTH}
 
 
 # === Engine error tests ===

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -975,6 +975,14 @@ class AdjudicationState:
     Populated by ApplyMovementOutcomes; empty outside Movement. Carried
     forward by the Engine into the next phase's State.contested_provinces."""
 
+    next_supply_centers: Tuple[SupplyCenter, ...] = ()
+    """Supply-center ownership as it should appear after this phase
+    resolves. Populated by UpdateSupplyCenterOwnership (Retreat phase
+    only): recomputed from post-retreat unit positions when the next
+    phase is Adjustment, copied through unchanged otherwise. Empty
+    until that reducer runs; consumed by the Engine when building the
+    next phase's State."""
+
 
 # === Views ===
 
@@ -1211,6 +1219,9 @@ class StateView:
     def raw_orders(self) -> Tuple[RawOrder, ...]:
         return self._state.raw_orders
 
+    def supply_centers(self) -> Tuple[SupplyCenter, ...]:
+        return self._state.supply_centers
+
     def contested_provinces(self) -> frozenset:
         return frozenset(self._state.contested_provinces)
 
@@ -1219,6 +1230,9 @@ class StateView:
 
     def next_units(self) -> Tuple[Unit, ...]:
         return self._state.next_units
+
+    def next_supply_centers(self) -> Tuple[SupplyCenter, ...]:
+        return self._state.next_supply_centers
 
     def civil_disorder_disbands(self) -> Tuple[str, ...]:
         return self._state.civil_disorder_disbands


### PR DESCRIPTION
The prototype adjudicator never recomputed supply-center ownership — `Engine._to_external_states` carried the input `supply_centers` forward verbatim into every next-phase state. The Adjustment phase already consumes SC ownership (`BuildLocationIsOwnedCheck`, `NationView.owned_supply_centers()`), so a unit that ended a Fall turn standing on a supply center never gained ownership of it.

This adds SC-ownership recomputation, mirroring the existing `units → next_units` pattern:

- New output field `AdjudicationState.next_supply_centers`, with `StateView` accessors for it and the input `supply_centers`.
- New `Actions.UpdateSupplyCenterOwnership` + reducer. On the transition into an Adjustment phase, ownership is recounted from post-retreat unit positions: every variant supply-center province occupied by a unit transfers to that unit's nation; unoccupied supply centers keep their current owner. Named coasts map to their parent province. On any other transition, ownership is carried through unchanged.
- The reducer is appended to `RetreatPhaseResolver.ACTIONS` after `ApplyRetreatOutcomes`, so it reads the post-retreat unit list.
- `_to_external_states` builds the next state's `supply_centers` from `next_supply_centers` when a reducer recomputed it; the resolved phase keeps its input ownership.

The recompute keys off the next phase type being Adjustment rather than a season name, so it generalizes across variants with different season naming.

Tests cover the reducer's transfer, unoccupied-keep, and pass-through cases, plus an end-to-end Retreat adjudication where a unit retreats into a supply center and owns it in the following Adjustment phase. Full adjudicator suite (339 tests) passes.