### PR TITLE
UX a day: Order builder

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -718,6 +718,7 @@ export interface VictoryConditions {
 
 export interface VariantProvince {
   id: string;
+  name: string;
   /** @nullable */
   parentId: string | null;
 }

--- a/packages/web/src/components/FloatingMenu.tsx
+++ b/packages/web/src/components/FloatingMenu.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Portal } from "@radix-ui/react-portal";
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 
 export interface FloatingMenuProps {
@@ -63,6 +64,9 @@ function FloatingMenu({
     return (
       <Sheet open={open} onOpenChange={open => !open && onClose?.()}>
         <SheetContent side="bottom" className="rounded-t-lg">
+          <VisuallyHidden.Root>
+            <SheetTitle>Order options</SheetTitle>
+          </VisuallyHidden.Root>
           <div role="menu" className="flex flex-col py-1">
             {children}
           </div>

--- a/packages/web/src/components/FloatingMenu.tsx
+++ b/packages/web/src/components/FloatingMenu.tsx
@@ -3,7 +3,7 @@ import { Portal } from "@radix-ui/react-portal";
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 
 export interface FloatingMenuProps {
@@ -66,6 +66,7 @@ function FloatingMenu({
         <SheetContent side="bottom" className="rounded-t-lg">
           <VisuallyHidden.Root>
             <SheetTitle>Order options</SheetTitle>
+            <SheetDescription>Select an order option</SheetDescription>
           </VisuallyHidden.Root>
           <div role="menu" className="flex flex-col py-1">
             {children}

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -34,6 +34,7 @@ type WizardState = {
   isComplete: boolean;
   selectedArray: string[];
   resolvedSelections: Record<string, string>;
+  resolvedLabels: Record<string, string>;
   nextField: string | null;
   choices: never[];
   selections: Record<string, string>;
@@ -48,6 +49,7 @@ function buildIdleWizard(): WizardState {
     isComplete: false,
     selectedArray: [],
     resolvedSelections: {},
+    resolvedLabels: {},
     nextField: "source",
     choices: [],
     selections: {},
@@ -180,6 +182,7 @@ function completeWizard() {
     isComplete: true,
     selectedArray: ["lon", "Move", "nth"],
     resolvedSelections: { source: "lon", orderType: "Move", target: "nth" },
+    resolvedLabels: { source: "London", orderType: "Move", target: "North Sea" },
   };
 }
 

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -86,7 +86,7 @@ const GameMap: React.FC = () => {
     [game?.members]
   );
 
-  const isWizardActive = Object.keys(wizard.selections).length > 0;
+  const isWizardActive = Object.keys(wizard.resolvedSelections).length > 0;
 
   const provinceNameMap = useMemo(
     () =>
@@ -223,7 +223,8 @@ const GameMap: React.FC = () => {
       ? buildOrderProgressText(
           wizard.resolvedSelections,
           wizard.resolvedLabels,
-          phase
+          phase,
+          wizard.isComplete
         )
       : null;
 

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -1,5 +1,5 @@
 import { useRequiredParams } from "../hooks";
-import { useRef, useMemo, useEffect, useState } from "react";
+import { useRef, useMemo, useEffect, useState, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { determineRenderableProvinces } from "../utils/provinces";
@@ -22,6 +22,31 @@ import {
 } from "../api/generated/endpoints";
 import { useOrderWizard } from "../hooks/useOrderWizard";
 
+function useBanner(duration = 3000) {
+  const [message, setMessage] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const show = useCallback(
+    (text: string) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setMessage(text);
+      timerRef.current = setTimeout(() => {
+        setMessage(null);
+        timerRef.current = null;
+      }, duration);
+    },
+    [duration]
+  );
+
+  return { message, show };
+}
+
 const GameMap: React.FC = () => {
   const { gameId, phaseId } = useRequiredParams<{
     gameId: string;
@@ -38,13 +63,12 @@ const GameMap: React.FC = () => {
   const { data: optionsData } = useGameOptionsRetrieve(gameId);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const bannerClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [menuPosition, setMenuPosition] = useState<{
     x: number;
     y: number;
   } | null>(null);
   const [pendingOrder, setPendingOrder] = useState<Order | null>(null);
-  const [bannerMessage, setBannerMessage] = useState<string | null>(null);
+  const banner = useBanner();
   const createOrderMutation = useGameOrdersCreate();
 
   const wizard = useOrderWizard(
@@ -84,31 +108,6 @@ const GameMap: React.FC = () => {
     if (!variant) return [];
     return determineRenderableProvinces(variant.provinces, highlightedIds);
   }, [variant, highlightedIds]);
-
-  const showBanner = (message: string, duration = 3000) => {
-    if (bannerClearRef.current) clearTimeout(bannerClearRef.current);
-    setBannerMessage(message);
-    bannerClearRef.current = setTimeout(() => {
-      setBannerMessage(null);
-      bannerClearRef.current = null;
-    }, duration);
-  };
-
-  useEffect(() => {
-    if (isWizardActive) {
-      if (bannerClearRef.current) {
-        clearTimeout(bannerClearRef.current);
-        bannerClearRef.current = null;
-      }
-      setBannerMessage(null);
-    }
-  }, [isWizardActive]);
-
-  useEffect(() => {
-    return () => {
-      if (bannerClearRef.current) clearTimeout(bannerClearRef.current);
-    };
-  }, []);
 
   useEffect(() => {
     if (!wizard.isComplete || wizard.selectedArray.length === 0) return;
@@ -168,11 +167,11 @@ const GameMap: React.FC = () => {
         if (!phase) return;
         const unit = phase.units.find((u) => u.province.id === province);
         if (unit && !game?.sandbox) {
-          showBanner(
+          banner.show(
             `${unitAbbrev(unit.type)} ${unit.province.name} (${unit.nation.name})`
           );
         } else if (!unit) {
-          showBanner(provinceNameMap[province] ?? province);
+          banner.show(provinceNameMap[province] ?? province);
         }
         return;
       }
@@ -228,7 +227,7 @@ const GameMap: React.FC = () => {
         )
       : null;
 
-  const displayBannerText = bannerMessage ?? progressText;
+  const displayBannerText = progressText ?? banner.message;
 
   return (
     <div ref={containerRef} className="relative w-full h-full">

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -4,6 +4,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { determineRenderableProvinces } from "../utils/provinces";
 import { buildOptimisticOrder } from "../utils/buildOptimisticOrder";
+import {
+  buildOrderProgressText,
+  unitAbbrev,
+} from "../utils/buildOrderProgressText";
 import { InteractiveMapZoomWrapper } from "./InteractiveMap/InteractiveMapZoomWrapper";
 import { FloatingMenu, FloatingMenuItem } from "./FloatingMenu";
 import {
@@ -34,11 +38,13 @@ const GameMap: React.FC = () => {
   const { data: optionsData } = useGameOptionsRetrieve(gameId);
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const bannerClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [menuPosition, setMenuPosition] = useState<{
     x: number;
     y: number;
   } | null>(null);
   const [pendingOrder, setPendingOrder] = useState<Order | null>(null);
+  const [bannerMessage, setBannerMessage] = useState<string | null>(null);
   const createOrderMutation = useGameOrdersCreate();
 
   const wizard = useOrderWizard(
@@ -58,12 +64,17 @@ const GameMap: React.FC = () => {
 
   const isWizardActive = Object.keys(wizard.selections).length > 0;
 
+  const provinceNameMap = useMemo(
+    () =>
+      Object.fromEntries(
+        (variant?.provinces ?? []).map((p) => [p.id, p.name])
+      ),
+    [variant?.provinces]
+  );
+
   const highlightedIds = useMemo(() => {
     if (!isWizardActive) return [];
-    if (
-      wizard.nextField === "target" ||
-      wizard.nextField === "aux"
-    ) {
+    if (wizard.nextField === "target" || wizard.nextField === "aux") {
       return wizard.choices.map((c) => c.id);
     }
     return [];
@@ -73,6 +84,31 @@ const GameMap: React.FC = () => {
     if (!variant) return [];
     return determineRenderableProvinces(variant.provinces, highlightedIds);
   }, [variant, highlightedIds]);
+
+  const showBanner = (message: string, duration = 3000) => {
+    if (bannerClearRef.current) clearTimeout(bannerClearRef.current);
+    setBannerMessage(message);
+    bannerClearRef.current = setTimeout(() => {
+      setBannerMessage(null);
+      bannerClearRef.current = null;
+    }, duration);
+  };
+
+  useEffect(() => {
+    if (isWizardActive) {
+      if (bannerClearRef.current) {
+        clearTimeout(bannerClearRef.current);
+        bannerClearRef.current = null;
+      }
+      setBannerMessage(null);
+    }
+  }, [isWizardActive]);
+
+  useEffect(() => {
+    return () => {
+      if (bannerClearRef.current) clearTimeout(bannerClearRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!wizard.isComplete || wizard.selectedArray.length === 0) return;
@@ -128,7 +164,18 @@ const GameMap: React.FC = () => {
     }
 
     if (wizard.nextField === "source") {
-      if (!wizard.choices.some((c) => c.id === province)) return;
+      if (!wizard.choices.some((c) => c.id === province)) {
+        if (!phase) return;
+        const unit = phase.units.find((u) => u.province.id === province);
+        if (unit && !game?.sandbox) {
+          showBanner(
+            `${unitAbbrev(unit.type)} ${unit.province.name} (${unit.nation.name})`
+          );
+        } else if (!unit) {
+          showBanner(provinceNameMap[province] ?? province);
+        }
+        return;
+      }
       captureMenuPosition(event);
       wizard.select(province);
     } else if (
@@ -172,6 +219,17 @@ const GameMap: React.FC = () => {
       ]
     : orders;
 
+  const progressText =
+    phase && isWizardActive
+      ? buildOrderProgressText(
+          wizard.resolvedSelections,
+          wizard.resolvedLabels,
+          phase
+        )
+      : null;
+
+  const displayBannerText = bannerMessage ?? progressText;
+
   return (
     <div ref={containerRef} className="relative w-full h-full">
       {game && variant && phase && orders && (
@@ -206,6 +264,11 @@ const GameMap: React.FC = () => {
             ))}
           </FloatingMenu>
         </>
+      )}
+      {displayBannerText !== null && (
+        <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 bg-black/70 text-white px-4 py-2 rounded-full text-sm font-medium pointer-events-none whitespace-nowrap">
+          {displayBannerText}
+        </div>
       )}
     </div>
   );

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -20,10 +20,19 @@ const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
 
 const nation = { nationId: "england", name: "England", color: "#fff", flagUrl: null };
 
+const province = (id: string, name: string) => ({
+  id,
+  name,
+  type: "land",
+  supplyCenter: false,
+  parentId: null,
+  namedCoastIds: [] as string[],
+});
+
 const army = (provinceId: string, provinceName: string) => ({
   type: "Army",
   nation,
-  province: { id: provinceId, name: provinceName },
+  province: province(provinceId, provinceName),
   dislodged: false,
   dislodgedBy: null,
 });
@@ -31,7 +40,7 @@ const army = (provinceId: string, provinceName: string) => ({
 const fleet = (provinceId: string, provinceName: string) => ({
   type: "Fleet",
   nation,
-  province: { id: provinceId, name: provinceName },
+  province: province(provinceId, provinceName),
   dislodged: false,
   dislodgedBy: null,
 });

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -18,9 +18,11 @@ const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
   nextPhaseId: null,
 });
 
+const nation = { nationId: "england", name: "England", color: "#fff", flagUrl: null };
+
 const army = (provinceId: string, provinceName: string) => ({
   type: "Army",
-  nation: { id: "england", name: "England" },
+  nation,
   province: { id: provinceId, name: provinceName },
   dislodged: false,
   dislodgedBy: null,
@@ -28,7 +30,7 @@ const army = (provinceId: string, provinceName: string) => ({
 
 const fleet = (provinceId: string, provinceName: string) => ({
   type: "Fleet",
-  nation: { id: "england", name: "England" },
+  nation,
   province: { id: provinceId, name: provinceName },
   dislodged: false,
   dislodgedBy: null,

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from "vitest";
+import { buildOrderProgressText, unitAbbrev } from "./buildOrderProgressText";
+import type { PhaseRetrieve } from "../api/generated/endpoints";
+
+const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
+  id: 1,
+  ordinal: 1,
+  season: "Spring",
+  year: 1901,
+  name: "Spring 1901",
+  type: "Diplomacy",
+  remainingTime: 0,
+  scheduledResolution: "",
+  status: "pending" as PhaseRetrieve["status"],
+  units,
+  supplyCenters: [],
+  previousPhaseId: null,
+  nextPhaseId: null,
+});
+
+const army = (provinceId: string, provinceName: string) => ({
+  type: "Army",
+  nation: { id: "england", name: "England" },
+  province: { id: provinceId, name: provinceName },
+  dislodged: false,
+  dislodgedBy: null,
+});
+
+const fleet = (provinceId: string, provinceName: string) => ({
+  type: "Fleet",
+  nation: { id: "england", name: "England" },
+  province: { id: provinceId, name: provinceName },
+  dislodged: false,
+  dislodgedBy: null,
+});
+
+describe("unitAbbrev", () => {
+  it("returns A for Army", () => expect(unitAbbrev("Army")).toBe("A"));
+  it("returns F for Fleet", () => expect(unitAbbrev("Fleet")).toBe("F"));
+  it("returns empty string for unknown", () => expect(unitAbbrev("unknown")).toBe(""));
+  it("returns empty string for undefined", () => expect(unitAbbrev(undefined)).toBe(""));
+});
+
+describe("buildOrderProgressText", () => {
+  const phase = makePhase([army("par", "Paris"), fleet("bre", "Brest")]);
+
+  describe("no source", () => {
+    it("returns null", () => {
+      expect(buildOrderProgressText({}, {}, phase, false)).toBeNull();
+    });
+  });
+
+  describe("source only (no orderType)", () => {
+    it("shows unit abbreviation and label when unit is in province", () => {
+      expect(
+        buildOrderProgressText({ source: "par" }, { source: "Paris" }, phase, false)
+      ).toBe("A Paris");
+    });
+
+    it("shows just the province label when no unit is there", () => {
+      expect(
+        buildOrderProgressText({ source: "lon" }, { source: "London" }, phase, false)
+      ).toBe("London");
+    });
+
+    it("falls back to the province id when no label", () => {
+      expect(
+        buildOrderProgressText({ source: "par" }, {}, phase, false)
+      ).toBe("A par");
+    });
+  });
+
+  describe("Build", () => {
+    const emptyPhase = makePhase();
+
+    it("shows ellipsis when unitType not yet selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "lon", orderType: "Build" },
+          { source: "London" },
+          emptyPhase,
+          false
+        )
+      ).toBe("Build in London ...");
+    });
+
+    it("shows full build text when unitType selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "lon", orderType: "Build", unitType: "Army" },
+          { source: "London", unitType: "Army" },
+          emptyPhase,
+          false
+        )
+      ).toBe("Build Army in London");
+    });
+
+    it("falls back to unitType id when no label", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "lon", orderType: "Build", unitType: "Army" },
+          { source: "London" },
+          emptyPhase,
+          false
+        )
+      ).toBe("Build Army in London");
+    });
+  });
+
+  describe("Hold", () => {
+    it("shows unit + Hold", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Hold" },
+          { source: "Paris" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Hold");
+    });
+  });
+
+  describe("Disband", () => {
+    it("shows unit + Disband", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "bre", orderType: "Disband" },
+          { source: "Brest" },
+          phase,
+          true
+        )
+      ).toBe("F Brest Disband");
+    });
+  });
+
+  describe("Move", () => {
+    it("shows ellipsis when target not selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Move" },
+          { source: "Paris" },
+          phase,
+          false
+        )
+      ).toBe("A Paris Move to ...");
+    });
+
+    it("shows full move text when target selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Move", target: "bur" },
+          { source: "Paris", target: "Burgundy" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Move to Burgundy");
+    });
+
+    it("falls back to target id when no label", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Move", target: "bur" },
+          { source: "Paris" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Move to bur");
+    });
+  });
+
+  describe("MoveViaConvoy", () => {
+    it("shows ellipsis with via Convoy suffix when target not selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "MoveViaConvoy" },
+          { source: "Paris" },
+          phase,
+          false
+        )
+      ).toBe("A Paris Move via Convoy to ...");
+    });
+
+    it("shows full move via convoy text", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "MoveViaConvoy", target: "lon" },
+          { source: "Paris", target: "London" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Move via Convoy to London");
+    });
+  });
+
+  describe("Support", () => {
+    it("shows ellipsis when aux not selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Support" },
+          { source: "Paris" },
+          phase,
+          false
+        )
+      ).toBe("A Paris Supports ...");
+    });
+
+    it("shows aux with ellipsis when target not selected and not complete (hold support in progress)", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Support", aux: "bre" },
+          { source: "Paris", aux: "Brest" },
+          phase,
+          false
+        )
+      ).toBe("A Paris Supports F Brest ...");
+    });
+
+    it("shows aux without ellipsis when isComplete (hold support)", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Support", aux: "bre" },
+          { source: "Paris", aux: "Brest" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Supports F Brest");
+    });
+
+    it("shows full support move text with target", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Support", aux: "bre", target: "pic" },
+          { source: "Paris", aux: "Brest", target: "Picardy" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Supports F Brest to Picardy");
+    });
+
+    it("shows aux province name when no unit in aux province", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Support", aux: "lon" },
+          { source: "Paris", aux: "London" },
+          phase,
+          true
+        )
+      ).toBe("A Paris Supports London");
+    });
+  });
+
+  describe("Convoy", () => {
+    it("shows ellipsis when aux not selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "bre", orderType: "Convoy" },
+          { source: "Brest" },
+          phase,
+          false
+        )
+      ).toBe("F Brest Convoys ...");
+    });
+
+    it("shows aux with ellipsis when target not selected", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "bre", orderType: "Convoy", aux: "par" },
+          { source: "Brest", aux: "Paris" },
+          phase,
+          false
+        )
+      ).toBe("F Brest Convoys A Paris to ...");
+    });
+
+    it("shows full convoy text with target", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "bre", orderType: "Convoy", aux: "par", target: "lon" },
+          { source: "Brest", aux: "Paris", target: "London" },
+          phase,
+          true
+        )
+      ).toBe("F Brest Convoys A Paris to London");
+    });
+
+    it("shows aux province name when no unit in aux province", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "bre", orderType: "Convoy", aux: "lon", target: "edi" },
+          { source: "Brest", aux: "London", target: "Edinburgh" },
+          phase,
+          true
+        )
+      ).toBe("F Brest Convoys London to Edinburgh");
+    });
+  });
+
+  describe("unknown orderType", () => {
+    it("returns sourceLabel as fallback", () => {
+      expect(
+        buildOrderProgressText(
+          { source: "par", orderType: "Unknown" },
+          { source: "Paris" },
+          phase,
+          false
+        )
+      ).toBe("A Paris");
+    });
+  });
+});

