### PR TITLE
Fix N+1 query explosion in shadow-mode phase converter

### DIFF
--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -49,6 +49,20 @@ class PhaseQuerySet(models.QuerySet):
             "phase_states__orders__resolution",
         )
 
+    def with_canonical_state_data(self):
+        return self.prefetch_related(
+            "units__nation",
+            "units__province",
+            "units__dislodged_by__province__parent",
+            "supply_centers__nation",
+            "supply_centers__province",
+            "phase_states__member__nation",
+            "phase_states__orders__source",
+            "phase_states__orders__target",
+            "phase_states__orders__aux",
+            "phase_states__orders__named_coast",
+        )
+
     def filter_due_phases(self):
         deadline_passed = (
             Q(scheduled_resolution__isnull=False)
@@ -76,6 +90,9 @@ class PhaseManager(models.Manager):
 
     def with_adjudication_data(self):
         return self.get_queryset().with_adjudication_data()
+
+    def with_canonical_state_data(self):
+        return self.get_queryset().with_canonical_state_data()
 
     def filter_due_phases(self):
         return self.get_queryset().filter_due_phases()

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -9,7 +9,7 @@ from django.db import connection
 from datetime import timedelta
 from unittest.mock import patch, Mock
 from rest_framework import status
-from common.constants import PhaseStatus, PhaseType, OrderType, UnitType, GameStatus, DeadlineMode
+from common.constants import PhaseStatus, PhaseType, OrderType, UnitType, GameStatus, DeadlineMode, ProvinceType
 from game.models import Game
 from .models import Phase, PhaseState
 from .serializers import PhaseStateSerializer
@@ -3035,3 +3035,95 @@ class TestPhaseToCanonicalGameState:
         # A fleet build on a multi-coast province addresses the coast as its source.
         assert orders_by_unit_type["Fleet"]["source"] == "stp/nc"
         assert orders_by_unit_type["Army"]["source"] == "edi"
+
+
+class TestPhaseToCanonicalGameStatePerformance:
+
+    def _game_with_members(self, variant, primary_user, secondary_user):
+        game = Game.objects.create(
+            name="Converter Perf Game", variant=variant, status=GameStatus.ACTIVE
+        )
+        england = Member.objects.create(
+            game=game,
+            user=primary_user,
+            nation=Nation.objects.get(name="England", variant=variant),
+        )
+        france = Member.objects.create(
+            game=game,
+            user=secondary_user,
+            nation=Nation.objects.get(name="France", variant=variant),
+        )
+        return game, england, france
+
+    def _build_phase(self, variant, game, england, france, units_per_nation):
+        provinces = [
+            p
+            for p in variant.provinces.all().order_by("province_id")
+            if p.type != ProvinceType.NAMED_COAST
+        ]
+        phase = Phase.objects.create(
+            game=game,
+            variant=variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        england_state = phase.phase_states.create(member=england)
+        france_state = phase.phase_states.create(member=france)
+        assignments = [
+            (england.nation, england_state, provinces[:units_per_nation]),
+            (
+                france.nation,
+                france_state,
+                provinces[units_per_nation : units_per_nation * 2],
+            ),
+        ]
+        for nation, phase_state, nation_provinces in assignments:
+            for province in nation_provinces:
+                phase.units.create(
+                    type=UnitType.ARMY, nation=nation, province=province
+                )
+                phase.supply_centers.create(nation=nation, province=province)
+                phase_state.orders.create(
+                    source=province, order_type=OrderType.HOLD
+                )
+        return phase
+
+    def _count_queries(self, phase):
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            phase_to_canonical_game_state(phase)
+        return len(connection.queries)
+
+    @pytest.mark.django_db
+    def test_query_count_small_game(
+        self, classical_variant, primary_user, secondary_user
+    ):
+        game, england, france = self._game_with_members(
+            classical_variant, primary_user, secondary_user
+        )
+        phase = self._build_phase(classical_variant, game, england, france, 3)
+
+        assert self._count_queries(phase) == 12
+
+    @pytest.mark.django_db
+    def test_query_count_does_not_scale_with_units_and_orders(
+        self, classical_variant, primary_user, secondary_user
+    ):
+        game, england, france = self._game_with_members(
+            classical_variant, primary_user, secondary_user
+        )
+        small_phase = self._build_phase(classical_variant, game, england, france, 3)
+        small_count = self._count_queries(small_phase)
+
+        large_game, large_england, large_france = self._game_with_members(
+            classical_variant, primary_user, secondary_user
+        )
+        large_phase = self._build_phase(
+            classical_variant, large_game, large_england, large_france, 15
+        )
+        large_count = self._count_queries(large_phase)
+
+        assert small_count == large_count

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -433,6 +433,7 @@ def _canonical_order(order, phase_type):
 
 
 def phase_to_canonical_game_state(phase):
+    phase = type(phase).objects.with_canonical_state_data().get(pk=phase.pk)
     return {
         "phase": {
             "season": phase.season,

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -210,6 +210,20 @@ class TestVariantToCanonicalDict:
             deserialize_variant(canonical)
 
     @pytest.mark.django_db
+    def test_query_count_does_not_scale_with_variant_size(self, classical_variant):
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            variant_to_canonical_dict(Variant.objects.get(pk="italy-vs-germany"))
+        small_count = len(connection.queries)
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            variant_to_canonical_dict(Variant.objects.get(pk="classical"))
+        large_count = len(connection.queries)
+
+        assert small_count == large_count == 6
+
+    @pytest.mark.django_db
     def test_classical_structure(self, classical_variant):
         canonical = variant_to_canonical_dict(classical_variant)
 


### PR DESCRIPTION
## What changed

PR #464 wired the shadow-mode adjudication harness into `adjudication.service.resolve()`, which calls `phase_to_canonical_game_state(phase)` on every phase resolution. The converter walked `phase.units`, `phase.supply_centers`, and `phase.phase_states -> orders` with no prefetching, reading FK relations (`nation`, `province`, `dislodged_by`, `parent`, and order `source`/`target`/`aux`/`named_coast`/`nation`) per row. That is an N+1 across several models, and the query count scaled with the number of units and orders in the phase.

- Added `PhaseQuerySet.with_canonical_state_data()` (plus the manager passthrough) that prefetches exactly the relations the converter reads. `order.nation` is a property resolving `phase_state.member.nation`, so it is covered by prefetching `phase_states__member__nation` rather than a non-existent `orders__nation` relation.
- `phase_to_canonical_game_state` now re-fetches the phase through that queryset, so the optimization holds regardless of how the caller obtained the phase (scheduled resolution, manual resolution, or a direct test call).

## Query counts

`phase_to_canonical_game_state`, measured with the `connection.queries` pattern, for a phase with 6 units/orders vs 30:

| | before | after |
|---|---|---|
| small (6 units, 6 orders) | 39 | 12 |
| large (30 units, 30 orders) | 159 | 12 |

The count no longer scales with unit/order count.

## variant_to_canonical_dict

Investigated as a suspect and found safe: it builds `nation_id_by_pk` / `province_id_by_pk` maps and reads raw FK id columns (`unit.nation_id`, `unit.province_id`), so there are no per-row queries. Its count is a constant 6 for both `italy-vs-germany` and `classical`. No change made; a regression-guard test locks the constant count.

One observation, not fixed here: when the variant is not prefetched, `variant.template_phase` falls back to `variant.phases.all()`, which loads every phase of every game on that variant in a single query. That is a row-volume cost, not a query-count regression, and is out of scope for this N+1 fix.

## Remaining shadow-mode cost

This fix addresses the query side only. The shadow harness also runs the full Python `Engine().adjudicate()` on every resolution — that is CPU cost, unaffected by prefetching. If resolution is still slow after this change, the engine compute should be profiled and addressed separately.

## Tests

- `phase/tests.py::TestPhaseToCanonicalGameStatePerformance` — small-game count is constant (12) and does not scale between a 6-unit and a 30-unit phase. Fails on `main` (39 ≠ 159).
- `variant/tests.py::TestVariantToCanonicalDict::test_query_count_does_not_scale_with_variant_size` — locks the constant count of 6.
- Existing `TestPhaseToCanonicalGameState` and `TestVariantToCanonicalDict` round-trip tests still pass, confirming converter output is unchanged.

Closes #467