### PR TITLE
Promote map SVG to GPU compositing layer to reduce Android Chrome flicker

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -152,6 +152,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = (props) => {
     width: props.style?.width ?? viewBox.width,
     height: props.style?.height ?? viewBox.height,
     display: "block",
+    transform: "translateZ(0)",
     ...props.style,
   };
 

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -186,7 +186,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
       >
-        <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
+        <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }} contentStyle={{ willChange: "transform" }}>
           <InteractiveMap
             ref={svgRef}
             {...interactiveMapProps}


### PR DESCRIPTION
## Summary

- Adds `will-change: transform` to the `TransformComponent` content wrapper in `InteractiveMapZoomWrapper`
- Adds `transform: translateZ(0)` to the SVG element in `InteractiveMap`

## Problem

On Android Chrome, maps like Spice Islands flicker white during zoom/scroll. The root cause is that Chrome demotes the compositing layer under GPU memory pressure (large SVGs with embedded base64 PNGs are expensive to keep GPU-resident), then repaints from scratch — showing white tiles before the SVG is re-rasterized.

## Fix

These two hints together tell Chrome to promote and keep the map in its own GPU compositing layer across frames:
- `will-change: transform` on the zoom/pan content wrapper (signals upcoming transforms)
- `translateZ(0)` on the SVG itself (forces a separate compositing layer for the SVG)

## Test plan

- [ ] Open a game with a map on Android Chrome and zoom/scroll — verify reduced or eliminated white flicker
- [ ] Verify maps still render and interact correctly on desktop browsers
- [ ] Verify zoom/pan behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)