### PR TITLE
Fix Discord invite link

### DIFF
--- a/packages/web/src/screens/Home/Community.tsx
+++ b/packages/web/src/screens/Home/Community.tsx
@@ -6,8 +6,7 @@ import { ScreenContainer } from "@/components/ui/screen-container";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { Button } from "@/components/ui/button";
 
-const DISCORD_URL =
-  "https://discord.com/channels/565625522407604254/697344626859704340";
+const DISCORD_URL = "https://discord.gg/2TkZbBRPW";
 
 const GITHUB_DISCUSSIONS_URL =
   "https://github.com/johnpooch/diplicity-react/discussions";


### PR DESCRIPTION
Replace channel-specific link with the public invite link.

Previous link was to a channel - I 'reshared' it when I moved the discord link because I heard a report it was broken, but didn't know how discord worked. Worked on my end every time :D