### PR TITLE
Fix N+1 in Variant.template_phase non-prefetch fallback

### DIFF
--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -127,11 +127,7 @@ class Variant(BaseModel):
         if hasattr(self, "template_phases"):
             return self.template_phases[0] if self.template_phases else None
 
-        # Fall back to database query if not prefetched
-        for phase in self.phases.all():
-            if phase.game is None and phase.status == PhaseStatus.TEMPLATE:
-                return phase
-        return None
+        return self.phases.filter(game__isnull=True, status=PhaseStatus.TEMPLATE).first()
 
 
 class VariantSvg(BaseModel):

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -224,6 +224,24 @@ class TestVariantToCanonicalDict:
         assert small_count == large_count == 6
 
     @pytest.mark.django_db
+    def test_query_count_does_not_scale_with_phase_history(self, classical_variant):
+        from common.constants import GameStatus
+        from game.models import Game
+
+        for i in range(5):
+            game = Game.objects.create(variant=classical_variant, name=f"g{i}", status=GameStatus.ACTIVE)
+            Phase.objects.create(
+                game=game, variant=classical_variant, ordinal=1,
+                season="Spring", year=1901, type="Movement", status=PhaseStatus.ACTIVE,
+            )
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            variant_to_canonical_dict(Variant.objects.get(pk="classical"))
+
+        assert len(connection.queries) == 6
+
+    @pytest.mark.django_db
     def test_classical_structure(self, classical_variant):
         canonical = variant_to_canonical_dict(classical_variant)
 


### PR DESCRIPTION
The non-prefetch fallback in `Variant.template_phase` walks `variant.phases.all()` and accesses `phase.game` on each row, firing a per-row `Game` lookup. Shadow mode now calls `variant_to_canonical_dict` on every adjudication, so in production this fans out to ~780 `game_game` SELECTs and ~15s of wall-clock per phase resolve — visible in [this Honeycomb trace](https://ui.honeycomb.io/diplicity-react/environments/diplicity/datasets/diplicity-service/result/96CchLPmbNJ/trace?source=query&span=6c3ef203db4291c5&trace_id=b793aaebb1de4a04dc777f66eb0b79d4) as 798 child spans under `adjudication.resolve`.

Replace the Python-side loop with a single filtered `.first()` so the template row is asked for directly. Adds a regression-guard test that creates several non-template phases and asserts the canonical dict still hits exactly 6 queries.

<sub>Generated with Claude Code</sub>