### PR TITLE
Remove will-change: transform from map SVG wrapper

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -186,7 +186,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
       >
-        <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }} contentStyle={{ willChange: "transform" }}>
+        <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap
             ref={svgRef}
             {...interactiveMapProps}


### PR DESCRIPTION
## Summary

- Removes `will-change: transform` from the `TransformComponent` content wrapper in `InteractiveMapZoomWrapper`

## Background

`will-change: transform` was added as a performance experiment to pre-promote the map to a GPU compositor layer. However, this causes the browser to **rasterize the SVG into a fixed-resolution bitmap texture** before any transform is applied. When the map is then panned or zoomed, the browser scales that bitmap rather than re-rendering the vectors — resulting in visibly blurred province borders, labels, and coastlines.

The intended benefit (avoiding a layer-promotion cost at gesture start) is not meaningful for SVG: CSS `transform` is GPU-composited by the browser regardless of `will-change`, so pan/zoom animations remain hardware-accelerated without it. On low-end devices the tradeoff is worse still — the rasterized texture consumes GPU memory and the initial rasterization adds a load-time cost.

The improvement is not in line with the cost of a blurred map.

## Test plan

- [ ] Open the map screen and verify province borders and labels are sharp
- [ ] Pan and zoom the map and verify animations remain smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)