### PR TITLE
Fix gunicorn crash on Python 3.12 (pkg_resources removed)

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -4,7 +4,7 @@ django-cors-headers>=3.7.0,<4.0
 djangorestframework-camel-case>=1.2.0,<2.0
 djangorestframework-simplejwt>=5.0.0,<6.0
 drf-spectacular>=0.25.0,<1.0
-gunicorn>=20.0.0,<21.0
+gunicorn>=23.0.0,<24.0
 psycopg2-binary
 google-auth>=2.0.0,<3.0
 cryptography>=3.4.0,<4.0


### PR DESCRIPTION
The web service has been crash-looping since the Python 3.12 bump merged (#486). Root cause:

```
ModuleNotFoundError: No module named 'pkg_resources'
  File ".../gunicorn/util.py", line 25, in <module>
    import pkg_resources
```

`gunicorn` 20.x imports `pkg_resources` at startup. Python 3.12 no longer bundles `setuptools`, and modern setuptools (81+) dropped `pkg_resources` entirely — so adding setuptools does not fix it. gunicorn 23.x switched to `importlib.metadata` and boots cleanly on 3.12.

This path was missed in #486's verification: migrations, the procrastinate worker, and pytest all run without invoking gunicorn, so the web boot was never exercised locally. Confirmed the fix by running gunicorn from the rebuilt image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)