### PR TITLE
Run a single staging environment and stop clobbering PR deploys

### DIFF
--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -14,6 +14,7 @@ env:
   PROD_ENV_ID: 0372f6a0-88ab-4a58-b472-16789135ad71
   DJANGO_SERVICE_ID: 5f342326-a52a-4c40-8bc1-910588628f8a
   POSTGRES_SERVICE_ID: 6ae5f2bc-1398-4ad2-a08f-2151ca1024f2
+  WORKER_SERVICE_ID: 54286c74-c5c3-4bcc-95b4-817cb3eeefa8
 
 jobs:
   deploy-staging:
@@ -35,6 +36,40 @@ jobs:
               issue_number: context.payload.pull_request.number,
               name: 'deploy-to-staging'
             });
+
+      - name: Tear down other staging environments
+        continue-on-error: true
+        run: |
+          # Keep a single staging environment at a time: delete every other
+          # staging-pr-* environment before deploying this PR. Never touches
+          # production or the current PR's own environment.
+          KEEP_NAME="staging-pr-${PR_NUMBER}"
+
+          QUERY_PAYLOAD=$(jq -n --arg projectId "$PROJECT_ID" \
+            '{query: ("{ project(id: \"" + $projectId + "\") { environments { edges { node { id name } } } } }")}')
+
+          RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+            -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$QUERY_PAYLOAD")
+
+          echo "$RESULT" | jq -r '.data.project.environments.edges[].node | "\(.id) \(.name)"' | while read -r EID ENAME; do
+            case "$ENAME" in
+              staging-pr-*) ;;
+              *) continue ;;
+            esac
+            if [ "$EID" = "$PROD_ENV_ID" ] || [ "$ENAME" = "$KEEP_NAME" ]; then
+              continue
+            fi
+            echo "Deleting stale staging environment: $ENAME ($EID)"
+            DEL_PAYLOAD=$(jq -n --arg envId "$EID" \
+              '{query: "mutation($id: String!) { environmentDelete(id: $id) }", variables: {id: $envId}}')
+            curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$DEL_PAYLOAD" > /dev/null
+          done
+          echo "Teardown of other staging environments complete."
 
       - name: Find or create staging environment
         id: create_env
@@ -89,6 +124,34 @@ jobs:
           echo "env_id=$ENV_ID" >> "$GITHUB_OUTPUT"
           echo "env_name=$ENV_NAME" >> "$GITHUB_OUTPUT"
           echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Disable auto-deploy on staging services
+        env:
+          ENV_ID: ${{ steps.create_env.outputs.env_id }}
+        run: |
+          # Forked service instances inherit auto-deploy on main, so every push
+          # to main redeploys all staging environments and overwrites the PR
+          # code. Turn it off so this environment stays pinned to the PR's SHA.
+          if [ "$ENV_ID" = "$PROD_ENV_ID" ]; then
+            echo "ERROR: ENV_ID matches PROD_ENV_ID — refusing to change production auto-deploy."
+            exit 1
+          fi
+
+          for SVC in "$DJANGO_SERVICE_ID" "$WORKER_SERVICE_ID"; do
+            PAYLOAD=$(jq -n \
+              --arg projectId "$PROJECT_ID" \
+              --arg envId "$ENV_ID" \
+              --arg serviceId "$SVC" \
+              '{
+                query: "mutation($input: ServiceInstanceAutoDeployUpdateInput!) { serviceInstanceAutoDeployUpdate(input: $input) { enabled } }",
+                variables: { input: { projectId: $projectId, environmentId: $envId, serviceId: $serviceId, enabled: false } }
+              }')
+            RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD")
+            echo "Auto-deploy update for $SVC: $RESULT"
+          done
 
       - name: Get or create staging domain
         id: domain
@@ -246,6 +309,63 @@ jobs:
           echo "Waiting 20s for the container to terminate and release connections..."
           sleep 20
 
+      - name: Stop staging worker before clone
+        env:
+          ENV_ID: ${{ steps.create_env.outputs.env_id }}
+        run: |
+          # The worker holds a DB connection and crash-loops if the schema is
+          # dropped under it during the clone, so stop it first. Best-effort.
+          if [ "$ENV_ID" = "$PROD_ENV_ID" ]; then
+            echo "ERROR: ENV_ID matches PROD_ENV_ID — refusing to stop production deployments."
+            exit 1
+          fi
+
+          LIST_PAYLOAD=$(jq -n \
+            --arg projectId "$PROJECT_ID" \
+            --arg envId "$ENV_ID" \
+            --arg serviceId "$WORKER_SERVICE_ID" \
+            '{
+              query: "query($input: DeploymentListInput!) { deployments(input: $input, first: 1) { edges { node { id status } } } }",
+              variables: { input: { projectId: $projectId, environmentId: $envId, serviceId: $serviceId } }
+            }')
+
+          for i in $(seq 1 30); do
+            RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$LIST_PAYLOAD")
+            STATUS=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.status // empty')
+            DEP_ID=$(echo "$RESULT" | jq -r '.data.deployments.edges[0].node.id // empty')
+
+            case "$STATUS" in
+              SUCCESS)
+                STOP_PAYLOAD=$(jq -n --arg id "$DEP_ID" \
+                  '{query: "mutation($id: String!) { deploymentStop(id: $id) }", variables: {id: $id}}')
+                STOP_RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+                  -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  -d "$STOP_PAYLOAD")
+                echo "Worker stop response: $STOP_RESULT"
+                if [ "$(echo "$STOP_RESULT" | jq -r '.data.deploymentStop // empty')" = "true" ]; then
+                  echo "Worker stopped."
+                  break
+                fi
+                echo "Attempt $i/30: stop not accepted yet, retrying in 10s..."
+                ;;
+              CRASHED|FAILED|REMOVED|REMOVING|SKIPPED|SLEEPING|"")
+                echo "Worker status is '${STATUS:-none}' — nothing to stop."
+                break
+                ;;
+              *)
+                echo "Attempt $i/30: worker status is $STATUS, waiting 10s..."
+                ;;
+            esac
+            sleep 10
+          done
+
+          echo "Waiting 15s for the worker to release its connection..."
+          sleep 15
+
       - name: Clone production database to staging
         env:
           PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
