### PR TITLE
2X a day: Remove stale 'leave game' button in PlayerInfo

### DIFF
--- a/packages/web/src/screens/Home/PlayerInfo.tsx
+++ b/packages/web/src/screens/Home/PlayerInfo.tsx
@@ -1,23 +1,12 @@
 import React, { Suspense } from "react";
 import { useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
-import { UserPlus, UserMinus } from "lucide-react";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
 import { GameDropdownMenu } from "@/components/GameDropdownMenu";
-import {
-  useGameRetrieveSuspense,
-  useGameJoinCreate,
-  useGameLeaveDestroy,
-} from "@/api/generated/endpoints";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Button } from "@/components/ui/button";
+import { useGameRetrieveSuspense } from "@/api/generated/endpoints";
 import { PlayerInfoContent } from "@/components/PlayerInfoContent";
 
 const PlayerInfo: React.FC = () => {
@@ -25,16 +14,6 @@ const PlayerInfo: React.FC = () => {
 
   const navigate = useNavigate();
   const { data: game } = useGameRetrieveSuspense(gameId);
-  const joinGameMutation = useGameJoinCreate();
-  const leaveGameMutation = useGameLeaveDestroy();
-
-  const handleJoinGame = async () => {
-    await joinGameMutation.mutateAsync({ gameId, data: {} });
-  };
-
-  const handleLeaveGame = async () => {
-    await leaveGameMutation.mutateAsync({ gameId });
-  };
 
   const handlePlayerInfo = () => {
     navigate(`/player-info/${gameId}`);
@@ -44,53 +23,16 @@ const PlayerInfo: React.FC = () => {
     navigate(`/game-info/${gameId}`);
   };
 
-  const joinLeaveButton = game.canJoin ? (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          onClick={handleJoinGame}
-          disabled={joinGameMutation.isPending}
-          variant="outline"
-          aria-label="Join game"
-        >
-          <UserPlus className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p>Join game</p>
-      </TooltipContent>
-    </Tooltip>
-  ) : (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          onClick={handleLeaveGame}
-          disabled={leaveGameMutation.isPending}
-          variant="outline"
-          aria-label="Leave game"
-        >
-          <UserMinus className="size-4" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <p>Leave game</p>
-      </TooltipContent>
-    </Tooltip>
-  );
-
   return (
     <ScreenContainer>
       <ScreenHeader
         title="Player Info"
         actions={
-          <>
-            {joinLeaveButton}
-            <GameDropdownMenu
-              game={game}
-              onNavigateToGameInfo={handleGameInfo}
-              onNavigateToPlayerInfo={handlePlayerInfo}
-            />
-          </>
+          <GameDropdownMenu
+            game={game}
+            onNavigateToGameInfo={handleGameInfo}
+            onNavigateToPlayerInfo={handlePlayerInfo}
+          />
         }
       />
       <PlayerInfoContent />

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -14,6 +14,7 @@ const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
   status: "pending" as PhaseRetrieve["status"],
   units,
   supplyCenters: [],
+  provinceNations: {},
   previousPhaseId: null,
   nextPhaseId: null,
 });


### PR DESCRIPTION
## Summary

- Removes the join/leave icon button from the Player Info screen header, where it was redundant and out of place.

Users can leave a pending game by navigating to the Game Info screen (tap the game title/card from My Games), which has a clearly labelled **Leave game** button.

## Test plan

- [ ] Open My Games > Staging > overflow menu > Player Info — confirm no join/leave button appears in the header
- [ ] Confirm the Game Info screen still shows the Leave game button for pending games

🤖 Generated with [Claude Code](https://claude.com/claude-code)