### PR TITLE
Exclude bare multi-coast provinces from fleet move-options

### DIFF
--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -134,6 +134,8 @@ def _movement_options(view: StateView) -> List[OrderOption]:
 def _move_is_orderable(
     view: StateView, order: MoveOrder, sea_fleet_locs: Tuple[str, ...]
 ) -> bool:
+    if _fleet_target_is_bare_multi_coast(view, order):
+        return False
     for check_cls in MoveOrder.LEGALITY_CHECKS:
         if check_cls.check(view, order):
             continue
@@ -163,6 +165,19 @@ def _move_has_convoy_path(
     if not sea_fleet_locs:
         return False
     return convoy_path_exists(view, source_parent, target_parent, sea_fleet_locs)
+
+
+def _fleet_target_is_bare_multi_coast(view: StateView, order: MoveOrder) -> bool:
+    """A fleet enters a multi-coast province only via a specific named
+    coast, never the bare parent — godip models this in its fleet
+    adjacency graph. Armies are unaffected: they move to the bare parent
+    and ignore coasts."""
+    if order.unit_type != Unit.FLEET:
+        return False
+    variant = view.variant()
+    if order.target != variant.parent_of(order.target):
+        return False
+    return bool(variant.coasts_of(order.target))
 
 
 def _support_options(

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -9375,6 +9375,54 @@ def test_options_movement_fleet_at_multi_coast_destination_emits_one_option_per_
     assert "mlc" not in fleet_moves
 
 
+def test_options_movement_fleet_move_to_bare_multi_coast_parent_is_excluded():
+    """A fleet's move options into a multi-coast province are the named
+    coasts, never the bare parent — even when the variant graph carries a
+    fleet edge to the bare parent. godip's fleet adjacencies connect to
+    named coasts; the option generator must match that. A comparable army
+    still moves to the bare parent."""
+    variant = make_variant()
+    # Inject a fleet edge between "sea" and the bare "mlc" parent — an
+    # edge a godip-correct graph would not have. The option generator
+    # must still not offer the bare parent to a fleet.
+    sea = variant.provinces["sea"]
+    mlc = variant.provinces["mlc"]
+    provinces = dict(variant.provinces)
+    provinces["sea"] = replace(
+        sea, adjacencies=sea.adjacencies + (Adjacency(to="mlc", pass_="fleet"),)
+    )
+    provinces["mlc"] = replace(
+        mlc, adjacencies=mlc.adjacencies + (Adjacency(to="sea", pass_="fleet"),)
+    )
+    variant = replace(variant, provinces=provinces)
+
+    fleet_state = make_state(
+        variant,
+        phase_type=Phase.MOVEMENT,
+        units=[Unit(nation=NORTH, type=Unit.FLEET, location="sea")],
+    )
+    fleet_moves = {
+        o.target
+        for o in get_options(fleet_state)
+        if o.order_type == "Move" and o.source == "sea"
+    }
+    assert "mlc/nc" in fleet_moves
+    assert "mlc/sc" in fleet_moves
+    assert "mlc" not in fleet_moves
+
+    army_state = make_state(
+        variant,
+        phase_type=Phase.MOVEMENT,
+        units=[Unit(nation=NORTH, type=Unit.ARMY, location="iso")],
+    )
+    army_moves = {
+        o.target
+        for o in get_options(army_state)
+        if o.order_type == "Move" and o.source == "iso"
+    }
+    assert "mlc" in army_moves
+
+
 def test_options_movement_army_move_to_named_coast_is_excluded():
     """DATC 6.B.12: armies ignore named coasts; target must be a parent."""
     variant = make_variant()


### PR DESCRIPTION
The Movement-phase option generator (`_movement_options` in `service/adjudicator/options.py`) offered a fleet a Move to a bare province even when that province has named coasts. In Diplomacy a fleet entering a multi-coast province such as Spain or Bulgaria must move to a specific named coast (`spa/nc`, `spa/sc`), never the bare parent. Armies are the opposite — they ignore coasts and move to the bare parent.

`_move_is_orderable` now skips a Move target that is a bare province with named coasts when the moving unit is a fleet. Army move enumeration is unchanged. This matches godip, whose fleet adjacencies connect to named coasts rather than the bare parent.

The engine's `MoveTargetIsReachableCheck` already rejects a submitted fleet move to a bare multi-coast parent given godip-correct variant data (fleet adjacencies go to the named coasts, so the bare parent has no fleet-passable edge), so no engine-side change is needed — the fix is scoped to option generation.

Added `test_options_movement_fleet_move_to_bare_multi_coast_parent_is_excluded`, which injects a fleet edge to a bare parent and asserts the fleet is offered the named coasts but not the bare parent, while a comparable army still is. Full adjudicator suite passes (341 tests).