--- a/packages/web/src/utils/buildOrderProgressText.ts
+++ b/packages/web/src/utils/buildOrderProgressText.ts
@@ -9,11 +9,12 @@ function unitAbbrev(type: string | undefined): string {
 function buildOrderProgressText(
   resolvedSelections: Record<string, string>,
   resolvedLabels: Record<string, string>,
-  phase: PhaseRetrieve
-): string {
+  phase: PhaseRetrieve,
+  isComplete: boolean
+): string | null {
   const { source, orderType, target, aux, unitType } = resolvedSelections;
 
-  if (!source) return "";
+  if (!source) return null;
 
   const unitsByProvince = Object.fromEntries(
     phase.units.map((u) => [u.province.id, u])
@@ -28,7 +29,7 @@ function buildOrderProgressText(
 
   if (orderType === "Build") {
     if (!unitType) return `Build in ${sourceName} ...`;
-    return `Build ${unitType} in ${sourceName}`;
+    return `Build ${resolvedLabels["unitType"] ?? unitType} in ${sourceName}`;
   }
 
   const unit = unitsByProvince[source];
@@ -48,7 +49,7 @@ function buildOrderProgressText(
     const auxUnit = unitsByProvince[aux];
     const auxName = resolvedLabels["aux"] ?? aux;
     const auxLabel = auxUnit ? `${unitAbbrev(auxUnit.type)} ${auxName}` : auxName;
-    if (!target) return `${sourceLabel} Supports ${auxLabel} ...`;
+    if (!target) return isComplete ? `${sourceLabel} Supports ${auxLabel}` : `${sourceLabel} Supports ${auxLabel} ...`;
     return `${sourceLabel} Supports ${auxLabel} to ${resolvedLabels["target"] ?? target}`;
   }
 

--- a/packages/web/src/utils/buildOrderProgressText.ts
+++ b/packages/web/src/utils/buildOrderProgressText.ts
@@ -1,0 +1,63 @@
+import type { PhaseRetrieve } from "../api/generated/endpoints";
+
+function unitAbbrev(type: string | undefined): string {
+  if (type === "Army") return "A";
+  if (type === "Fleet") return "F";
+  return "";
+}
+
+function buildOrderProgressText(
+  resolvedSelections: Record<string, string>,
+  resolvedLabels: Record<string, string>,
+  phase: PhaseRetrieve
+): string {
+  const { source, orderType, target, aux, unitType } = resolvedSelections;
+
+  if (!source) return "";
+
+  const sourceName = resolvedLabels["source"] ?? source;
+
+  if (!orderType) {
+    const unit = phase.units.find((u) => u.province.id === source);
+    return unit ? `${unitAbbrev(unit.type)} ${sourceName}` : sourceName;
+  }
+
+  if (orderType === "Build") {
+    if (!unitType) return `Build in ${sourceName} ...`;
+    return `Build ${unitType} in ${sourceName}`;
+  }
+
+  const unit = phase.units.find((u) => u.province.id === source);
+  const sourceLabel = unit ? `${unitAbbrev(unit.type)} ${sourceName}` : sourceName;
+
+  if (orderType === "Hold") return `${sourceLabel} Hold`;
+  if (orderType === "Disband") return `${sourceLabel} Disband`;
+
+  if (orderType === "Move" || orderType === "MoveViaConvoy") {
+    const via = orderType === "MoveViaConvoy" ? " via Convoy" : "";
+    if (!target) return `${sourceLabel} Move${via} to ...`;
+    return `${sourceLabel} Move${via} to ${resolvedLabels["target"] ?? target}`;
+  }
+
+  if (orderType === "Support") {
+    if (!aux) return `${sourceLabel} Supports ...`;
+    const auxUnit = phase.units.find((u) => u.province.id === aux);
+    const auxName = resolvedLabels["aux"] ?? aux;
+    const auxLabel = auxUnit ? `${unitAbbrev(auxUnit.type)} ${auxName}` : auxName;
+    if (!target) return `${sourceLabel} Supports ${auxLabel} ...`;
+    return `${sourceLabel} Supports ${auxLabel} to ${resolvedLabels["target"] ?? target}`;
+  }
+
+  if (orderType === "Convoy") {
+    if (!aux) return `${sourceLabel} Convoys ...`;
+    const auxUnit = phase.units.find((u) => u.province.id === aux);
+    const auxName = resolvedLabels["aux"] ?? aux;
+    const auxLabel = auxUnit ? `${unitAbbrev(auxUnit.type)} ${auxName}` : auxName;
+    if (!target) return `${sourceLabel} Convoys ${auxLabel} to ...`;
+    return `${sourceLabel} Convoys ${auxLabel} to ${resolvedLabels["target"] ?? target}`;
+  }
+
+  return sourceLabel;
+}
+
+export { buildOrderProgressText, unitAbbrev };

--- a/packages/web/src/utils/buildOrderProgressText.ts
+++ b/packages/web/src/utils/buildOrderProgressText.ts
@@ -15,10 +15,14 @@ function buildOrderProgressText(
 
   if (!source) return "";
 
+  const unitsByProvince = Object.fromEntries(
+    phase.units.map((u) => [u.province.id, u])
+  );
+
   const sourceName = resolvedLabels["source"] ?? source;
 
   if (!orderType) {
-    const unit = phase.units.find((u) => u.province.id === source);
+    const unit = unitsByProvince[source];
     return unit ? `${unitAbbrev(unit.type)} ${sourceName}` : sourceName;
   }
 
@@ -27,7 +31,7 @@ function buildOrderProgressText(
     return `Build ${unitType} in ${sourceName}`;
   }
 
-  const unit = phase.units.find((u) => u.province.id === source);
+  const unit = unitsByProvince[source];
   const sourceLabel = unit ? `${unitAbbrev(unit.type)} ${sourceName}` : sourceName;
 
   if (orderType === "Hold") return `${sourceLabel} Hold`;
@@ -41,7 +45,7 @@ function buildOrderProgressText(
 
   if (orderType === "Support") {
     if (!aux) return `${sourceLabel} Supports ...`;
-    const auxUnit = phase.units.find((u) => u.province.id === aux);
+    const auxUnit = unitsByProvince[aux];
     const auxName = resolvedLabels["aux"] ?? aux;
     const auxLabel = auxUnit ? `${unitAbbrev(auxUnit.type)} ${auxName}` : auxName;
     if (!target) return `${sourceLabel} Supports ${auxLabel} ...`;
@@ -50,7 +54,7 @@ function buildOrderProgressText(
 
   if (orderType === "Convoy") {
     if (!aux) return `${sourceLabel} Convoys ...`;
-    const auxUnit = phase.units.find((u) => u.province.id === aux);
+    const auxUnit = unitsByProvince[aux];
     const auxName = resolvedLabels["aux"] ?? aux;
     const auxLabel = auxUnit ? `${unitAbbrev(auxUnit.type)} ${auxName}` : auxName;
     if (!target) return `${sourceLabel} Convoys ${auxLabel} to ...`;

--- a/packages/web/src/utils/deriveWizardStep.ts
+++ b/packages/web/src/utils/deriveWizardStep.ts
@@ -17,6 +17,7 @@ export interface WizardStep {
   isComplete: boolean;
   selectedArray: string[];
   resolvedSelections: Record<string, string>;
+  resolvedLabels: Record<string, string>;
 }
 
 const UNIVERSAL_PREFIX: FieldName[] = ["source", "orderType"];
@@ -50,6 +51,7 @@ export function deriveWizardStep(
   selections: Record<string, string>
 ): WizardStep {
   const resolvedSelections: Record<string, string> = { ...selections };
+  const resolvedLabels: Record<string, string> = {};
 
   // Handle empty orders early
   if (orders.length === 0) {
@@ -59,6 +61,7 @@ export function deriveWizardStep(
       isComplete: false,
       selectedArray: [],
       resolvedSelections,
+      resolvedLabels,
     };
   }
 
@@ -80,6 +83,12 @@ export function deriveWizardStep(
     for (const f of sequence) {
       const field = f as FieldName;
       if (resolvedSelections[field] !== undefined) {
+        if (resolvedLabels[field] === undefined) {
+          const matchFV = filtered
+            .find((o) => o[field]?.id === resolvedSelections[field])
+            ?.[field];
+          if (matchFV) resolvedLabels[field] = matchFV.label;
+        }
         continue;
       }
 
@@ -99,8 +108,9 @@ export function deriveWizardStep(
       }
 
       if (distinct.length === 1) {
-        // Auto-advance: record and re-filter
+        // Auto-advance: record selection and label, then re-filter
         resolvedSelections[field] = distinct[0].id;
+        resolvedLabels[field] = distinct[0].label;
         filtered = filterOrders(orders, resolvedSelections);
         foundNextField = false;
         // Restart the sequence walk (break inner loop, re-run outer while)
@@ -114,6 +124,7 @@ export function deriveWizardStep(
         isComplete: false,
         selectedArray: buildSelectedArray(fieldOrder, resolvedSelections),
         resolvedSelections,
+        resolvedLabels,
       };
     }
 
@@ -140,6 +151,7 @@ export function deriveWizardStep(
         isComplete: true,
         selectedArray: buildSelectedArray(fieldOrder, resolvedSelections),
         resolvedSelections,
+        resolvedLabels,
       };
     }
 
@@ -154,6 +166,7 @@ export function deriveWizardStep(
     isComplete: false,
     selectedArray: buildSelectedArray(fieldOrder, resolvedSelections),
     resolvedSelections,
+    resolvedLabels,
   };
 }
 

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -3060,11 +3060,14 @@ components:
       properties:
         id:
           type: string
+        name:
+          type: string
         parentId:
           type: string
           nullable: true
       required:
       - id
+      - name
       - parentId
     VariantTemplateNationRef:
       type: object

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -26,6 +26,7 @@ class VictoryConditionsSerializer(serializers.Serializer):
 
 class VariantProvinceSerializer(serializers.Serializer):
     id = serializers.CharField(source="province_id")
+    name = serializers.CharField()
     parent_id = serializers.CharField(source="parent.province_id", allow_null=True)
 
 


### PR DESCRIPTION
## Summary

- Adds a pill overlay on the map showing order progress text as the user builds an order (e.g. `A Paris Move to Burgundy ...`)
- Shows province/unit info when tapping a non-selectable province (auto-dismisses after 3s)
- Exposes `VariantProvince.name` from the API to support human-readable province names in the overlay
- Fixes missing `SheetTitle`/`SheetDescription` accessibility warning in `FloatingMenu`

## Test plan

- [ ] Tap a unit on the map — pill shows unit abbreviation and province name
- [ ] Step through each order type (Hold, Move, Support, Convoy, Build, Disband) — pill updates at each step
- [ ] Complete an order — pill clears
- [ ] Tap a non-selectable province — pill shows province/unit info and disappears after ~3s
- [ ] Tap another nation's unit in non-sandbox mode — pill shows unit info
- [ ] `npm run test buildOrderProgressText` passes (28 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)