### PR TITLE
Fix Hundred-variant phase progression in the prototype adjudicator

### DIFF
--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -61,6 +61,10 @@ class PhaseTransition:
     to_season: str
     to_type: str
     year_delta: int
+    # When set, this transition fires only if phase.year % year_mod == year_mod_value.
+    # When both are None the transition is unconditional.
+    year_mod: Optional[int] = None
+    year_mod_value: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -173,6 +173,8 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
                 to_season=t["to"]["season"],
                 to_type=t["to"]["type"],
                 year_delta=t["to"]["yearDelta"],
+                year_mod=t.get("condition", {}).get("yearMod"),
+                year_mod_value=t.get("condition", {}).get("yearModValue"),
             )
             for t in pp["transitions"]
         ),

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -10134,3 +10134,109 @@ def test_options_movement_unit_type_is_none_for_existing_unit_orders():
     non_build = [o for o in options if o.order_type != "Build"]
     assert all(o.unit_type is None for o in non_build)
 
+
+# === Phase progression (next_phase) ===
+
+
+def _hundred_progression(reverse: bool = False) -> PhaseProgression:
+    """A year-conditional progression mirroring the Hundred variant: a
+    Retreat in a year%10==5 year skips Adjustment and advances to the
+    next Movement (+5); a Retreat in a year%10==0 year goes to
+    Adjustment."""
+    transitions = (
+        PhaseTransition(
+            from_season="Year",
+            from_type=Phase.MOVEMENT,
+            to_season="Year",
+            to_type=Phase.RETREAT,
+            year_delta=0,
+        ),
+        PhaseTransition(
+            from_season="Year",
+            from_type=Phase.RETREAT,
+            to_season="Year",
+            to_type=Phase.MOVEMENT,
+            year_delta=5,
+            year_mod=10,
+            year_mod_value=5,
+        ),
+        PhaseTransition(
+            from_season="Year",
+            from_type=Phase.RETREAT,
+            to_season="Year",
+            to_type=Phase.ADJUSTMENT,
+            year_delta=0,
+            year_mod=10,
+            year_mod_value=0,
+        ),
+        PhaseTransition(
+            from_season="Year",
+            from_type=Phase.ADJUSTMENT,
+            to_season="Year",
+            to_type=Phase.MOVEMENT,
+            year_delta=5,
+        ),
+    )
+    if reverse:
+        transitions = tuple(reversed(transitions))
+    return PhaseProgression(seasons=("Year",), transitions=transitions)
+
+
+def _next_phase(variant: Variant, phase: Phase) -> Optional[Phase]:
+    state = AdjudicationState(
+        variant=variant,
+        phase=phase,
+        units=(),
+        supply_centers=(),
+        raw_orders=(),
+        contested_provinces=(),
+    )
+    return StateView(state).next_phase()
+
+
+def test_next_phase_conditional_retreat_skips_adjustment_in_year_mod_5():
+    variant = replace(make_variant(), phase_progression=_hundred_progression())
+    nxt = _next_phase(variant, Phase(season="Year", year=1425, type=Phase.RETREAT))
+    assert nxt == Phase(season="Year", year=1430, type=Phase.MOVEMENT)
+
+
+def test_next_phase_conditional_retreat_goes_to_adjustment_in_year_mod_0():
+    variant = replace(make_variant(), phase_progression=_hundred_progression())
+    nxt = _next_phase(variant, Phase(season="Year", year=1430, type=Phase.RETREAT))
+    assert nxt == Phase(season="Year", year=1430, type=Phase.ADJUSTMENT)
+
+
+def test_next_phase_conditional_progression_unconditional_transitions_progress():
+    variant = replace(make_variant(), phase_progression=_hundred_progression())
+    assert _next_phase(
+        variant, Phase(season="Year", year=1425, type=Phase.MOVEMENT)
+    ) == Phase(season="Year", year=1425, type=Phase.RETREAT)
+    assert _next_phase(
+        variant, Phase(season="Year", year=1430, type=Phase.ADJUSTMENT)
+    ) == Phase(season="Year", year=1435, type=Phase.MOVEMENT)
+
+
+def test_next_phase_conditional_resolution_is_independent_of_transition_order():
+    variant = replace(
+        make_variant(), phase_progression=_hundred_progression(reverse=True)
+    )
+    assert _next_phase(
+        variant, Phase(season="Year", year=1425, type=Phase.RETREAT)
+    ) == Phase(season="Year", year=1430, type=Phase.MOVEMENT)
+    assert _next_phase(
+        variant, Phase(season="Year", year=1430, type=Phase.RETREAT)
+    ) == Phase(season="Year", year=1430, type=Phase.ADJUSTMENT)
+
+
+def test_next_phase_unconditional_classical_variant_progresses_through_cycle():
+    variant = make_variant()
+    assert _next_phase(
+        variant, Phase(season="Spring", year=1901, type=Phase.MOVEMENT)
+    ) == Phase(season="Spring", year=1901, type=Phase.RETREAT)
+    assert _next_phase(
+        variant, Phase(season="Spring", year=1901, type=Phase.RETREAT)
+    ) == Phase(season="Spring", year=1901, type=Phase.ADJUSTMENT)
+    assert _next_phase(
+        variant, Phase(season="Spring", year=1901, type=Phase.ADJUSTMENT)
+    ) == Phase(season="Spring", year=1902, type=Phase.MOVEMENT)
+

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -21,6 +21,7 @@ from .domain import (
 )
 from .domain import (
     Phase,
+    PhaseTransition,
     ProvinceType,
     SupplyCenter,
     Unit,
@@ -1256,16 +1257,29 @@ class StateView:
         return OrdersView(self._state)
 
     def next_phase(self) -> Optional[Phase]:
+        phase = self._state.phase
+        fallback: Optional[PhaseTransition] = None
         for transition in self._state.variant.phase_progression.transitions:
             if (
-                transition.from_season == self._state.phase.season
-                and transition.from_type == self._state.phase.type
+                transition.from_season != phase.season
+                or transition.from_type != phase.type
             ):
-                return Phase(
-                    season=transition.to_season,
-                    year=self._state.phase.year + transition.year_delta,
-                    type=transition.to_type,
-                )
+                continue
+            if transition.year_mod is not None:
+                if phase.year % transition.year_mod == transition.year_mod_value:
+                    return Phase(
+                        season=transition.to_season,
+                        year=phase.year + transition.year_delta,
+                        type=transition.to_type,
+                    )
+            elif fallback is None:
+                fallback = transition
+        if fallback is not None:
+            return Phase(
+                season=fallback.to_season,
+                year=phase.year + fallback.year_delta,
+                type=fallback.to_type,
+            )
         return None
 
     def replace(self, **kwargs) -> "StateView":

--- a/service/variant/migrations/0015_correct_hundred_phase_progression.py
+++ b/service/variant/migrations/0015_correct_hundred_phase_progression.py
@@ -1,0 +1,56 @@
+from django.db import migrations
+
+
+CORRECTED_HUNDRED_PHASE_PROGRESSION = {
+    "seasons": ["Year"],
+    "transitions": [
+        {"from": {"season": "Year", "type": "Movement"},
+         "to": {"season": "Year", "type": "Retreat", "yearDelta": 0}},
+        {"from": {"season": "Year", "type": "Retreat"},
+         "to": {"season": "Year", "type": "Movement", "yearDelta": 5},
+         "condition": {"yearMod": 10, "yearModValue": 5}},
+        {"from": {"season": "Year", "type": "Retreat"},
+         "to": {"season": "Year", "type": "Adjustment", "yearDelta": 0},
+         "condition": {"yearMod": 10, "yearModValue": 0}},
+        {"from": {"season": "Year", "type": "Adjustment"},
+         "to": {"season": "Year", "type": "Movement", "yearDelta": 5}},
+    ],
+}
+
+
+PREVIOUS_HUNDRED_PHASE_PROGRESSION = {
+    "seasons": ["Year"],
+    "transitions": [
+        {"from": {"season": "Year", "type": "Movement"},
+         "to": {"season": "Year", "type": "Retreat", "yearDelta": 0}},
+        {"from": {"season": "Year", "type": "Retreat"},
+         "to": {"season": "Year", "type": "Adjustment", "yearDelta": 0}},
+        {"from": {"season": "Year", "type": "Adjustment"},
+         "to": {"season": "Year", "type": "Movement", "yearDelta": 5}},
+    ],
+}
+
+
+def apply_corrected(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    Variant.objects.filter(id="hundred").update(
+        phase_progression=CORRECTED_HUNDRED_PHASE_PROGRESSION
+    )
+
+
+def revert_corrected(apps, schema_editor):
+    Variant = apps.get_model("variant", "Variant")
+    Variant.objects.filter(id="hundred").update(
+        phase_progression=PREVIOUS_HUNDRED_PHASE_PROGRESSION
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("variant", "0014_backfill_variant_svgs"),
+    ]
+
+    operations = [
+        migrations.RunPython(apply_corrected, revert_corrected),
+    ]


### PR DESCRIPTION
The Hundred variant's phase cycle is year-conditional. After a Retreat phase, years where `year % 10 == 5` skip Adjustment and advance straight to the next Movement (`year + 5`), while `year % 10 == 0` years go to Adjustment. `PhaseTransition` could only key on `(from_season, from_type)`, so the ambiguous `(Year, Retreat)` key always resolved to Adjustment — resolving e.g. "Year 1425 Retreat" advanced to "Year 1425 Adjustment" instead of "Year 1430 Movement".

`PhaseTransition` gains optional `year_mod` / `year_mod_value` fields. A transition with them set fires only when `phase.year % year_mod == year_mod_value`; transitions without them stay unconditional. `next_phase()` returns a firing conditional transition over the unconditional fallback, deterministically regardless of transition order. `deserialize_variant` parses an optional `condition: {yearMod, yearModValue}` object per transition, so classical variants that omit it are unaffected.

A new data migration (`0015`) re-backfills the `hundred` variant with the corrected conditional progression. Historical migration `0011` is left untouched, as is the unconditional classical `default_phase_progression`.

Added `next_phase()` tests covering both conditional branches, order-independence, and the unchanged classical cycle. All 345 adjudicator tests and 80 variant tests pass.

<sub>Generated with Claude Code</sub>