### PR TITLE
2X a day: Variant description and rules on game info and create game screens

### DIFF
--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Calendar, Clock, Users, Lock, Unlock, User, Map, Trophy, Pause, Shield, MessageSquare, MessageSquareOff } from "lucide-react";
+import { BookOpen, Calendar, Clock, Users, Lock, Unlock, User, Map, Trophy, Pause, Shield, MessageSquare, MessageSquareOff } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -38,6 +38,24 @@ const MetadataRow: React.FC<MetadataRowProps> = ({ icon, label, value }) => {
   );
 };
 
+interface MetadataTextRowProps {
+  icon: React.ReactNode;
+  label: string;
+  text: string;
+}
+
+const MetadataTextRow: React.FC<MetadataTextRowProps> = ({ icon, label, text }) => {
+  return (
+    <div className="py-3 px-2">
+      <div className="flex items-center gap-3 mb-1">
+        <div className="text-muted-foreground">{icon}</div>
+        <span className="text-sm">{label}</span>
+      </div>
+      <p className="text-sm text-muted-foreground whitespace-pre-line pl-7">{text}</p>
+    </div>
+  );
+};
+
 interface GameInfoContentProps {
   onNavigateToPlayerInfo: () => void;
 }
@@ -72,18 +90,27 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
             label="Variant"
             value={variant?.name ?? <Skeleton className="h-4 w-24" />}
           />
+          {variant?.description && (
+            <MetadataTextRow
+              icon={<Map className="size-4" />}
+              label="Description"
+              text={variant.description}
+            />
+          )}
           <MetadataRow
             icon={<Clock className="size-4" />}
             label="Created"
             value={formatTimeAgo(game.createdAt)}
           />
-          <MetadataRow
-            icon={<Calendar className="size-4" />}
-            label="Phase deadlines"
-            value={
+          <div className="py-3 px-2">
+            <div className="flex items-center gap-3 mb-1">
+              <div className="text-muted-foreground"><Calendar className="size-4" /></div>
+              <span className="text-sm">Phase deadlines</span>
+            </div>
+            <div className="text-sm text-muted-foreground pl-7">
               <DeadlineSummary game={game} />
-            }
-          />
+            </div>
+          </div>
           <MetadataRow
             icon={
               game.private ? (
@@ -181,6 +208,13 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
             label="Original author"
             value={variant?.author ?? <Skeleton className="h-4 w-24" />}
           />
+          {variant?.rules && (
+            <MetadataTextRow
+              icon={<BookOpen className="size-4" />}
+              label="Rules"
+              text={variant.rules}
+            />
+          )}
           {variant && currentPhase ? (
             <div className="w-full aspect-square overflow-hidden">
               <MapPreview

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Users, Calendar, User, Clock } from "lucide-react";
+import { BookOpen, Calendar, Clock, Map, User, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -111,7 +111,8 @@ const modeToBackendFields = (mode: StandardGameFormValues["mode"]) => ({
 
 interface MetadataRow {
   label: string;
-  value: string | React.ReactNode;
+  value?: string | React.ReactNode;
+  text?: string;
   icon?: React.ReactNode;
 }
 
@@ -122,15 +123,25 @@ interface GameMetadataTableProps {
 const GameMetadataTable: React.FC<GameMetadataTableProps> = ({ rows }) => {
   return (
     <div className="divide-y border rounded-lg">
-      {rows.map((row, index) => (
-        <div key={index} className="flex items-center justify-between p-4">
-          <div className="flex items-center gap-3">
-            {row.icon}
-            <span className="text-sm">{row.label}</span>
+      {rows.map((row, index) =>
+        row.text ? (
+          <div key={index} className="p-4">
+            <div className="flex items-center gap-3 mb-1">
+              {row.icon}
+              <span className="text-sm">{row.label}</span>
+            </div>
+            <p className="text-sm text-muted-foreground whitespace-pre-line pl-7">{row.text}</p>
           </div>
-          <span className="text-sm text-muted-foreground">{row.value}</span>
-        </div>
-      ))}
+        ) : (
+          <div key={index} className="flex items-center justify-between p-4">
+            <div className="flex items-center gap-3">
+              {row.icon}
+              <span className="text-sm">{row.label}</span>
+            </div>
+            <span className="text-sm text-muted-foreground">{row.value}</span>
+          </div>
+        )
+      )}
     </div>
   );
 };
@@ -207,6 +218,16 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
             value: selectedVariant?.author,
             icon: <User className="size-4" />,
           },
+          ...(selectedVariant?.description ? [{
+            label: "Description",
+            text: selectedVariant.description,
+            icon: <Map className="size-4" />,
+          }] : []),
+          ...(selectedVariant?.rules ? [{
+            label: "Rules",
+            text: selectedVariant.rules,
+            icon: <BookOpen className="size-4" />,
+          }] : []),
         ]}
       />
     </div>


### PR DESCRIPTION
Summary
                                                                                                                                                                                            
  - Adds Description and Rules fields from the variant (.dvar) to the Game Info screen — description appears below Variant, rules below Original author                                   
  - Adds the same two fields to the Create Game screen's variant metadata table                                                                                                             
  - Fixes Phase deadlines on the Game Info screen to display its text on a new line below the label (consistent with description/rules), since the deadline summary can be long             
                                                                                                                                                                                            
  Details                                                                                                                                                                                   
                                                                                                                                                                                            
  Both fields are conditionally rendered (only shown when the variant provides them). Long-form text uses whitespace-pre-line so newlines in the source data (e.g. multi-line rules) render 
  correctly.
                                                                                                                                                                                            
  A new MetadataTextRow component handles the stacked label+body layout in GameInfoContent. The GameMetadataTable in CreateGame was extended with an optional text field to support the same
   pattern without a separate component.
                                                                                                                                                                                            
  Test plan                                                                                                                                                                               

  - Open Game Info for a variant that has description/rules — confirm both fields appear in the correct positions                                                                           
  - Open Game Info for classic Diplomacy (no description/rules in dVAR) — confirm neither field appears
  - Open Create Game, select a variant with description/rules — confirm they appear below Original author in the variant table                                                              
  - Verify Phase deadlines text wraps correctly on a narrow screen         


<img width="838" height="489" alt="create-game" src="https://github.com/user-attachments/assets/29fc6186-3590-4b3e-abf8-27dbcfb25727" />
<img width="474" height="841" alt="new-game-info-mobile" src="https://github.com/user-attachments/assets/a9cffcc2-506c-4f76-b1b8-711afae55522" />
<img width="915" height="894" alt="new-game-info" src="https://github.com/user-attachments/assets/c7b369be-cc9d-44a4-96ca-028d262f3356" />

<img width="473" height="546" alt="create-game-mobile" src="https://github.com/user-attachments/assets/65b43af6-f28b-4c01-be93-ab3eae216c7f" />