@@ -301,21 +421,70 @@ jobs:
         env:
           ENV_ID: ${{ steps.create_env.outputs.env_id }}
         run: |
-          PAYLOAD=$(jq -n \
+          deploy_service() {
+            local SERVICE_ID="$1" SERVICE_NAME="$2"
+            local PAYLOAD RESULT
+            PAYLOAD=$(jq -n \
+              --arg envId "$ENV_ID" \
+              --arg serviceId "$SERVICE_ID" \
+              --arg sha "$COMMIT_SHA" \
+              '{
+                query: "mutation($envId: String!, $serviceId: String!, $sha: String) { serviceInstanceDeployV2(environmentId: $envId, serviceId: $serviceId, commitSha: $sha) }",
+                variables: { envId: $envId, serviceId: $serviceId, sha: $sha }
+              }')
+            RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD")
+            echo "$SERVICE_NAME deploy triggered: $RESULT"
+          }
+
+          # Deploy Django first: its migrations install the Procrastinate schema
+          # the worker needs. Deploy the worker only once Django is up.
+          deploy_service "$DJANGO_SERVICE_ID" "diplicity-react"
+
+          STATUS_PAYLOAD=$(jq -n \
+            --arg projectId "$PROJECT_ID" \
             --arg envId "$ENV_ID" \
             --arg serviceId "$DJANGO_SERVICE_ID" \
-            --arg sha "$COMMIT_SHA" \
             '{
-              query: "mutation($envId: String!, $serviceId: String!, $sha: String) { serviceInstanceDeployV2(environmentId: $envId, serviceId: $serviceId, commitSha: $sha) }",
-              variables: { envId: $envId, serviceId: $serviceId, sha: $sha }
+              query: "query($input: DeploymentListInput!) { deployments(input: $input, first: 1) { edges { node { status } } } }",
+              variables: { input: { projectId: $projectId, environmentId: $envId, serviceId: $serviceId } }
             }')
 
-          RESULT=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
-            -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
+          # Let the new deployment register as the latest before polling, so we
+          # don't read the previous (now-stopped) deployment's status.
+          sleep 20
 
-          echo "Deploy triggered: $RESULT"
+          echo "Waiting for diplicity-react to migrate and reach SUCCESS..."
+          DJANGO_OK=false
+          for i in $(seq 1 40); do
+            STATUS=$(curl -s -X POST "$RAILWAY_API_ENDPOINT" \
+              -H "Authorization: Bearer $RAILWAY_ACCOUNT_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$STATUS_PAYLOAD" | jq -r '.data.deployments.edges[0].node.status // empty')
+            case "$STATUS" in
+              SUCCESS)
+                echo "diplicity-react is up."
+                DJANGO_OK=true
+                break
+                ;;
+              CRASHED|FAILED)
+                echo "diplicity-react deployment is $STATUS — skipping worker deploy."
+                break
+                ;;
+              *)
+                echo "Attempt $i/40: diplicity-react status is '${STATUS:-pending}', waiting 15s..."
+                sleep 15
+                ;;
+            esac
+          done
+
+          if [ "$DJANGO_OK" = "true" ]; then
+            deploy_service "$WORKER_SERVICE_ID" "diplicity-worker"
+          else
+            echo "WARNING: diplicity-react did not reach SUCCESS; worker not deployed."
+          fi
 
       - name: Comment on PR with staging URL
         env:


### PR DESCRIPTION
Reworks the PR staging workflow to fix three problems found while investigating crashed staging environments (see #495).

## Single environment at a time

A new step deletes every other `staging-pr-*` environment before deploying the current PR. Previously environments only got torn down when their PR closed, so they accumulated — 9 were alive at once. Production and the current PR's own environment are never touched.

## Stop main pushes from clobbering staging

Forked service instances inherit auto-deploy on `main`. The workflow deployed the PR's SHA once, but every later push to `main` redeployed all staging environments and overwrote the PR code with `main`'s HEAD — after any merge, staging stopped testing the PR. The workflow now disables auto-deploy on the staging `diplicity-react` and `diplicity-worker` instances, so the environment stays pinned to the PR commit.

## Stop the worker crashing during the clone

The clone step does `DROP SCHEMA public CASCADE` but only stopped `diplicity-react` first. The worker kept running, lost the Procrastinate schema mid-flight, and crash-looped (`function procrastinate_prune_stalled_workers_v1 does not exist`). The worker is now stopped before the clone and deployed only after `diplicity-react` has migrated and come up.

## Not covered here

- The trigger cron services (`trigger-phase-resolve`, `trigger-deadline-warnings`) curl the hardcoded production URL, so in staging they hit production instead of staging. Tracked as a follow-up in #495.
- The `variant_variant already exists` migration-history failure on a fresh prod clone (same recurring production bug).

The existing 9 staging environments were already deleted manually. This needs a live run (add `deploy-to-staging` to a PR) to validate end to end.