### PR TITLE
Fix convoy-option over-generation in the prototype adjudicator

### DIFF
--- a/service/adjudicator/convoy.py
+++ b/service/adjudicator/convoy.py
@@ -7,7 +7,8 @@ disrupted at resolution time if any fleet in the path is dislodged.
 This module answers the static question; C3 will integrate the dynamic
 question into the Decision graph.
 
-The only public symbol is `convoy_path_exists`. Everything else is
+Public symbols: `convoy_path_exists`, `convoy_path_through_fleet`,
+`is_convoy_redundant`, and `fleet_reaches_coast`. Everything else is
 module-private.
 """
 from __future__ import annotations
@@ -76,6 +77,79 @@ def convoy_path_exists(
                 if not state.province(neighbour).is_sea():
                     continue
                 if neighbour in visited:
+                    continue
+                if neighbour in allowed_interior:
+                    next_frontier.add(neighbour)
+        frontier = next_frontier
+    return False
+
+
+def convoy_path_through_fleet(
+    state: StateView,
+    army_source: str,
+    army_target: str,
+    fleet_location: str,
+    convoying_fleet_locations: Collection[str],
+) -> bool:
+    """Return True iff a convoy chain from `army_source` to `army_target`
+    through `convoying_fleet_locations` exists that the fleet at
+    `fleet_location` is actually part of.
+
+    `convoy_path_exists` answers whether *some* chain connects the two
+    coasts; this answers the stricter question godip's option generator
+    needs — whether a chain exists that this specific fleet is on
+    (godip's `ConvoyPathFinder` path-finds from the convoying fleet's
+    own location). A chain A→B through F exists iff F is reachable from
+    `army_source` and `army_target` is reachable from F, both restricted
+    to the given on-board fleet set."""
+    if army_source == army_target:
+        return False
+    variant = state.variant()
+    fleet_parent = variant.parent_of(fleet_location)
+    if not state.province(fleet_parent).is_sea():
+        return False
+    allowed_interior: Set[str] = {
+        variant.parent_of(loc) for loc in convoying_fleet_locations
+    }
+    if fleet_parent not in allowed_interior:
+        return False
+    return _sea_chain_connects(
+        state, _sea_neighbours(state, army_source), {fleet_parent}, allowed_interior
+    ) and _sea_chain_connects(
+        state, {fleet_parent}, _sea_neighbours(state, army_target), allowed_interior
+    )
+
+
+def _sea_chain_connects(
+    state: StateView,
+    start_set: Set[str],
+    end_set: Set[str],
+    allowed_interior: Set[str],
+) -> bool:
+    """BFS over fleet-passable sea adjacency: True iff some node in
+    `end_set` is reachable from `start_set`, with every visited node
+    constrained to `allowed_interior`. Only nodes in `allowed_interior`
+    are ever checked against `end_set`, matching `convoy_path_exists` —
+    the first and last sea province in a convoy chain must each hold a
+    convoying fleet."""
+    visited: Set[str] = set()
+    frontier: Set[str] = start_set & allowed_interior
+    variant = state.variant()
+    while frontier:
+        next_frontier: Set[str] = set()
+        for node in frontier:
+            if node in visited:
+                continue
+            visited.add(node)
+            if node in end_set:
+                return True
+            for adjacency in variant.adjacencies_of(node):
+                if not adjacency.allows(Unit.FLEET):
+                    continue
+                neighbour = variant.parent_of(adjacency.to)
+                if neighbour in visited:
+                    continue
+                if not state.province(neighbour).is_sea():
                     continue
                 if neighbour in allowed_interior:
                     next_frontier.add(neighbour)

--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -25,12 +25,13 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-from .convoy import convoy_path_exists
+from .convoy import convoy_path_exists, convoy_path_through_fleet
 from .domain import OrderOption, Phase, ProvinceType, State, Unit
 from .types import (
     AdjudicationState,
     AdjustmentDisbandOrder,
     BuildOrder,
+    ConvoyFleetReachesEndpointsCheck,
     ConvoyOrder,
     MoveOrder,
     MoveTargetIsReachableCheck,
@@ -122,7 +123,11 @@ def _movement_options(view: StateView) -> List[OrderOption]:
         if unit.type == Unit.FLEET and view.province(
             variant.parent_of(source_loc)
         ).is_sea():
-            options.extend(_convoy_options(view, unit, source_loc, standing_items))
+            options.extend(
+                _convoy_options(
+                    view, unit, source_loc, sea_fleet_locs, standing_items
+                )
+            )
     return options
 
 
@@ -268,6 +273,7 @@ def _convoy_options(
     view: StateView,
     fleet: Unit,
     source_loc: str,
+    sea_fleet_locs: Tuple[str, ...],
     standing_items: Tuple[Tuple[str, Unit], ...],
 ) -> List[OrderOption]:
     options: List[OrderOption] = []
@@ -291,7 +297,7 @@ def _convoy_options(
                 army_target=army_target,
                 unit_type=fleet.type,
             )
-            if all(c.check(view, order) for c in ConvoyOrder.LEGALITY_CHECKS):
+            if _convoy_is_orderable(view, order, sea_fleet_locs):
                 options.append(
                     OrderOption(
                         source=source_loc,
@@ -303,6 +309,38 @@ def _convoy_options(
                     )
                 )
     return options
+
+
+def _convoy_is_orderable(
+    view: StateView, order: ConvoyOrder, sea_fleet_locs: Tuple[str, ...]
+) -> bool:
+    # ConvoyFleetReachesEndpointsCheck is the engine's order-legality
+    # check: a purely topological reachability test that is intentionally
+    # lenient. Options instead require a convoy chain through the fleets
+    # actually on the board, with this fleet on it — strictly stronger,
+    # so it fully replaces the topological check rather than supplementing
+    # it. See the module docstring and docs/options-design.md.
+    for check_cls in ConvoyOrder.LEGALITY_CHECKS:
+        if check_cls is ConvoyFleetReachesEndpointsCheck:
+            continue
+        if not check_cls.check(view, order):
+            return False
+    return _convoy_has_real_path(view, order, sea_fleet_locs)
+
+
+def _convoy_has_real_path(
+    view: StateView, order: ConvoyOrder, sea_fleet_locs: Tuple[str, ...]
+) -> bool:
+    if not sea_fleet_locs:
+        return False
+    variant = view.variant()
+    return convoy_path_through_fleet(
+        view,
+        variant.parent_of(order.army_source),
+        variant.parent_of(order.army_target),
+        order.source,
+        sea_fleet_locs,
+    )
 
 
 # === Retreat phase ===

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -9603,6 +9603,96 @@ def test_options_movement_no_convoy_when_no_army_present():
     assert [o for o in options if o.order_type == "Convoy"] == []
 
 
+def _convoy_options_two_sea_variant() -> Variant:
+    """Two sea provinces, s1 and s2, fleet-adjacent to each other so the
+    sea graph is one connected component (as on the classical map). A
+    fleet in s1 can therefore *topologically* reach `far` via s2 — but
+    with no fleet actually in s2, no real convoy chain does."""
+    edges = _edges(
+        ("home", "s1", "fleet"),
+        ("near", "s1", "fleet"),
+        ("far", "s2", "fleet"),
+        ("s1", "s2", "fleet"),
+    )
+    provinces = {
+        "home": _province("home", ProvinceType.COASTAL, adj=edges.get("home", ())),
+        "near": _province("near", ProvinceType.COASTAL, adj=edges.get("near", ())),
+        "far": _province("far", ProvinceType.COASTAL, adj=edges.get("far", ())),
+        "s1": _province("s1", ProvinceType.SEA, adj=edges.get("s1", ())),
+        "s2": _province("s2", ProvinceType.SEA, adj=edges.get("s2", ())),
+    }
+    progression = PhaseProgression(
+        seasons=("Spring",),
+        transitions=(
+            PhaseTransition(
+                from_season="Spring",
+                from_type=Phase.MOVEMENT,
+                to_season="Spring",
+                to_type=Phase.RETREAT,
+                year_delta=0,
+            ),
+        ),
+    )
+    return Variant(
+        id="convoy-options-two-sea",
+        name="Convoy Options Two Sea",
+        description="",
+        author="",
+        victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
+        rules=None,
+        adjudication_modifiers=(),
+        phase_progression=progression,
+        nations=(
+            Nation(id=NORTH, name="North", color="#000000"),
+            Nation(id=SOUTH, name="South", color="#ffffff"),
+        ),
+        provinces=provinces,
+        named_coasts={},
+        dominance_rules=(),
+    )
+
+
+def test_options_movement_convoy_only_for_coasts_reachable_via_on_board_fleets():
+    """`_convoy_options` enumerates convoys over the fleets actually on
+    the board, not the whole sea graph. A fleet in s1 with an adjacent
+    army in `home` can convoy to `near` (s1 touches both) but not to
+    `far` — reaching `far` needs a fleet in s2, and there is none. The
+    topological reach check alone would wrongly offer the `far` convoy
+    because s1→s2→far is a connected sea path."""
+    variant = _convoy_options_two_sea_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.MOVEMENT,
+        units=[
+            Unit(nation=NORTH, type=Unit.ARMY, location="home"),
+            Unit(nation=NORTH, type=Unit.FLEET, location="s1"),
+        ],
+    )
+    convoys = {
+        (o.aux, o.target) for o in get_options(state) if o.order_type == "Convoy"
+    }
+    assert ("home", "near") in convoys
+    assert ("home", "far") not in convoys
+
+    # Place a fleet in s2 and the s1→s2→far chain becomes real: `far`
+    # is now a legitimate convoy destination.
+    state_with_s2 = make_state(
+        variant,
+        phase_type=Phase.MOVEMENT,
+        units=[
+            Unit(nation=NORTH, type=Unit.ARMY, location="home"),
+            Unit(nation=NORTH, type=Unit.FLEET, location="s1"),
+            Unit(nation=NORTH, type=Unit.FLEET, location="s2"),
+        ],
+    )
+    convoys_with_s2 = {
+        (o.aux, o.target)
+        for o in get_options(state_with_s2)
+        if o.order_type == "Convoy"
+    }
+    assert ("home", "far") in convoys_with_s2
+
+
 # === Targeted Retreat-phase tests ===
 
 


### PR DESCRIPTION
## Summary

`_convoy_options` in `service/adjudicator/options.py` enumerated convoy orders using only `ConvoyOrder.LEGALITY_CHECKS`. Its gating check, `ConvoyFleetReachesEndpointsCheck`, is a purely topological BFS over the variant's sea graph — it ignores which fleets actually exist on the board. On the classical map all seas form one connected component, so a single fleet was offered a Convoy order for nearly every army to nearly every coastal province, including coasts no real fleet chain could reach.

Convoy options now path-find over the real on-board fleet positions, requiring a chain from the army's source to its target that the convoying fleet is actually on. This matches godip's `convoy.Options` (`orders/convoy.go`) and the approach `_move_has_convoy_path` and `_supported_can_convoy` already use.

## Changes

- `convoy.py`: added `convoy_path_through_fleet` — checks a convoy chain exists through the on-board fleet set with the convoying fleet on it (a chain A→B through F exists iff F is reachable from A and B is reachable from F). Backed by a private `_sea_chain_connects` BFS helper.
- `options.py`: `_convoy_options` now receives `sea_fleet_locs` (already computed in `_movement_options`). `_convoy_is_orderable` runs every legality check except `ConvoyFleetReachesEndpointsCheck`, then requires a real fleet path. The real-path check is strictly stronger than the topological one, so it replaces rather than supplements it.
- `ConvoyFleetReachesEndpointsCheck` and `fleet_reaches_coast` are unchanged — their topological leniency is the engine's intentional order-legality behavior.
- Added `test_options_movement_convoy_only_for_coasts_reachable_via_on_board_fleets`, which uses a two-sea variant to distinguish topological reachability from real fleet reachability.

Full adjudicator suite (340 tests) passes.