### PR TITLE
UX a day: Move join/leave game to inline CTA on game info screen"

### DIFF
--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -40,10 +40,12 @@ const MetadataRow: React.FC<MetadataRowProps> = ({ icon, label, value }) => {
 
 interface GameInfoContentProps {
   onNavigateToPlayerInfo: () => void;
+  pendingAction?: React.ReactNode;
 }
 
 export const GameInfoContent: React.FC<GameInfoContentProps> = ({
   onNavigateToPlayerInfo,
+  pendingAction,
 }) => {
   const { gameId } = useRequiredParams<{ gameId: string }>();
 
@@ -61,7 +63,7 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
 
   return (
     <>
-      <GameStatusAlerts game={game} variant={variant} />
+      <GameStatusAlerts game={game} variant={variant} action={pendingAction} />
       <ScreenCard>
         <ScreenCardHeader>
           <CardTitle>{game.name}</CardTitle>

--- a/packages/web/src/components/GameStatusAlerts.tsx
+++ b/packages/web/src/components/GameStatusAlerts.tsx
@@ -27,14 +27,18 @@ export function GameStatusAlerts({ game, variant, action }: GameStatusAlertsProp
   return (
     <>
       {game.status === "pending" && (
-        <Alert>
+        <Alert className="p-5">
           <Info className="size-4" />
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <AlertDescription>
               This game has not started yet. The game will start once{" "}
               {nationCount} players have joined.
             </AlertDescription>
-            {action}
+            {action && (
+              <div className="[&>button]:w-full sm:[&>button]:w-auto sm:flex sm:items-center sm:h-[1lh] shrink-0">
+                {action}
+              </div>
+            )}
           </div>
         </Alert>
       )}

--- a/packages/web/src/components/GameStatusAlerts.tsx
+++ b/packages/web/src/components/GameStatusAlerts.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Info, Trophy, AlertTriangle, Pause } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -13,9 +14,10 @@ interface GameStatusAlertsProps {
   variant?: {
     nations: { length: number } | readonly unknown[];
   };
+  action?: React.ReactNode;
 }
 
-export function GameStatusAlerts({ game, variant }: GameStatusAlertsProps) {
+export function GameStatusAlerts({ game, variant, action }: GameStatusAlertsProps) {
   const nationCount = variant?.nations
     ? Array.isArray(variant.nations)
       ? variant.nations.length
@@ -27,10 +29,13 @@ export function GameStatusAlerts({ game, variant }: GameStatusAlertsProps) {
       {game.status === "pending" && (
         <Alert>
           <Info className="size-4" />
-          <AlertDescription>
-            This game has not started yet. The game will start once{" "}
-            {nationCount} players have joined.
-          </AlertDescription>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <AlertDescription>
+              This game has not started yet. The game will start once{" "}
+              {nationCount} players have joined.
+            </AlertDescription>
+            {action}
+          </div>
         </Alert>
       )}
 

--- a/packages/web/src/components/GameStatusAlerts.tsx
+++ b/packages/web/src/components/GameStatusAlerts.tsx
@@ -29,7 +29,7 @@ export function GameStatusAlerts({ game, variant, action }: GameStatusAlertsProp
       {game.status === "pending" && (
         <Alert>
           <Info className="size-4" />
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <AlertDescription>
               This game has not started yet. The game will start once{" "}
               {nationCount} players have joined.

--- a/packages/web/src/screens/Home/GameInfo.test.tsx
+++ b/packages/web/src/screens/Home/GameInfo.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GameInfoScreen } from "./GameInfo";
+import { mockPendingGames, mockActiveGames } from "@/mocks";
+
+const mockJoinMutateAsync = vi.fn();
+const mockLeaveMutateAsync = vi.fn();
+const mockUseGameRetrieveSuspense = vi.fn();
+
+vi.mock("@/api/generated/endpoints", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    useGameRetrieveSuspense: (...args: unknown[]) =>
+      mockUseGameRetrieveSuspense(...args),
+    useGameJoinCreate: () => ({
+      mutateAsync: mockJoinMutateAsync,
+      isPending: false,
+    }),
+    useGameLeaveDestroy: () => ({
+      mutateAsync: mockLeaveMutateAsync,
+      isPending: false,
+    }),
+    getGameRetrieveQueryKey: (gameId: string) => ["games", gameId],
+  };
+});
+
+vi.mock("@/components/GameInfoContent", () => ({
+  GameInfoContent: ({
+    pendingAction,
+  }: {
+    pendingAction?: React.ReactNode;
+    onNavigateToPlayerInfo: () => void;
+  }) => <div data-testid="game-info-content">{pendingAction}</div>,
+}));
+
+vi.mock("@/components/GameDropdownMenu", () => ({
+  GameDropdownMenu: () => <div data-testid="game-dropdown-menu" />,
+}));
+
+const pendingGameCanJoin = mockPendingGames.find((g) => g.canJoin)!;
+const pendingGameCanLeave = mockPendingGames.find((g) => !g.canJoin)!;
+
+const renderGameInfo = (gameId: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/game-info/${gameId}`]}>
+        <Routes>
+          <Route path="/game-info/:gameId" element={<GameInfoScreen />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  return { queryClient };
+};
+
+describe("GameInfoScreen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJoinMutateAsync.mockResolvedValue(undefined);
+    mockLeaveMutateAsync.mockResolvedValue(undefined);
+  });
+
+  describe("CTA placement", () => {
+    it("shows 'Join game' button in the content area for a pending game the user can join", () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanJoin });
+      renderGameInfo(pendingGameCanJoin.id);
+
+      const content = screen.getByTestId("game-info-content");
+      expect(
+        within(content).getByRole("button", { name: /join game/i })
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'Leave game' button in the content area for a pending game the user has already joined", () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanLeave });
+      renderGameInfo(pendingGameCanLeave.id);
+
+      const content = screen.getByTestId("game-info-content");
+      expect(
+        within(content).getByRole("button", { name: /leave game/i })
+      ).toBeInTheDocument();
+    });
+
+    it("shows no join/leave button for an active game", () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: mockActiveGames[0] });
+      renderGameInfo(mockActiveGames[0].id);
+
+      const content = screen.getByTestId("game-info-content");
+      expect(
+        within(content).queryByRole("button", { name: /join game/i })
+      ).not.toBeInTheDocument();
+      expect(
+        within(content).queryByRole("button", { name: /leave game/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("join game", () => {
+    it("calls the join mutation when 'Join game' is clicked", async () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanJoin });
+      renderGameInfo(pendingGameCanJoin.id);
+
+      await userEvent.click(screen.getByRole("button", { name: /join game/i }));
+
+      expect(mockJoinMutateAsync).toHaveBeenCalledWith({
+        gameId: pendingGameCanJoin.id,
+        data: {},
+      });
+    });
+
+    it("invalidates the game query after joining so the button updates immediately", async () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanJoin });
+      const { queryClient } = renderGameInfo(pendingGameCanJoin.id);
+
+      await userEvent.click(screen.getByRole("button", { name: /join game/i }));
+
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["games", pendingGameCanJoin.id],
+      });
+    });
+  });
+
+  describe("leave game", () => {
+    it("calls the leave mutation when 'Leave game' is clicked", async () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanLeave });
+      renderGameInfo(pendingGameCanLeave.id);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /leave game/i })
+      );
+
+      expect(mockLeaveMutateAsync).toHaveBeenCalledWith({
+        gameId: pendingGameCanLeave.id,
+      });
+    });
+
+    it("invalidates the game query after leaving so the button updates immediately", async () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanLeave });
+      const { queryClient } = renderGameInfo(pendingGameCanLeave.id);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /leave game/i })
+      );
+
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["games", pendingGameCanLeave.id],
+      });
+    });
+  });
+});

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -1,21 +1,17 @@
 import React, { Suspense } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRequiredParams } from "@/hooks";
-import { UserPlus, UserMinus } from "lucide-react";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { GameDropdownMenu } from "@/components/GameDropdownMenu";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   useGameRetrieveSuspense,
   useGameJoinCreate,
   useGameLeaveDestroy,
+  getGameRetrieveQueryKey,
 } from "@/api/generated/endpoints";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
@@ -25,6 +21,7 @@ const GameInfo: React.FC = () => {
   const { gameId } = useRequiredParams<{ gameId: string }>();
 
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { data: game } = useGameRetrieveSuspense(gameId);
   const joinGameMutation = useGameJoinCreate();
   const leaveGameMutation = useGameLeaveDestroy();
@@ -32,6 +29,7 @@ const GameInfo: React.FC = () => {
   const handleJoinGame = async () => {
     try {
       await joinGameMutation.mutateAsync({ gameId, data: {} });
+      await queryClient.invalidateQueries({ queryKey: getGameRetrieveQueryKey(gameId) });
       toast.success("Game joined successfully");
     } catch {
       toast.error("Failed to join game");
@@ -41,6 +39,7 @@ const GameInfo: React.FC = () => {
   const handleLeaveGame = async () => {
     try {
       await leaveGameMutation.mutateAsync({ gameId });
+      await queryClient.invalidateQueries({ queryKey: getGameRetrieveQueryKey(gameId) });
       toast.success("Game left successfully");
     } catch {
       toast.error("Failed to leave game");
@@ -55,56 +54,41 @@ const GameInfo: React.FC = () => {
     navigate(`/game-info/${gameId}`);
   };
 
-  const joinLeaveButton = game.canJoin ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          onClick={handleJoinGame}
-          disabled={joinGameMutation.isPending}
-          variant="outline"
-          aria-label="Join game"
-        >
-          <UserPlus className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p>Join game</p>
-      </TooltipContent>
-    </Tooltip>
-  ) : (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          onClick={handleLeaveGame}
-          disabled={leaveGameMutation.isPending}
-          variant="outline"
-          aria-label="Leave game"
-        >
-          <UserMinus className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p>Leave game</p>
-      </TooltipContent>
-    </Tooltip>
-  );
+  const pendingAction = game.status === "pending" ? (
+    game.canJoin ? (
+      <Button
+        onClick={handleJoinGame}
+        disabled={joinGameMutation.isPending}
+      >
+        Join game
+      </Button>
+    ) : (
+      <Button
+        onClick={handleLeaveGame}
+        disabled={leaveGameMutation.isPending}
+        variant="outline"
+      >
+        Leave game
+      </Button>
+    )
+  ) : null;
 
   return (
     <ScreenContainer>
       <ScreenHeader
         title="Game Info"
         actions={
-          <>
-            {joinLeaveButton}
-            <GameDropdownMenu
-              game={game}
-              onNavigateToGameInfo={handleGameInfo}
-              onNavigateToPlayerInfo={handlePlayerInfo}
-            />
-          </>
+          <GameDropdownMenu
+            game={game}
+            onNavigateToGameInfo={handleGameInfo}
+            onNavigateToPlayerInfo={handlePlayerInfo}
+          />
         }
       />
-      <GameInfoContent onNavigateToPlayerInfo={handlePlayerInfo} />
+      <GameInfoContent
+        onNavigateToPlayerInfo={handlePlayerInfo}
+        pendingAction={pendingAction}
+      />
     </ScreenContainer>
   );
 };


### PR DESCRIPTION
##
The 'join game' button was a non-salient button in the app bar. It was not clear that was where to join - the key CTA on this screen. I moved the button to the 'Game has not yet started' block, and made 'Join game' a primary button - so it's very salient, if you're on this screen the next logical step should be to join it. 
                                                             
  ## Summary                                                                                                                                                                                
  - Moves the join/leave game buttons from the app bar icon buttons to a text CTA adjacent to the \"game not started yet\" notice
  - On desktop the button sits inline to the right of the notice; on mobile it appears below it                                                                                             
  - Invalidates the game query after join/leave so the button switches immediately without a page reload                                                                                    
                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                              
  - [ ] Open a pending game as a non-member — \"Join game\" (dark) appears next to the notice                                                                                               
  - [ ] Click Join game — button switches to \"Leave game\" (outline) after server confirms                                                                                                 
  - [ ] Open a pending game as a member — \"Leave game\" (outline) appears next to the notice                                                                                               
  - [ ] Click Leave game — button switches to \"Join game\" after server confirms                                                                                                           
  - [ ] On mobile viewport — button appears below the notice text                                                                                                                           
  - [ ] App bar no longer shows the icon-only join/leave button                                                                                                                           
                                                                                                                                                                                            
 