### PR TITLE
Speed up GET + POST orders endpoints

### DIFF
--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -2,6 +2,7 @@ from rest_framework.permissions import BasePermission
 from django.shortcuts import get_object_or_404
 from django.apps import apps
 from common.constants import GameStatus, PressType
+from common.views import resolve_game
 
 Game = apps.get_model("game", "Game")
 Channel = apps.get_model("channel", "Channel")
@@ -12,8 +13,7 @@ class IsActiveGame(BasePermission):
     message = "This game is not active."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.status == GameStatus.ACTIVE
 
 
@@ -22,8 +22,7 @@ class IsActiveOrCompletedGame(BasePermission):
     message = "This game is not active or finished."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.status in (GameStatus.ACTIVE, GameStatus.COMPLETED, GameStatus.ABANDONED)
 
 
@@ -31,8 +30,7 @@ class IsGameMember(BasePermission):
     message = "User is not a member of the game."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.members.filter(user=request.user).exists()
 
 
@@ -40,8 +38,7 @@ class IsActiveGameMember(BasePermission):
     message = "User cannot perform this action."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
 
         member = game.members.filter(user=request.user).first()
         if not member:
@@ -75,8 +72,7 @@ class IsPendingGame(BasePermission):
     message = "Game is not in pending status."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.status == GameStatus.PENDING
 
 
@@ -84,8 +80,7 @@ class IsNotGameMember(BasePermission):
     message = "User is already a member of the game."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return not game.members.filter(user=request.user).exists()
 
 
@@ -93,8 +88,7 @@ class IsSpaceAvailable(BasePermission):
     message = "Game already has the maximum number of players."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.members.count() < game.variant.nations.count()
 
 
@@ -104,8 +98,7 @@ class IsCurrentPhaseActive(BasePermission):
     def has_permission(self, request, view):
         from common.constants import PhaseStatus
 
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         current_phase = game.phases.last()
         return current_phase and current_phase.status == PhaseStatus.ACTIVE
 
@@ -114,8 +107,7 @@ class IsUserPhaseStateExists(BasePermission):
     message = "No phase state found for user."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         member = game.members.filter(user=request.user).first()
         if not member:
             return False
@@ -129,8 +121,7 @@ class IsSandboxGame(BasePermission):
     message = "This action is only available for sandbox games."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return game.sandbox
 
 
@@ -138,8 +129,7 @@ class IsNotSandboxGame(BasePermission):
     message = "This action is not available for sandbox games."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         return not game.sandbox
 
 
@@ -147,8 +137,7 @@ class IsNotNoPressActiveGame(BasePermission):
     message = "Messaging is not available in active No Press games."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         if game.press_type != PressType.NO_PRESS:
             return True
         return game.status in (GameStatus.COMPLETED, GameStatus.ABANDONED)
@@ -158,8 +147,7 @@ class IsGameMaster(BasePermission):
     message = "Only the Game Master can perform this action."
 
     def has_permission(self, request, view):
-        game_id = view.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(request, view.kwargs.get("game_id"))
         member = game.members.filter(user=request.user).first()
         if not member:
             self.message = "User is not a member of the game."

--- a/service/common/views.py
+++ b/service/common/views.py
@@ -6,6 +6,33 @@ Game = apps.get_model("game", "Game")
 Channel = apps.get_model("channel", "Channel")
 
 
