### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
Bumps `packages/web/package.json` version from 1.2.0 to 1.3.0. Fastlane reads this as `MARKETING_VERSION` for the next iOS build; the build number is auto-generated.

<sub>Generated with Claude Code</sub>