### PR TITLE
Add admin action to safely replace variant files

### DIFF
--- a/service/variant/admin.py
+++ b/service/variant/admin.py
@@ -1,10 +1,69 @@
+import json
+
 from django import forms
 from django.contrib import admin, messages
+from django.db import transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import path, reverse
 from lxml.etree import XMLSyntaxError
 
 from common.constants import VariantStatus
 from .models import Variant, VariantSvg
-from .utils import normalize_dsvg, validate_dsvg
+from .utils import (
+    apply_safe_replacement,
+    normalize_dsvg,
+    validate_dsvg,
+    validate_safe_replacement,
+)
+
+
+class ReplaceVariantFilesForm(forms.Form):
+    dvar = forms.FileField(label="DVAR file (JSON)")
+    dsvg = forms.FileField(label="DSVG file (SVG)")
+
+    def __init__(self, *args, variant=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.variant = variant
+        self.parsed_dvar = None
+        self.parsed_dsvg = None
+
+    def clean(self):
+        cleaned_data = super().clean()
+        dvar_upload = cleaned_data.get("dvar")
+        dsvg_upload = cleaned_data.get("dsvg")
+
+        if dvar_upload is not None:
+            try:
+                dvar_text = dvar_upload.read().decode("utf-8")
+            except UnicodeDecodeError:
+                self.add_error("dvar", "DVAR file is not valid UTF-8.")
+            else:
+                try:
+                    self.parsed_dvar = json.loads(dvar_text)
+                except json.JSONDecodeError as exc:
+                    self.add_error("dvar", f"DVAR is not valid JSON: {exc}.")
+
+        if dsvg_upload is not None:
+            try:
+                dsvg_text = dsvg_upload.read().decode("utf-8")
+            except UnicodeDecodeError:
+                self.add_error("dsvg", "DSVG file is not valid UTF-8.")
+            else:
+                try:
+                    self.parsed_dsvg = normalize_dsvg(dsvg_text)
+                except XMLSyntaxError as exc:
+                    self.add_error("dsvg", f"DSVG could not be parsed: {exc}.")
+
+        if self.parsed_dvar is not None and self.variant is not None:
+            safe_errors = validate_safe_replacement(self.variant, self.parsed_dvar)
+            if safe_errors:
+                self.add_error(
+                    "dvar",
+                    [f"{error.code}: {error.message}" for error in safe_errors],
+                )
+
+        return cleaned_data
 
 
 @admin.register(Variant)
@@ -14,6 +73,7 @@ class VariantAdmin(admin.ModelAdmin):
     search_fields = ("name", "id")
     autocomplete_fields = ("owner",)
     actions = ("publish_selected", "archive_selected", "revert_to_draft_selected")
+    change_form_template = "admin/variant/variant/change_form.html"
 
     @admin.action(description="Publish selected drafts")
     def publish_selected(self, request, queryset):
@@ -29,6 +89,70 @@ class VariantAdmin(admin.ModelAdmin):
     def revert_to_draft_selected(self, request, queryset):
         updated = queryset.exclude(status=VariantStatus.DRAFT).update(status=VariantStatus.DRAFT)
         self.message_user(request, f"Reverted {updated} variant(s) to draft.", level=messages.WARNING)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<path:object_id>/replace-files/",
+                self.admin_site.admin_view(self.replace_files_view),
+                name="variant_variant_replace_files",
+            ),
+        ]
+        return custom + urls
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        variant = self.get_object(request, object_id)
+        if variant is not None and variant.status == VariantStatus.PUBLISHED:
+            extra_context["replace_files_url"] = reverse(
+                "admin:variant_variant_replace_files", args=[object_id]
+            )
+        return super().change_view(request, object_id, form_url, extra_context)
+
+    def replace_files_view(self, request, object_id):
+        variant = get_object_or_404(Variant, pk=object_id)
+
+        if variant.status != VariantStatus.PUBLISHED:
+            self.message_user(
+                request,
+                "Safe replacement is only available for published variants.",
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(
+                reverse("admin:variant_variant_change", args=[object_id])
+            )
+
+        if request.method == "POST":
+            form = ReplaceVariantFilesForm(request.POST, request.FILES, variant=variant)
+            if form.is_valid():
+                dsvg_errors = validate_dsvg(form.parsed_dsvg, variant)
+                if dsvg_errors:
+                    for error in dsvg_errors:
+                        form.add_error("dsvg", f"{error.code}: {error.message}")
+                else:
+                    with transaction.atomic():
+                        apply_safe_replacement(variant, form.parsed_dvar, form.parsed_dsvg)
+                    self.message_user(
+                        request,
+                        f"Replaced files for variant '{variant.id}'.",
+                        level=messages.SUCCESS,
+                    )
+                    return HttpResponseRedirect(
+                        reverse("admin:variant_variant_change", args=[object_id])
+                    )
+        else:
+            form = ReplaceVariantFilesForm(variant=variant)
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": f"Replace files for {variant.name}",
+            "variant": variant,
+            "form": form,
+            "opts": self.model._meta,
+            "original": variant,
+        }
+        return render(request, "admin/variant/variant/replace_files.html", context)
 
 
 class VariantSvgAdminForm(forms.ModelForm):