+def resolve_game(request, game_id):
+    """Fetch the Game once per request, regardless of how many permission
+    classes and mixins ask for it. Several views combine 2-3 permission
+    checks + a mixin (e.g. orders create chains IsActiveGame +
+    IsActiveGameMember + CurrentPhaseMixin), each of which would otherwise
+    issue an independent SELECT against game_game."""
+    cache = getattr(request, "_game_cache", None)
+    if cache is None:
+        cache = {}
+        request._game_cache = cache
+    if game_id not in cache:
+        cache[game_id] = get_object_or_404(Game, id=game_id)
+    return cache[game_id]
+
+
+def resolve_phase(request, game_id, phase_id):
+    """Cache the Phase fetch per request alongside resolve_game."""
+    cache = getattr(request, "_phase_cache", None)
+    if cache is None:
+        cache = {}
+        request._phase_cache = cache
+    key = (game_id, phase_id)
+    if key not in cache:
+        cache[key] = get_object_or_404(Phase, id=phase_id, game_id=game_id)
+    return cache[key]
+
+
 class SelectedGameMixin:
     """
     Used by views that have a game parameter in the URL. Provides a get_game
@@ -14,7 +41,7 @@ class SelectedGameMixin:
 
     def get_game(self):
         game_id = self.kwargs.get("game_id")
-        return get_object_or_404(Game, id=game_id)
+        return resolve_game(self.request, game_id)
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -31,7 +58,7 @@ class SelectedPhaseMixin:
     def get_phase(self):
         game_id = self.kwargs.get("game_id")
         phase_id = self.kwargs.get("phase_id")
-        return get_object_or_404(Phase, id=phase_id, game_id=game_id)
+        return resolve_phase(self.request, game_id, phase_id)
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -47,7 +74,7 @@ class CurrentPhaseMixin:
 
     def get_phase(self):
         game_id = self.kwargs.get("game_id")
-        game = get_object_or_404(Game, id=game_id)
+        game = resolve_game(self.request, game_id)
         return game.current_phase
 
     def get_serializer_context(self):

--- a/service/order/models.py
+++ b/service/order/models.py
@@ -199,18 +199,29 @@ class Order(BaseModel):
 
     @property
     def options_display(self):
-        self.options
-        display_options = []
-        for option in self.options:
-            try:
-                province = self.variant.provinces.get(province_id=option)
-            except ObjectDoesNotExist:
-                province = None
-            if province is not None:
-                display_options.append({"value": option, "label": province.name})
-            else:
-                display_options.append({"value": option, "label": option})
-        return display_options
+        options = self.options
+        if not options:
+            # Complete orders (the common case in list responses) have no
+            # options to display — skip the variant.provinces lookup entirely.
+            return []
+
+        # Build the variant's province lookup once on the variant. Same
+        # variant object is shared across all orders in a list response via
+        # select_related on phase_state__phase__game__variant, so the second
+        # order onward reuses the cached dict.
+        variant = self.variant
+        province_lookup = getattr(variant, "_options_province_lookup", None)
+        if province_lookup is None:
+            province_lookup = {p.province_id: p for p in variant.provinces.all()}
+            variant._options_province_lookup = province_lookup
+
+        return [
+            {
+                "value": opt,
+                "label": (province_lookup[opt].name if opt in province_lookup else opt),
+            }
+            for opt in options
+        ]
 
     @property
     def selected(self):

--- a/service/order/serializers.py
+++ b/service/order/serializers.py
@@ -72,16 +72,22 @@ class OrderSerializer(serializers.Serializer):
             get_options_for_order(order.phase.transformed_options, order)
         except Exception as e:
             raise exceptions.ValidationError(e)
+        # Stash the validated order so create() doesn't have to re-run
+        # create_from_selected (which would re-query phase_states and
+        # rebuild province_lookup).
+        self.context["_validated_order"] = order
         return order.selected
 
     def create(self, validated_data):
-        province_lookup = self.context.get("_province_lookup")
-        if province_lookup is None:
-            province_lookup = {p.province_id: p for p in self.context["phase"].variant.provinces.all()}
+        order = self.context.get("_validated_order")
+        if order is None:
+            province_lookup = self.context.get("_province_lookup")
+            if province_lookup is None:
+                province_lookup = {p.province_id: p for p in self.context["phase"].variant.provinces.all()}
+            order = Order.objects.create_from_selected(
+                self.context["request"].user, self.context["phase"], validated_data["selected"], province_lookup=province_lookup
+            )
 
-        order = Order.objects.create_from_selected(
-            self.context["request"].user, self.context["phase"], validated_data["selected"], province_lookup=province_lookup
-        )
         if order.complete:
             Order.objects.delete_existing_for_source(order.phase_state, order.source)
             order.save()

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -719,7 +719,7 @@ class TestOrderListViewQueryPerformance:
             response = authenticated_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(connection.queries) == 8
+        assert len(connection.queries) == 7  # was 8 before resolve_game cache + transformed_options cached_property
 
     @pytest.mark.django_db
     def test_list_orders_query_count_with_multiple_orders(
@@ -756,7 +756,7 @@ class TestOrderListViewQueryPerformance:
             response = authenticated_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(connection.queries) == 8
+        assert len(connection.queries) == 7
 
     @pytest.mark.django_db
     def test_list_orders_query_count_with_many_orders(
@@ -829,7 +829,7 @@ class TestOrderListViewQueryPerformance:
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
 
-        assert query_count == 8
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_orders_query_count_with_many_orders_with_resolutions(
@@ -913,7 +913,7 @@ class TestOrderListViewQueryPerformance:
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
 
-        assert query_count == 8
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_orders_no_n_plus_one_for_named_coast_fleet_moves(
@@ -991,7 +991,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 18
+        assert query_count == 15  # was 18 before resolve_game cache + dedup create_from_selected
 
     @pytest.mark.django_db
     def test_order_create_query_count_with_support_order(self, authenticated_client, game_with_options):
@@ -1006,7 +1006,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 18
+        assert query_count == 15
 
     @pytest.mark.django_db
     def test_order_create_query_count_with_many_phase_states(self, authenticated_client, game_with_many_phase_states):
@@ -1021,7 +1021,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 18
+        assert query_count == 15
 
 
 class TestOrderDeleteViewQueryPerformance:
@@ -1055,7 +1055,7 @@ class TestOrderDeleteViewQueryPerformance:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         query_count = len(connection.queries)
 
-        assert query_count == 8
+        assert query_count == 6
 
 
 class TestGetOptionsForOrder:

--- a/service/order/tests/test_orders_perf.py
+++ b/service/order/tests/test_orders_perf.py
@@ -1,0 +1,217 @@
+"""Local benchmark harness for the orders endpoints.
+
+Production traces (14 days):
+  GET /game/<id>/orders/<phase_id>  P50  64 ms  P95  404 ms  P99 1072 ms
+  POST /game/<id>/orders/           P50 195 ms  P95  452 ms  P99  674 ms
+
+The list endpoint has a striking ~10x P50→P99 spread — the slow tail is
+where there's headroom. The create endpoint is hitting an interactive
+action ~190 ms below the floor we'd want (sub-100 ms).
+
+Run with -s to see the printed comparison table:
+
+    docker compose run --rm service \\
+        python3 -m pytest order/tests/test_orders_perf.py -s -v
+"""
+import time
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext, override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from common.constants import OrderType
+
+
+def _measure(label, fn, *, trials=3, warmup=1):
+    """Warm-up + median-of-trials. Returns label + median sample."""
+    for _ in range(warmup):
+        fn()
+    samples = []
+    for _ in range(trials):
+        with CaptureQueriesContext(connection) as ctx, override_settings(DEBUG=True):
+            start = time.perf_counter()
+            result = fn()
+            elapsed_ms = (time.perf_counter() - start) * 1000
+        samples.append(
+            {
+                "wall_ms": elapsed_ms,
+                "sql_count": len(ctx.captured_queries),
+                "sql_ms": sum(float(q["time"]) for q in ctx.captured_queries) * 1000,
+                "result": result,
+            }
+        )
+    samples.sort(key=lambda s: s["wall_ms"])
+    return {"label": label, **samples[len(samples) // 2]}
+
+
+def _print_row(label, metrics, payload_bytes):
+    print(
+        f"  {label:<32} "
+        f"sql={metrics['sql_count']:>4}  "
+        f"sql_ms={metrics['sql_ms']:>7.1f}  "
+        f"wall_ms={metrics['wall_ms']:>7.1f}  "
+        f"bytes={payload_bytes:>7}"
+    )
+
+
+def _print_header():
+    print()
+    print("  pattern                          sql    sql_ms     wall_ms    bytes")
+    print("  " + "-" * 70)
+
+
+@pytest.fixture
+def game_with_orders(
+    db,
+    game_with_options,
+    primary_user,
+    classical_england_nation,
+    classical_edinburgh_province,
+    classical_liverpool_province,
+    classical_london_province,
+):
+    """Game with options populated AND a handful of existing orders so the
+    list endpoint isn't empty. England (primary_user) has orders on bud and
+    tri (the two sources covered by sample_options)."""
+    from order.models import Order
+    from province.models import Province
+
+    game = game_with_options
+    phase = game.current_phase
+    phase_state = phase.phase_states.get(member__user=primary_user)
+
+    bud = Province.objects.get(province_id="bud", variant=game.variant)
+    tri = Province.objects.get(province_id="tri", variant=game.variant)
+    gal = Province.objects.get(province_id="gal", variant=game.variant)
+    ven = Province.objects.get(province_id="ven", variant=game.variant)
+
+    # The sample_options fixture only covers bud and tri sources for England.
+    Order.objects.create(
+        phase_state=phase_state, order_type=OrderType.MOVE, source=bud, target=gal,
+    )
+    Order.objects.create(
+        phase_state=phase_state, order_type=OrderType.MOVE, source=tri, target=ven,
+    )
+    return game
+
+
+@pytest.mark.django_db
+def test_list_orders_baseline(authenticated_client, game_with_orders):
+    """GET /game/<id>/orders/<phase_id>."""
+    game = game_with_orders
+    phase = game.current_phase
+    url = reverse("order-list", args=[game.id, phase.id])
+
+    metrics = _measure("GET /orders/", lambda: authenticated_client.get(url))
+    response = metrics["result"]
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data) == 2
+
+    _print_header()
+    _print_row("GET /orders/ (2 orders)", metrics, len(response.content))
+
+
+@pytest.mark.django_db
+def test_list_orders_with_incomplete_orders(
+    authenticated_client, game_with_options, primary_user
+):
+    """GET /game/<id>/orders/ with two INCOMPLETE orders (source-only,
+    no order_type yet). This is the scenario the production P99 tail
+    points at: each incomplete order computes options_display, which
+    historically did a variant.provinces.get(province_id=...) per option.
+    Regression guard for the variant.provinces lookup N+1."""
+    from order.models import Order
+    from province.models import Province
+
+    game = game_with_options
+    phase = game.current_phase
+    phase_state = phase.phase_states.get(member__user=primary_user)
+
+    bud = Province.objects.get(province_id="bud", variant=game.variant)
+    tri = Province.objects.get(province_id="tri", variant=game.variant)
+    Order.objects.create(phase_state=phase_state, source=bud)
+    Order.objects.create(phase_state=phase_state, source=tri)
+
+    url = reverse("order-list", args=[game.id, phase.id])
+    metrics = _measure("GET /orders/ (incomplete)", lambda: authenticated_client.get(url))
+    assert metrics["result"].status_code == status.HTTP_200_OK
+
+    _print_header()
+    _print_row("GET /orders/ (2 incomplete)", metrics, len(metrics["result"].content))
+
+
+@pytest.mark.django_db
+def test_create_order_partial_baseline(authenticated_client, game_with_options):
+    """POST /game/<id>/orders/ with a partial selection (source only).
+    Exercises the validate + return path without saving."""
+    game = game_with_options
+    url = reverse("order-create", args=[game.id])
+
+    metrics = _measure(
+        "POST /orders/ (partial)",
+        lambda: authenticated_client.post(url, {"selected": ["bud"]}, format="json"),
+    )
+    response = metrics["result"]
+    assert response.status_code == status.HTTP_201_CREATED
+
+    _print_header()
+    _print_row("POST /orders/ (partial)", metrics, len(response.content))
+
+
+@pytest.mark.django_db
+def test_create_order_complete_baseline(authenticated_client, game_with_options):
+    """POST /game/<id>/orders/ with a complete selection (source + Hold).
+    Exercises the full path: validate, delete existing, save, re-fetch via
+    with_related_data. This is what users do most: click → confirm."""
+    game = game_with_options
+    url = reverse("order-create", args=[game.id])
+
+    metrics = _measure(
+        "POST /orders/ (complete)",
+        lambda: authenticated_client.post(
+            url, {"selected": ["bud", "Hold"]}, format="json"
+        ),
+    )
+    response = metrics["result"]
+    assert response.status_code == status.HTTP_201_CREATED
+
+    _print_header()
+    _print_row("POST /orders/ (complete)", metrics, len(response.content))
+
+
+def _print_queries(label, ctx):
+    print()
+    print(f"  {label} — {len(ctx.captured_queries)} queries")
+    print("  " + "-" * 70)
+    for i, q in enumerate(ctx.captured_queries, 1):
+        sql = q["sql"]
+        if len(sql) > 130:
+            sql = sql[:127] + "..."
+        print(f"  {i:>2}. {sql}")
+
+
+@pytest.mark.django_db
+def test_query_breakdown_complete_create(authenticated_client, game_with_options):
+    game = game_with_options
+    url = reverse("order-create", args=[game.id])
+    authenticated_client.post(url, {"selected": ["bud", "Hold"]}, format="json")  # warm
+    with CaptureQueriesContext(connection) as ctx, override_settings(DEBUG=True):
+        response = authenticated_client.post(
+            url, {"selected": ["bud", "Hold"]}, format="json"
+        )
+    assert response.status_code == status.HTTP_201_CREATED
+    _print_queries("POST /orders/ (complete)", ctx)
+
+
+@pytest.mark.django_db
+def test_query_breakdown_list(authenticated_client, game_with_orders):
+    game = game_with_orders
+    phase = game.current_phase
+    url = reverse("order-list", args=[game.id, phase.id])
+    authenticated_client.get(url)  # warm
+    with CaptureQueriesContext(connection) as ctx, override_settings(DEBUG=True):
+        response = authenticated_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    _print_queries("GET /orders/", ctx)

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from functools import cached_property
 
 from django.db import models, transaction
 from django.db.models import Q, Exists, OuterRef, Count
@@ -658,7 +659,7 @@ class Phase(BaseModel):
     def all_orders(self):
         return [order for phase_state in self.phase_states.all() for order in phase_state.orders.all()]
 
-    @property
+    @cached_property
     def transformed_options(self):
         return transform_options(self.options or {})
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -163,17 +163,22 @@ def test_phase_should_not_resolve_immediately_partial_confirmation(
 def test_nations_with_possible_orders_various_scenarios(
     godip_options_england_london_hold, godip_options_england_france_both_hold
 ):
-    phase = Phase()
-    phase.options = {}
-    assert len(phase.nations_with_possible_orders) == 0
-    phase.options = {"England": {}, "France": {}}
-    assert len(phase.nations_with_possible_orders) == 0
-    phase.options = godip_options_england_london_hold
-    nations = phase.nations_with_possible_orders
+    # Phase.transformed_options is a cached_property, so each scenario uses
+    # a fresh Phase instance to avoid the cache carrying old options across
+    # cases.
+    empty = Phase(options={})
+    assert len(empty.nations_with_possible_orders) == 0
+
+    empty_nations = Phase(options={"England": {}, "France": {}})
+    assert len(empty_nations.nations_with_possible_orders) == 0
+
+    one_nation = Phase(options=godip_options_england_london_hold)
+    nations = one_nation.nations_with_possible_orders
     assert len(nations) == 1
     assert "England" in nations
-    phase.options = godip_options_england_france_both_hold
-    nations = phase.nations_with_possible_orders
+
+    two_nations = Phase(options=godip_options_england_france_both_hold)
+    nations = two_nations.nations_with_possible_orders
     assert len(nations) == 2
     assert "England" in nations
     assert "France" in nations
@@ -1589,7 +1594,7 @@ class TestPhaseListViewPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 6
+        assert query_count == 3  # was 6 before resolve_game cache eliminated the dup phase fetches
 
 
 class TestPhaseRetrieveViewQueryPerformance:


### PR DESCRIPTION
Production traces (14 days) show both order endpoints have headroom on user-facing latency:

| | P50 | P95 | P99 |
|---|---|---|---|
| `GET /game/<id>/orders/<phase_id>` | 64 ms | 404 ms | **1072 ms** |
| `POST /game/<id>/orders/` | **195 ms** | 452 ms | 674 ms |

The list P99 is ~17× the P50 — a heavy tail. The POST P50 sits above the ~100 ms interactive-feel threshold; users are noticing the click → confirm gap.

## Four changes

**1. Request-scoped `resolve_game` / `resolve_phase`** (`service/common/views.py`, `service/common/permissions.py`). `IsActiveGame`, `IsActiveGameMember`, 9 sibling permission classes, and the `SelectedGame`/`SelectedPhase`/`CurrentPhase` mixins each ran their own `get_object_or_404(Game, ...)`. On orders POST that meant **3 separate `SELECT game`** in a single request. Now they share a per-request cache.

**2. `cached_property` on `Phase.transformed_options`** (`service/phase/models.py`). `transform_options()` walks the options JSON; the property was called 3+ times per POST (validate, create, `options_display`). One test that mutated `phase.options` between assertions had to switch to fresh `Phase` instances.

**3. `Order.options_display` rewrite** (`service/order/models.py`). Returns `[]` immediately for complete orders (the common case in list responses). For incomplete orders, builds a province lookup once on the variant rather than firing `variant.provinces.get(province_id=...)` per option — the structural N+1 behind the GET P99 tail.

**4. `OrderSerializer.validate_selected` stashes the constructed order** (`service/order/serializers.py`). `create()` reuses it instead of running `Order.objects.create_from_selected` a second time (which would re-query `phase_states` and rebuild `province_lookup`).

## Local harness numbers

`service/order/tests/test_orders_perf.py` — median of 3 trials, warm-up, real Postgres:

| | SQL (before → after) | Wall ms (before → after) |
|---|---|---|
| GET /orders/ (2 complete) | 8 → **7** | 6.3 → 6.0 |
| GET /orders/ (2 incomplete) | * → **10** | * → 8.8 |
| POST /orders/ (partial) | 18 → **13** (-28%) | 7.3 → 6.9 |
| POST /orders/ (complete) | 18 → **15** (-17%) | 14.7 → 14.2 |

The "incomplete-orders" case is a new regression guard for the `options_display` N+1; no prior baseline. Wall times are small absolute deltas locally — the wins are in the *structural* metrics that scale to production (SQL count, payload bytes, repeat work eliminated).

The harness file ships with this PR; it stays around as both a benchmark surface for future iteration and a regression guard alongside the legacy `TestOrderListViewQueryPerformance` / `TestOrderCreateViewQueryPerformance` query-count assertions, which were updated from 8 → 7 and 18 → 15.

## Side effects on other endpoints

The `resolve_game` cache benefits every endpoint that uses any of `IsActiveGame`, `IsActiveGameMember`, `IsGameMember`, `IsGameMaster`, `IsPendingGame`, `IsCurrentPhaseActive`, etc., or the game/phase mixins. `TestPhaseListViewPerformance::test_list_phases_query_count` dropped from 6 to 3 queries as a free side effect.

All 1326 backend tests pass.