### PR TITLE
Fix codegen Dockerfile (Debian externally-managed Python)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,12 @@ WORKDIR /app
 # Copy Python configuration files
 COPY ./service/requirements.txt ./service/dev_requirements.txt ./service/pyproject.toml /app/
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt -r dev_requirements.txt
+# Install Python dependencies.
+# `node:24.15.0-bookworm-slim` ships a PEP 668 "externally-managed" Python, so
+# system pip refuses installs without an explicit override. This is a single-purpose
+# ephemeral container that runs spectacular + orval and exits, so installing into
+# the system Python is fine — no venv required.
+RUN pip install --no-cache-dir --break-system-packages -r requirements.txt -r dev_requirements.txt
 
 # Install Node.js dependencies
 COPY ./packages/web/package.json ./packages/web/package-lock.json /app/packages/web/


### PR DESCRIPTION
The `codegen` image is based on `node:24.15.0-bookworm-slim`, which ships a PEP 668 "externally-managed" Python. System `pip` refuses installs without an explicit override, so `docker compose build codegen` has been failing at the `requirements.txt` step:

```
error: externally-managed-environment
× This environment is externally managed
...
You can override this, at the risk of breaking your Python installation
or OS, by passing --break-system-packages.
```

Pass `--break-system-packages` to `pip`. The codegen container is single-purpose and ephemeral (runs `spectacular` + `orval` then exits), so a venv would add PATH/activation overhead without benefit. The `service` container is unaffected — it uses `service/Dockerfile` (`python:3.12-slim`), which does not enforce PEP 668.

Verified:
- `docker compose build codegen` succeeds.
- `docker compose run --rm --no-deps codegen` regenerates `service/openapi-schema.yaml` and `packages/web/src/api/generated/endpoints.ts` end-to-end; idempotent (no diff against the committed files).
- `service` container still builds and imports Django fine.