--- a/service/variant/templates/admin/variant/variant/change_form.html
+++ b/service/variant/templates/admin/variant/variant/change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+    {% if replace_files_url %}
+        <li>
+            <a href="{{ replace_files_url }}" class="historylink">Replace files safely</a>
+        </li>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}

--- a/service/variant/templates/admin/variant/variant/replace_files.html
+++ b/service/variant/templates/admin/variant/variant/replace_files.html
@@ -1,0 +1,37 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<div id="content-main">
+    <p>
+        Replace the DVAR and DSVG of <strong>{{ variant.name }}</strong>
+        ({{ variant.id }}) without affecting games already using it. The new
+        files must preserve every nation_id and province_id currently in use;
+        no nations or provinces may be added or removed. Adjacency and rule
+        changes are allowed and will apply to future phase resolutions of
+        in-flight games.
+    </p>
+
+    <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <fieldset class="module aligned">
+            {% for field in form %}
+                <div class="form-row">
+                    {{ field.errors }}
+                    <div>
+                        {{ field.label_tag }}
+                        {{ field }}
+                        {% if field.help_text %}
+                            <div class="help">{{ field.help_text }}</div>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </fieldset>
+        <div class="submit-row">
+            <input type="submit" value="Replace files" class="default" />
+            <a href="{% url 'admin:variant_variant_change' variant.id %}" class="button cancel-link">Cancel</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/service/variant/tests/test_safe_replacement.py
+++ b/service/variant/tests/test_safe_replacement.py
@@ -1,0 +1,292 @@
+import copy
+
+import pytest
+
+from common.constants import VariantStatus
+from game.models import Game
+from nation.models import Nation, NationFlag
+from phase.models import Phase
+from province.models import Province
+from supply_center.models import SupplyCenter
+from unit.models import Unit
+from variant.models import Variant, VariantSvg
+from variant.utils import (
+    apply_safe_replacement,
+    create_variant_from_dvar,
+    validate_safe_replacement,
+    variant_to_canonical_dict,
+)
+
+
+@pytest.fixture
+def published_variant(db, classical_variant, primary_user):
+    base_dvar = variant_to_canonical_dict(classical_variant)
+    base_dvar["id"] = "safe-replace-test"
+    dvar = copy.deepcopy(base_dvar)
+    variant = create_variant_from_dvar(dvar, owner=primary_user, status=VariantStatus.PUBLISHED)
+    VariantSvg.objects.create(variant=variant, svg=classical_variant.svg.svg)
+    return variant
+
+
+@pytest.fixture
+def published_variant_dvar(published_variant):
+    return variant_to_canonical_dict(published_variant)
+
+
+@pytest.fixture
+def published_variant_dsvg(published_variant):
+    return published_variant.svg.svg
+
+
+@pytest.fixture
+def sandbox_game_on_published(primary_user, published_variant):
+    return Game.objects.create_sandbox(
+        user=primary_user, name="Safe replace sandbox", variant=published_variant
+    )
+
+
+def _error_codes(errors):
+    return [error.code for error in errors]
+
+
+@pytest.mark.django_db
+def test_validate_accepts_identical_dvar(published_variant, published_variant_dvar):
+    errors = validate_safe_replacement(published_variant, published_variant_dvar)
+    assert errors == []
+
+
+@pytest.mark.django_db
+def test_validate_rejects_mismatched_id(published_variant, published_variant_dvar):
+    bad = copy.deepcopy(published_variant_dvar)
+    bad["id"] = "different-id"
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "VARIANT_ID_MISMATCH" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_added_nation(published_variant, published_variant_dvar):
+    bad = copy.deepcopy(published_variant_dvar)
+    bad["nations"].append({"id": "atlantis", "name": "Atlantis", "color": "#abcdef"})
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "NATION_ADDED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_removed_nation(published_variant, published_variant_dvar):
+    bad = copy.deepcopy(published_variant_dvar)
+    removed_id = bad["nations"][0]["id"]
+    surviving_id = bad["nations"][1]["id"]
+    bad["nations"] = [nation for nation in bad["nations"] if nation["id"] != removed_id]
+    for province in bad["provinces"]:
+        if province.get("homeNation") == removed_id:
+            province.pop("homeNation", None)
+    for unit in bad["initialState"]["units"]:
+        if unit["nation"] == removed_id:
+            unit["nation"] = surviving_id
+    for sc in bad["initialState"]["supplyCenters"]:
+        if sc["nation"] == removed_id:
+            sc["nation"] = surviving_id
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "NATION_REMOVED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_added_province(published_variant, published_variant_dvar):
+    bad = copy.deepcopy(published_variant_dvar)
+    bad["provinces"].append(
+        {
+            "id": "atl",
+            "name": "Atlantis",
+            "type": "sea",
+            "supplyCenter": False,
+            "adjacencies": [],
+        }
+    )
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "PROVINCE_ADDED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_removed_province(published_variant, published_variant_dvar):
+    bad = copy.deepcopy(published_variant_dvar)
+    removed_id = next(
+        province["id"] for province in bad["provinces"]
+        if province["type"] == "sea" and not province["supplyCenter"]
+    )
+    bad["provinces"] = [
+        province for province in bad["provinces"] if province["id"] != removed_id
+    ]
+    for province in bad["provinces"]:
+        province["adjacencies"] = [
+            adjacency for adjacency in province.get("adjacencies", [])
+            if adjacency["to"] != removed_id
+        ]
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "PROVINCE_REMOVED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_supply_center_removal_when_active_sc_exists(
+    published_variant, published_variant_dvar, sandbox_game_on_published
+):
+    sc_province_id = (
+        SupplyCenter.objects.filter(phase__game=sandbox_game_on_published)
+        .first()
+        .province.province_id
+    )
+    bad = copy.deepcopy(published_variant_dvar)
+    for province in bad["provinces"]:
+        if province["id"] == sc_province_id:
+            province["supplyCenter"] = False
+            break
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "SUPPLY_CENTER_REMOVED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_rejects_parent_change_when_units_exist(
+    published_variant, published_variant_dvar, sandbox_game_on_published
+):
+    template_named_coast = (
+        published_variant.provinces.filter(parent__isnull=False).first()
+    )
+    assert template_named_coast is not None
+    Unit.objects.filter(phase__game=sandbox_game_on_published).first()
+    unit = Unit.objects.filter(phase__game=sandbox_game_on_published).first()
+    unit.province = template_named_coast
+    unit.save()
+
+    new_parent_province = (
+        published_variant.provinces.exclude(province_id=template_named_coast.parent.province_id)
+        .filter(parent__isnull=True)
+        .first()
+    )
+    bad = copy.deepcopy(published_variant_dvar)
+    for coast in bad["namedCoasts"]:
+        if coast["id"] == template_named_coast.province_id:
+            coast["parentProvince"] = new_parent_province.province_id
+            break
+    errors = validate_safe_replacement(published_variant, bad)
+    assert "PARENT_CHANGED" in _error_codes(errors)
+
+
+@pytest.mark.django_db
+def test_validate_accepts_adjacency_change(
+    published_variant, published_variant_dvar, sandbox_game_on_published
+):
+    modified = copy.deepcopy(published_variant_dvar)
+    for province in modified["provinces"]:
+        if province["adjacencies"]:
+            province["adjacencies"] = province["adjacencies"][:-1]
+            break
+    errors = validate_safe_replacement(published_variant, modified)
+    adjacency_errors = [
+        error for error in errors
+        if error.code in ("ASYMMETRIC_ADJACENCY", "INCONSISTENT_ADJACENCY")
+    ]
+    nation_or_province_errors = [
+        error for error in errors
+        if error.code in (
+            "NATION_ADDED", "NATION_REMOVED", "PROVINCE_ADDED", "PROVINCE_REMOVED",
+            "PARENT_CHANGED", "SUPPLY_CENTER_REMOVED",
+        )
+    ]
+    assert nation_or_province_errors == []
+    assert adjacency_errors
+
+
+@pytest.mark.django_db
+def test_apply_preserves_pks(
+    published_variant, published_variant_dvar, published_variant_dsvg
+):
+    nation_pks_before = dict(published_variant.nations.values_list("nation_id", "id"))
+    province_pks_before = dict(published_variant.provinces.values_list("province_id", "id"))
+
+    apply_safe_replacement(published_variant, published_variant_dvar, published_variant_dsvg)
+
+    nation_pks_after = dict(
+        Nation.objects.filter(variant=published_variant).values_list("nation_id", "id")
+    )
+    province_pks_after = dict(
+        Province.objects.filter(variant=published_variant).values_list("province_id", "id")
+    )
+    assert nation_pks_after == nation_pks_before
+    assert province_pks_after == province_pks_before
+
+
+@pytest.mark.django_db
+def test_apply_preserves_game_data(
+    published_variant, published_variant_dvar, published_variant_dsvg,
+    sandbox_game_on_published,
+):
+    game = sandbox_game_on_published
+    game_phase_ids = list(game.phases.values_list("id", flat=True))
+    unit_ids = list(Unit.objects.filter(phase__game=game).values_list("id", flat=True))
+    sc_ids = list(SupplyCenter.objects.filter(phase__game=game).values_list("id", flat=True))
+    member_ids = list(game.members.values_list("id", flat=True))
+
+    apply_safe_replacement(published_variant, published_variant_dvar, published_variant_dsvg)
+
+    assert list(game.phases.values_list("id", flat=True)) == game_phase_ids
+    assert list(Unit.objects.filter(phase__game=game).values_list("id", flat=True)) == unit_ids
+    assert list(SupplyCenter.objects.filter(phase__game=game).values_list("id", flat=True)) == sc_ids
+    assert list(game.members.values_list("id", flat=True)) == member_ids
+
+
+@pytest.mark.django_db
+def test_apply_regenerates_template_phase(
+    published_variant, published_variant_dvar, published_variant_dsvg
+):
+    template_phase_id_before = published_variant.template_phase.id
+    apply_safe_replacement(published_variant, published_variant_dvar, published_variant_dsvg)
+    refreshed_template = Phase.objects.get(
+        variant=published_variant, game__isnull=True
+    )
+    assert refreshed_template.id != template_phase_id_before
+    assert refreshed_template.units.exists()
+    assert refreshed_template.supply_centers.exists()
+
+
+@pytest.mark.django_db
+def test_apply_preserves_flags(
+    published_variant, published_variant_dvar, published_variant_dsvg
+):
+    nation = published_variant.nations.first()
+    flag_svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>'
+    NationFlag.objects.create(nation=nation, svg=flag_svg)
+    flag_hash_before = nation.flag.content_hash
+
+    apply_safe_replacement(published_variant, published_variant_dvar, published_variant_dsvg)
+
+    refreshed_flag = NationFlag.objects.get(nation=nation)
+    assert refreshed_flag.content_hash == flag_hash_before
+
+
+@pytest.mark.django_db
+def test_apply_replaces_svg(
+    published_variant, published_variant_dvar, published_variant_dsvg
+):
+    new_dsvg = published_variant_dsvg.replace(
+        '<g id="background"', '<g id="background"><rect id="marker" width="1" height="1"/>', 1
+    )
+    hash_before = published_variant.svg.content_hash
+    apply_safe_replacement(published_variant, published_variant_dvar, new_dsvg)
+    refreshed = Variant.objects.get(id=published_variant.id)
+    assert refreshed.svg.content_hash != hash_before
+
+
+@pytest.mark.django_db
+def test_apply_updates_variant_level_fields(
+    published_variant, published_variant_dvar, published_variant_dsvg
+):
+    modified = copy.deepcopy(published_variant_dvar)
+    modified["name"] = "Renamed Variant"
+    modified["description"] = "Updated description"
+    modified["rules"] = "New rules text"
+
+    apply_safe_replacement(published_variant, modified, published_variant_dsvg)
+
+    refreshed = Variant.objects.get(id=published_variant.id)
+    assert refreshed.name == "Renamed Variant"
+    assert refreshed.description == "Updated description"
+    assert refreshed.rules == "New rules text"

