### PR TITLE
Fix support-option over-generation into named coasts

### DIFF
--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -117,7 +117,7 @@ def _movement_options(view: StateView) -> List[OrderOption]:
                 )
         options.extend(
             _support_options(
-                view, unit, source_loc, sea_fleet_locs, all_locations, standing_items
+                view, unit, source_loc, sea_fleet_locs, standing_items
             )
         )
         if unit.type == Unit.FLEET and view.province(
@@ -185,7 +185,6 @@ def _support_options(
     supporter: Unit,
     source_loc: str,
     sea_fleet_locs: Tuple[str, ...],
-    all_locations: Tuple[str, ...],
     standing_items: Tuple[Tuple[str, Unit], ...],
 ) -> List[OrderOption]:
     options: List[OrderOption] = []
@@ -215,8 +214,10 @@ def _support_options(
     for mover_loc, mover in standing_items:
         if variant.parent_of(mover_loc) == source_parent:
             continue
-        for target in all_locations:
-            if variant.parent_of(target) == source_parent:
+        # A support is given to a province, never a named coast — enumerate
+        # bare provinces only so a multi-coast target yields a single option.
+        for target in variant.provinces:
+            if target == source_parent:
                 continue
             order = SupportMoveOrder(
                 nation=supporter.nation,

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -9532,6 +9532,41 @@ def test_options_movement_support_move_via_convoy_emitted():
     assert len(via_convoy) == 1
 
 
+def test_options_movement_support_move_targets_bare_province_not_named_coast():
+    """A support is given to a province, never a named coast. When a mover
+    can advance into a multi-coast province, the supporter gets exactly one
+    support-for-a-move option — targeting the bare parent, not one option
+    per coast. Mirrors godip, where a support targets the move's Super()."""
+    variant = make_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.MOVEMENT,
+        units=[
+            # army at iso can move into the multi-coast province mlc
+            Unit(nation=NORTH, type=Unit.ARMY, location="iso"),
+            # fleet at sea can support a move to mlc (via either named coast)
+            Unit(nation=NORTH, type=Unit.FLEET, location="sea"),
+        ],
+    )
+    options = get_options(state)
+    support_into_mlc = [
+        o
+        for o in options
+        if o.order_type == "Support"
+        and o.source == "sea"
+        and o.aux == "iso"
+        and variant.parent_of(o.target) == "mlc"
+    ]
+    assert len(support_into_mlc) == 1
+    assert support_into_mlc[0].target == "mlc"
+    named_coast_targets = {
+        o.target
+        for o in options
+        if o.order_type == "Support" and o.target in ("mlc/nc", "mlc/sc")
+    }
+    assert named_coast_targets == set()
+
+
 def test_options_movement_support_of_unit_on_named_coast_uses_parent_in_path():
     """A unit at a named coast is referenced by its bare parent in the
     Support option's aux field — matches godip's TestSupportSTPOpts.


### PR DESCRIPTION
The support-for-a-move generator in `service/adjudicator/options.py` enumerated candidate targets over every province plus every named coast. A move into a multi-coast province (e.g. `bul`) therefore produced a separate support option per coast — `bul`, `bul/ec`, `bul/sc` — when only the bare-province option is correct. In Diplomacy a support is given to a province, never a specific coast.

`_support_options` now enumerates support-for-a-move targets over bare provinces only and emits the bare province. This validates correctly for both fleet and army movers: `SupportMoveSupporterCanReachCheck` and `SupportMoveSupportedCanReachCheck` evaluate reachability through the parent-aware `Variant.can_support_to`, which treats a bare-province target as reachable via any of its named coasts. The now-unused `all_locations` parameter was dropped from the function.

Added `test_options_movement_support_move_targets_bare_province_not_named_coast`, which asserts an army moving into a multi-coast province yields exactly one support option targeting the bare parent and none targeting a named coast.

<sub>Generated with Claude Code</sub>