### PR TITLE
Show static 'Orders for sandbox units' text in sandbox games

### DIFF
--- a/packages/web/src/components/PhaseGuidance.tsx
+++ b/packages/web/src/components/PhaseGuidance.tsx
@@ -56,7 +56,9 @@ function usePhaseGuidance(): GuidanceResult {
 
       if (submittedCount === 0) {
         return {
-          text: `Submit orders for ${totalOrderable} unit${totalOrderable > 1 ? "s" : ""}`,
+          text: game.sandbox
+            ? "Orders for sandbox units"
+            : `Submit orders for ${totalOrderable} unit${totalOrderable > 1 ? "s" : ""}`,
           isComplete: false,
           isConfirmed,
         };


### PR DESCRIPTION
## Summary

In the orders subpanel phase guidance indicator, when the current game is a sandbox game and no orders have been submitted yet, display a static `"Orders for sandbox units"` string instead of the dynamic `"Submit orders for N units"` text shown in regular games.

This was a UX inconsistency - the order screen showed how many units THE USER could provide (e.g. mounted as 'player'). This led to there to be 3 orders asked, with 21 units on the map. This makes it static and reinforces the Sandbox state.

## Changes

- `PhaseGuidance.tsx`: Branch on `game.sandbox` in the Movement phase / zero-orders-submitted case to return the static sandbox string

🤖 Generated with [Claude Code](https://claude.com/claude-code)