### PR TITLE
Add https://localhost to CORS allowed origins (Android WebView)

### DIFF
--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -112,7 +112,7 @@ MIDDLEWARE = [
 ]
 
 CORS_ALLOWED_ORIGINS = os.getenv(
-    "DJANGO_CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173,http://diplicity-web:5173,capacitor://localhost"
+    "DJANGO_CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173,http://diplicity-web:5173,capacitor://localhost,https://localhost"
 ).split(",")
 
 CORS_ALLOW_HEADERS = [


### PR DESCRIPTION
## What

Adds `https://localhost` to the default `CORS_ALLOWED_ORIGINS` in Django settings.

## Why

The Capacitor Android WebView makes requests from the origin `https://localhost`. Without this entry, all API calls from the Android app are rejected with a CORS preflight error, making login impossible.

This is a one-line change to the default value of `DJANGO_CORS_ALLOWED_ORIGINS`. Production and staging environments that override this env var are unaffected — only local dev and Android WebView requests are impacted.

## Testing

Verified working end-to-end on Pixel 8a (debug build against local backend) — Google Sign-In, email/password login, and all API calls succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)