--- a/service/variant/utils.py
+++ b/service/variant/utils.py
@@ -837,6 +837,213 @@ def update_variant_from_dvar(variant, dvar):
     return variant
 
 
+@dataclass(frozen=True)
+class SafeReplacementError:
+    code: str
+    message: str
+
+
+def validate_safe_replacement(variant, dvar):
+    from supply_center.models import SupplyCenter
+    from unit.models import Unit
+
+    errors = list(validate_dvar(dvar))
+    if errors:
+        return [SafeReplacementError(error.code, error.message) for error in errors]
+
+    if dvar["id"] != variant.id:
+        return [
+            SafeReplacementError(
+                "VARIANT_ID_MISMATCH",
+                f"DVAR id '{dvar['id']}' does not match variant id '{variant.id}'.",
+            )
+        ]
+
+    errors = []
+
+    old_nation_ids = set(variant.nations.values_list("nation_id", flat=True))
+    new_nation_ids = {nation["id"] for nation in dvar["nations"]}
+    for nation_id in sorted(new_nation_ids - old_nation_ids):
+        errors.append(
+            SafeReplacementError(
+                "NATION_ADDED",
+                f"Nation '{nation_id}' is in the new DVAR but not in the existing variant.",
+            )
+        )
+    for nation_id in sorted(old_nation_ids - new_nation_ids):
+        errors.append(
+            SafeReplacementError(
+                "NATION_REMOVED",
+                f"Nation '{nation_id}' exists in the variant but is missing from the new DVAR.",
+            )
+        )
+
+    old_provinces = {
+        province.province_id: province for province in variant.provinces.all()
+    }
+    new_province_parent_by_id = {
+        province["id"]: None for province in dvar["provinces"]
+    }
+    for coast in dvar.get("namedCoasts", []):
+        new_province_parent_by_id[coast["id"]] = coast["parentProvince"]
+    new_province_sc_by_id = {
+        province["id"]: province["supplyCenter"] for province in dvar["provinces"]
+    }
+
+    for province_id in sorted(set(new_province_parent_by_id) - set(old_provinces)):
+        errors.append(
+            SafeReplacementError(
+                "PROVINCE_ADDED",
+                f"Province '{province_id}' is in the new DVAR but not in the existing variant.",
+            )
+        )
+    for province_id in sorted(set(old_provinces) - set(new_province_parent_by_id)):
+        errors.append(
+            SafeReplacementError(
+                "PROVINCE_REMOVED",
+                f"Province '{province_id}' exists in the variant but is missing from the new DVAR.",
+            )
+        )
+
+    province_ids_with_units = set(
+        Unit.objects.filter(province__variant=variant)
+        .exclude(phase__game__isnull=True)
+        .values_list("province__province_id", flat=True)
+        .distinct()
+    )
+    for province_id in sorted(province_ids_with_units):
+        if province_id not in new_province_parent_by_id or province_id not in old_provinces:
+            continue
+        old_parent_id = (
+            old_provinces[province_id].parent.province_id
+            if old_provinces[province_id].parent_id
+            else None
+        )
+        new_parent_id = new_province_parent_by_id[province_id]
+        if old_parent_id != new_parent_id:
+            errors.append(
+                SafeReplacementError(
+                    "PARENT_CHANGED",
+                    f"Province '{province_id}' has units in active games; "
+                    f"its named-coast parent cannot change "
+                    f"(was {old_parent_id!r}, now {new_parent_id!r}).",
+                )
+            )
+
+    province_ids_with_supply_centers = set(
+        SupplyCenter.objects.filter(province__variant=variant)
+        .exclude(phase__game__isnull=True)
+        .values_list("province__province_id", flat=True)
+        .distinct()
+    )
+    for province_id in sorted(province_ids_with_supply_centers):
+        if province_id not in new_province_sc_by_id:
+            continue
+        if not new_province_sc_by_id[province_id]:
+            errors.append(
+                SafeReplacementError(
+                    "SUPPLY_CENTER_REMOVED",
+                    f"Province '{province_id}' holds supply centers in active games "
+                    f"but is no longer marked as a supply center in the new DVAR.",
+                )
+            )
+
+    return errors
+
+
+def apply_safe_replacement(variant, dvar, dsvg_text):
+    from common.constants import PhaseStatus, ProvinceType
+    from nation.models import Nation
+    from phase.models import Phase
+    from province.models import Province
+    from supply_center.models import SupplyCenter
+    from unit.models import Unit
+    from variant.models import VariantSvg
+
+    province_type_for = {
+        "land": ProvinceType.LAND,
+        "sea": ProvinceType.SEA,
+        "coastal": ProvinceType.COASTAL,
+    }
+
+    variant.name = dvar["name"]
+    variant.description = dvar["description"]
+    variant.author = dvar.get("author", "")
+    variant.rules = dvar.get("rules", "")
+    variant.victory_conditions = dvar["victoryConditions"]
+    variant.adjudication_modifiers = dvar.get("adjudicationModifiers", [])
+    variant.phase_progression = dvar["phaseProgression"]
+    variant.save()
+
+    nation_by_id = {nation.nation_id: nation for nation in variant.nations.all()}
+    for payload in dvar["nations"]:
+        nation = nation_by_id[payload["id"]]
+        nation.name = payload["name"]
+        nation.color = payload["color"]
+        nation.save()
+    nation_by_id = {nation.nation_id: nation for nation in variant.nations.all()}
+
+    province_by_id = {province.province_id: province for province in variant.provinces.all()}
+    for payload in dvar["provinces"]:
+        province = province_by_id[payload["id"]]
+        province.name = payload["name"]
+        province.type = province_type_for[payload["type"]]
+        province.supply_center = payload["supplyCenter"]
+        province.home_nation = nation_by_id.get(payload.get("homeNation"))
+        province.parent = None
+        province.adjacencies = payload.get("adjacencies", [])
+        province.save()
+    for payload in dvar.get("namedCoasts", []):
+        province = province_by_id[payload["id"]]
+        province.name = payload["name"]
+        province.type = ProvinceType.NAMED_COAST
+        province.supply_center = False
+        province.home_nation = None
+        province.parent = province_by_id[payload["parentProvince"]]
+        province.adjacencies = payload.get("adjacencies", [])
+        province.save()
+
+    Phase.objects.filter(variant=variant, game__isnull=True).delete()
+    initial = dvar["initialState"]
+    template_phase = Phase.objects.create(
+        variant=variant,
+        game=None,
+        ordinal=1,
+        status=PhaseStatus.TEMPLATE,
+        season=initial["phase"]["season"],
+        year=initial["phase"]["year"],
+        type=initial["phase"]["type"],
+    )
+    Unit.objects.bulk_create(
+        [
+            Unit(
+                phase=template_phase,
+                type=unit["type"],
+                nation=nation_by_id[unit["nation"]],
+                province=province_by_id[unit["location"]],
+            )
+            for unit in initial["units"]
+        ]
+    )
+    SupplyCenter.objects.bulk_create(
+        [
+            SupplyCenter(
+                phase=template_phase,
+                nation=nation_by_id[sc["nation"]],
+                province=province_by_id[sc["province"]],
+            )
+            for sc in initial["supplyCenters"]
+        ]
+    )
+
+    VariantSvg.objects.update_or_create(variant=variant, defaults={"svg": dsvg_text})
+
+    if hasattr(variant, "_prefetched_objects_cache"):
+        variant._prefetched_objects_cache.clear()
+
+    return variant
+
+
 def _build_variant_children(variant, dvar):
     from common.constants import PhaseStatus, ProvinceType
     from nation.models import Nation


### PR DESCRIPTION
Adds a "Replace files safely" button on published variants in the Django admin that upserts the DVAR + DSVG in place without touching games using the variant. The existing destructive `update_variant_from_dvar` path (which deletes all games using the variant) remains the flow for draft variants.

Validation enforces nation/province set equality and blocks changes that would corrupt in-flight game state: named-coast parent changes for provinces with units in active games, and supply-center removal for provinces that already hold SCs in active phases. Adjacency, rule, and modifier changes are allowed and take effect on the next phase resolution (the adjudicator re-reads the variant per phase).

`apply_safe_replacement` upserts `Nation` and `Province` rows by their string IDs so existing FKs from `Unit`, `Order`, `SupplyCenter`, and `Member` keep pointing at the same PKs. Only the template phase is regenerated.