### PR TITLE
Add Procrastinate background-task worker (walking skeleton)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # It includes both frontend (Node.js) and backend (Python) dependencies.
 
 # Base image with Node.js and Python
-FROM node:24.15.0-bullseye-slim
+FROM node:24.15.0-bookworm-slim
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,33 @@ services:
     depends_on:
       - db
 
+  worker:
+    container_name: diplicity-worker
+    build:
+      context: ./service
+      dockerfile: Dockerfile
+      target: development
+    working_dir: /app/service
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      - DJANGO_DEBUG=True
+      - ROOT_LOG_LEVEL=INFO
+      - DJANGO_LOG_LEVEL=INFO
+      - DB_LOG_LEVEL=WARNING
+      - GAME_LOG_LEVEL=INFO
+      - PROCESS_ROLE=worker
+    command: >
+      sh -c "python manage.py procrastinate worker"
+    restart: on-failure
+    networks:
+      - diplicity-network
+    depends_on:
+      - db
+      - service
+
 networks:
   diplicity-network:
     name: diplicity-network

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,7 +9,7 @@
         "**/dist",
         "**/build"
     ],
-    "pythonVersion": "3.9",
+    "pythonVersion": "3.12",
     "pythonPlatform": "Darwin",
     "typeCheckingMode": "basic",
     "useLibraryCodeForTypes": true,

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage: Install dependencies and set up the app
-FROM python:3.9-slim AS base
+FROM python:3.12-slim AS base
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -2,7 +2,14 @@
 
 set -e
 
-echo "Starting entrypoint script..."
+PROCESS_ROLE="${PROCESS_ROLE:-web}"
+
+echo "Starting entrypoint script (role: $PROCESS_ROLE)..."
+
+if [ "$PROCESS_ROLE" = "worker" ]; then
+    echo "Starting Procrastinate worker..."
+    exec python manage.py procrastinate worker
+fi
 
 echo "Running database migrations..."
 if python manage.py migrate; then

--- a/service/health/tasks.py
+++ b/service/health/tasks.py
@@ -1,0 +1,11 @@
+import logging
+
+from procrastinate.contrib.django import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.periodic(cron="*/5 * * * *")
+@app.task
+def heartbeat(timestamp: int):
+    logger.info(f"Procrastinate worker heartbeat (scheduled for {timestamp})")

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "rest_framework.authtoken",
+    "procrastinate.contrib.django",
     "game",
     "member",
     "order",

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -11,6 +11,7 @@ cryptography>=3.4.0,<4.0
 PyJWT>=2.0.0,<3.0
 fcm-django>=2.2.1,<3.0
 firebase-admin>=7.0.0,<8.0
+procrastinate[django]>=3.8,<4.0
 requests>=2.32.0,<3.0
 dj-database-url>=2.1.0,<3.0
 whitenoise>=6.0.0


### PR DESCRIPTION
Introduces Procrastinate (Postgres-backed task queue) as the foundation for moving work off the synchronous request path. This is the walking skeleton — infrastructure plus one self-firing heartbeat task. No adjudication or notification behaviour is moved yet; those follow in separate PRs.

## Changes
- Bump the service runtime to Python 3.12. 3.9 is end-of-life, and Procrastinate requires >=3.10. The codegen image moves to a Debian bookworm base for the same reason.
- Add `procrastinate[django]` and `procrastinate.contrib.django` to `INSTALLED_APPS`. Its migrations create the queue tables through the existing `migrate` step.
- `entrypoint.sh` dispatches on `PROCESS_ROLE`: unset/`web` runs gunicorn, `worker` runs `manage.py procrastinate worker`. Both roles share one image, so the worker service is provisioned by setting a single env var.
- A 5-minute heartbeat periodic task in `health/tasks.py` gives a liveness signal and proves the worker loop end to end.
- A local `worker` service in docker-compose for dev parity.

## Deployment
The web service owns migrations; the worker role skips them to avoid two services migrating concurrently on deploy. The worker depends on the Procrastinate tables, so on first rollout it should come up after the web service has migrated (it self-heals via restart otherwise). The Railway worker service is added separately after this merges.

Verified locally: image builds on 3.12, migrations apply, `procrastinate healthchecks` passes, the heartbeat task is discovered and executes (both manually deferred and via the periodic scheduler), and the existing suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)