### PR TITLE
Fix SVG fill inheritance for maps with root fill="none"

### DIFF
--- a/packages/web/src/components/InteractiveMap/dsvgParser.test.ts
+++ b/packages/web/src/components/InteractiveMap/dsvgParser.test.ts
@@ -73,4 +73,22 @@ describe("parseDsvg", () => {
       parseDsvg('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
     ).toThrow(/viewBox/);
   });
+
+  test("captures root fill when present", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" fill="none">
+      <g id="background"></g>
+      <g id="provinces" style="display:none"></g>
+      <g id="named-coasts" style="display:none"></g>
+      <g id="unit-positions" style="display:none"></g>
+      <g id="supply-centers" style="display:none"></g>
+      <g id="province-names"></g>
+      <g id="borders"></g>
+      <g id="foreground"></g>
+    </svg>`;
+    expect(parseDsvg(svg).rootFill).toBe("none");
+  });
+
+  test("rootFill is null when root has no fill attribute", () => {
+    expect(parseDsvg(TOY_DSVG).rootFill).toBeNull();
+  });
 });

--- a/packages/web/src/components/InteractiveMap/dsvgParser.ts
+++ b/packages/web/src/components/InteractiveMap/dsvgParser.ts
@@ -9,6 +9,7 @@ export type ViewBox = {
 
 export type ParsedDsvg = {
   viewBox: ViewBox;
+  rootFill: string | null;
   defs: string;
   background: string;
   provinceNames: string;
@@ -105,6 +106,7 @@ export const parseDsvg = (svg: string): ParsedDsvg => {
 
   return {
     viewBox: parseViewBox(root),
+    rootFill: root.getAttribute("fill"),
     defs: collectDefs(root),
     background: layerMarkup(root, "background"),
     provinceNames: layerMarkup(root, "province-names"),

--- a/packages/web/src/components/InteractiveMap/mapRenderer.ts
+++ b/packages/web/src/components/InteractiveMap/mapRenderer.ts
@@ -657,9 +657,10 @@ export class DiplicityMap {
   }
 
   render(state: RenderState = {}): string {
-    const { viewBox, defs, background, provinceNames, borders, foreground } =
+    const { viewBox, rootFill, defs, background, provinceNames, borders, foreground } =
       this.parsed;
     const viewBoxAttr = `${viewBox.minX} ${viewBox.minY} ${viewBox.width} ${viewBox.height}`;
+    const fillAttr = rootFill !== null ? ` fill="${rootFill}"` : "";
     const fills = provinceFillsLayer(
       new Map([
         ...this.parsed.provincePaths,
@@ -672,7 +673,7 @@ export class DiplicityMap {
     const orders = ordersLayer(this.parsed.unitPositions, state);
 
     const parts = [
-      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBoxAttr}">`,
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBoxAttr}"${fillAttr}>`,
       defs,
     ];
     if (fills.includes("highlightedStripes")) {


### PR DESCRIPTION
## Summary

- SVGs exported by Figma (e.g. Spice Islands) set `fill="none"` on the root `<svg>` element; paths without explicit fills rely on inheriting that value
- The map renderer reassembled a new `<svg>` without forwarding that attribute, so those paths inherited SVG's default fill (`black`), causing dark blobs across the map
- Fix: `dsvgParser` now captures `rootFill` from the source SVG root; `mapRenderer` forwards it onto the rendered `<svg>` tag

## Test plan

- [ ] All existing `dsvgParser` and `mapRenderer` tests pass
- [ ] Two new `dsvgParser` tests cover the `rootFill` field (present and absent)
- [ ] Load the Spice Islands variant in-game and verify the map renders without black fills on terrain paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)