### PR TITLE
Fix N+1 query in clone-to-sandbox

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Diplicity React - Release Notes
 
+## Faster "Clone to Sandbox" (May 24, 2026)
+
+**Release Date:** May 24, 2026
+
+### Improvement: Cloning a game to a sandbox is quicker
+
+Cloning a game into a sandbox copied the board one database lookup at a time, which added up to hundreds of queries and a noticeable wait. The copy now loads the units and supply centers in two queries instead, so the sandbox opens faster.
+
 ## Sandbox Games for Uploaded Variants (May 21, 2026)
 
 **Release Date:** May 21, 2026

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -255,7 +255,7 @@ class GameManager(models.Manager):
                 province=unit.province,
                 dislodged=unit.dislodged,
             )
-            for unit in source_phase.units.all()
+            for unit in source_phase.units.select_related("nation", "province")
         ]
         Unit.objects.bulk_create(units_to_create)
 
@@ -265,7 +265,7 @@ class GameManager(models.Manager):
                 nation=sc.nation,
                 province=sc.province,
             )
-            for sc in source_phase.supply_centers.all()
+            for sc in source_phase.supply_centers.select_related("nation", "province")
         ]
         SupplyCenter.objects.bulk_create(supply_centers_to_create)
 

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -8,9 +8,11 @@ from django.utils import timezone
 from datetime import time, timedelta
 from zoneinfo import ZoneInfo
 from rest_framework import status
-from common.constants import PhaseStatus, PhaseType, GameStatus, NationAssignment, MovementPhaseDuration, DeadlineMode, PhaseFrequency
+from common.constants import PhaseStatus, PhaseType, GameStatus, NationAssignment, MovementPhaseDuration, DeadlineMode, PhaseFrequency, UnitType
 
 from phase.models import Phase
+from nation.models import Nation
+from province.models import Province
 from user_profile.models import UserProfile
 from .models import Game
 
@@ -2627,6 +2629,41 @@ class TestGameCloneToSandbox:
         url = reverse(clone_to_sandbox_viewname, args=["non-existent-game"])
         response = authenticated_client.post(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_clone_from_phase_query_count_independent_of_unit_count(self, classical_variant):
+        nation = Nation.objects.filter(variant=classical_variant).first()
+        provinces = list(Province.objects.filter(variant=classical_variant)[:20])
+
+        def build_source_phase(name, count):
+            game = Game.objects.create(name=name, variant=classical_variant, status=GameStatus.ACTIVE)
+            phase = game.phases.create(
+                variant=classical_variant,
+                season="Spring",
+                year=1901,
+                type=PhaseType.MOVEMENT,
+                status=PhaseStatus.ACTIVE,
+                ordinal=1,
+            )
+            for province in provinces[:count]:
+                phase.units.create(type=UnitType.ARMY, nation=nation, province=province)
+                phase.supply_centers.create(nation=nation, province=province)
+            return phase
+
+        small_phase = build_source_phase("Small Source", 2)
+        large_phase = build_source_phase("Large Source", 15)
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            Game.objects.clone_from_phase(small_phase, name="Small Source (Sandbox)")
+        small_query_count = len(connection.queries)
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            Game.objects.clone_from_phase(large_phase, name="Large Source (Sandbox)")
+        large_query_count = len(connection.queries)
+
+        assert large_query_count == small_query_count
 
 
 pause_viewname = "game-pause"


### PR DESCRIPTION
The `POST /game/{game_id}/clone-to-sandbox/` endpoint was slow because `GameManager.clone_from_phase` iterated the source phase's units and supply centers without `select_related`. Each `.nation` and `.province` access fired its own query, producing ~98 single-row lookups per clone — about 46% of the request in a production Honeycomb trace (`c0618fdafda74b57e1ff4e5a0b9a13cc`: 922ms of SELECTs out of a 1.26s request).

Adding `select_related("nation", "province")` to both loops collapses those 98 queries into 2, with no behavioural change. This matches the existing inline idiom (`phase/models.py:526`).

A regression test (`test_clone_from_phase_query_count_independent_of_unit_count`) clones a 2-row and a 15-row source phase and asserts equal query counts, so the count can no longer scale with board size. Verified it fails when the `select_related` is removed and passes with it; all existing `TestGameCloneToSandbox` tests still pass.

Not addressed here: on large variants the synchronous adjudication `get_options()` can still exceed the gunicorn worker timeout (Sentry `DIPLICITY-API-7E`). That's a separate problem to be tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)