### PR TITLE
Fix deadline warning notifications and update notification copy

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -111,3 +111,6 @@ CAPACITOR_IOS_FIREBASE_ENCODED_APP_ID="your-ios-encoded-app-id"
 # CAPACITOR ANDROID: Configuration for the Android Capacitor app.
 # These values come from Firebase Console -> Project Settings -> General -> Your apps -> Android apps.
 CAPACITOR_ANDROID_BUNDLE_ID="com.diplicity.app"
+
+# FRONTEND_URL: The base URL for the frontend app, used to build deep-link URLs in push notifications.
+FRONTEND_URL="https://diplicity.com"

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -1,5 +1,6 @@
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from rest_framework import serializers
 from django.db import transaction
 from django.db.models import Count, Q, Subquery, OuterRef
@@ -11,6 +12,7 @@ from member.serializers import MemberSerializer
 from unit.models import Unit
 from supply_center.models import SupplyCenter
 from notification import utils as notification_utils
+from phase.utils import format_deadline
 
 from victory.serializers import VictorySerializer
 from variant.models import Variant
@@ -34,7 +36,7 @@ def send_gm_action_notification(game, title, body, notification_type):
             title=title,
             body=body,
             notification_type=notification_type,
-            data={"game_id": str(game.id)},
+            data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
         )
     transaction.on_commit(_send)
 
@@ -423,7 +425,7 @@ class GamePauseSerializer(serializers.Serializer):
         instance.pause()
         send_gm_action_notification(
             instance,
-            title="Game Paused",
+            title=instance.name,
             body=f"Game paused by Game Master ({gm_username})",
             notification_type="game_paused",
         )
@@ -443,10 +445,10 @@ class GameUnpauseSerializer(serializers.Serializer):
         gm_username = self.context["request"].user.username
         instance.unpause()
         new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
-        deadline_str = new_deadline.strftime("%b %d, %Y at %I:%M %p") if new_deadline else "N/A"
+        deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
         send_gm_action_notification(
             instance,
-            title="Game Resumed",
+            title=instance.name,
             body=f"Game resumed by Game Master ({gm_username}). New deadline: {deadline_str}",
             notification_type="game_resumed",
         )
@@ -474,10 +476,12 @@ class GameExtendDeadlineSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         gm_username = self.context["request"].user.username
         instance.extend_deadline(validated_data["duration"])
+        new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
+        deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
         send_gm_action_notification(
             instance,
-            title="Deadline Extended",
-            body=f"Deadline extended by Game Master ({gm_username})",
+            title=instance.name,
+            body=f"Deadline extended by Game Master ({gm_username}). New deadline: {deadline_str}",
             notification_type="game_deadline_extended",
         )
         return instance

--- a/service/integration/tests.py
+++ b/service/integration/tests.py
@@ -1,5 +1,6 @@
 from re import I
 import pytest
+from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 from datetime import timedelta
@@ -313,10 +314,10 @@ def test_active_game_create_orders_and_confirm(
     # Notification is sent to both users
     mock_send_notification_to_users.assert_called_with(
         user_ids=[germany_member.user.id, italy_member.user.id],
-        title="Phase Resolved",
-        body=f"Phase '{first_phase.name}' has been resolved!",
+        title=active_game.name,
+        body=f"{first_phase.name} has been resolved",
         notification_type="phase_resolved",
-        data={"game_id": str(active_game.id), "link": f"https://diplicity.com/game/{active_game.id}"},
+        data={"game_id": str(active_game.id), "link": f"{settings.FRONTEND_URL}/game/{active_game.id}"},
     )
 
     # The empty Spring 1901 Retreat is skipped, so resolving the movement

--- a/service/notification/conftest.py
+++ b/service/notification/conftest.py
@@ -1,0 +1,68 @@
+import pytest
+from game.models import Game
+from phase.models import Phase
+from common.constants import GameStatus, PhaseStatus
+
+
+@pytest.fixture
+def make_draw_notification_game(
+    db,
+    italy_vs_germany_variant,
+    italy_vs_germany_italy_nation,
+    italy_vs_germany_germany_nation,
+    primary_user,
+    secondary_user,
+):
+    def _create():
+        game = Game.objects.create(
+            name="Draw Notification Test",
+            variant=italy_vs_germany_variant,
+            status=GameStatus.ACTIVE,
+        )
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Spring",
+            year=1901,
+            type="Movement",
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        italy = game.members.create(user=primary_user, nation=italy_vs_germany_italy_nation)
+        germany = game.members.create(user=secondary_user, nation=italy_vs_germany_germany_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+        phase.phase_states.create(member=germany, has_possible_orders=True)
+        return game, italy, germany
+
+    return _create
+
+
+@pytest.fixture
+def make_end_game_notification_game(
+    db,
+    italy_vs_germany_variant,
+    italy_vs_germany_italy_nation,
+    italy_vs_germany_germany_nation,
+    primary_user,
+    secondary_user,
+):
+    def _create():
+        game = Game.objects.create(
+            name="End Game Test",
+            variant=italy_vs_germany_variant,
+            status=GameStatus.ACTIVE,
+        )
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Spring",
+            year=1901,
+            type="Movement",
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        italy = game.members.create(user=primary_user, nation=italy_vs_germany_italy_nation)
+        germany = game.members.create(user=secondary_user, nation=italy_vs_germany_germany_nation)
+        return game, phase, italy, germany
+
+    return _create

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -1,13 +1,16 @@
 import logging
+from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from channel.models import ChannelMessage
+from draw_proposal.models import DrawProposal
 from game.models import Game
 from common.constants import GameStatus, PhaseStatus
 from notification.tasks import send_notification
 from notification.utils import send_notification_to_users
 from phase.models import Phase
+from victory.models import Victory
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +23,35 @@ def _truncate_body(text: str, max_lines: int = 3, max_chars: int = 200) -> str:
     elif len(lines) > max_lines:
         truncated += "…"
     return truncated
+
+
+@receiver(post_save, sender=DrawProposal)
+def send_draw_proposal_notification(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    other_members = instance.game.members.filter(
+        eliminated=False, kicked=False, civil_disorder=False
+    ).exclude(id=instance.created_by.id)
+    user_ids = [member.user_id for member in other_members if member.user_id is not None]
+    if not user_ids:
+        return
+
+    proposer_name = instance.created_by.name
+    game = instance.game
+    phase = instance.phase
+    link = (
+        f"{settings.FRONTEND_URL}/game/{game.id}/phase/{phase.id}/draw-proposals"
+        if phase is not None
+        else f"{settings.FRONTEND_URL}/game/{game.id}"
+    )
+    send_notification.defer(
+        user_ids=user_ids,
+        title=game.name,
+        body=f"{proposer_name} has proposed a draw. Respond to it now.",
+        notification_type="draw_proposal",
+        data={"game_id": str(game.id), "link": link},
+    )
 
 
 _game_status_cache = {}
@@ -43,9 +75,9 @@ def send_channel_message_notification(sender, instance, created, **kwargs):
     game = instance.channel.game
     current_phase = game.phases.last()
     link = (
-        f"https://diplicity.com/game/{game.id}/phase/{current_phase.id}/chat/channel/{instance.channel.id}"
+        f"{settings.FRONTEND_URL}/game/{game.id}/phase/{current_phase.id}/chat/channel/{instance.channel.id}"
         if current_phase
-        else f"https://diplicity.com/game/{game.id}"
+        else f"{settings.FRONTEND_URL}/game/{game.id}"
     )
 
     send_notification.defer(
@@ -70,27 +102,75 @@ def cache_game_status(sender, instance, **kwargs):
             pass
 
 
+def _send_game_start_notification(instance):
+    user_ids = [member.user_id for member in instance.members.all() if member.user_id is not None]
+    if not user_ids:
+        return
+
+    send_notification.defer(
+        user_ids=user_ids,
+        title=instance.name,
+        body="The game has started. You can now chat with other players and submit your orders. Good luck!",
+        notification_type="game_start",
+        data={
+            "game_id": str(instance.id),
+            "link": f"{settings.FRONTEND_URL}/game/{instance.id}",
+        },
+    )
+
+
+def _send_game_end_notification(game_id, game_name, all_member_user_ids):
+    try:
+        victory = Victory.objects.prefetch_related("members").get(game_id=game_id)
+    except Victory.DoesNotExist:
+        return
+
+    victory_members = list(victory.members.all())
+    link = f"{settings.FRONTEND_URL}/game/{game_id}"
+
+    if len(victory_members) >= 2:
+        names = ", ".join(m.name for m in victory_members)
+        send_notification.defer(
+            user_ids=all_member_user_ids,
+            title=game_name,
+            body=f"The game has ended in a draw, including {names}. Well played!",
+            notification_type="game_draw",
+            data={"game_id": str(game_id), "link": link},
+        )
+    elif len(victory_members) == 1:
+        winner = victory_members[0]
+        winner_user_ids = [winner.user_id] if winner.user_id is not None else []
+        other_user_ids = [uid for uid in all_member_user_ids if uid != winner.user_id]
+        if winner_user_ids:
+            send_notification.defer(
+                user_ids=winner_user_ids,
+                title=game_name,
+                body="The game has ended, you achieved a solo win! Congratulations!",
+                notification_type="game_solo_win",
+                data={"game_id": str(game_id), "link": link},
+            )
+        if other_user_ids:
+            send_notification.defer(
+                user_ids=other_user_ids,
+                title=game_name,
+                body=f"The game has ended, and {winner.name} achieved a solo win! Better luck next time!",
+                notification_type="game_solo_loss",
+                data={"game_id": str(game_id), "link": link},
+            )
+
+
 @receiver(post_save, sender=Game)
-def send_game_start_notification(sender, instance, created, **kwargs):
+def send_game_status_notifications(sender, instance, created, **kwargs):
     if created:
         return
 
     old_status = _game_status_cache.pop(instance.pk, None)
-    if old_status == GameStatus.PENDING and instance.status == GameStatus.ACTIVE:
-        user_ids = [member.user_id for member in instance.members.all() if member.user_id is not None]
-        if not user_ids:
-            return
 
-        send_notification.defer(
-            user_ids=user_ids,
-            title="Game Started",
-            body=f"Game '{instance.name}' has started!",
-            notification_type="game_start",
-            data={
-                "game_id": str(instance.id),
-                "link": f"https://diplicity.com/game/{instance.id}",
-            },
-        )
+    if old_status == GameStatus.PENDING and instance.status == GameStatus.ACTIVE:
+        _send_game_start_notification(instance)
+    elif old_status == GameStatus.ACTIVE and instance.status == GameStatus.COMPLETED:
+        all_member_user_ids = [m.user_id for m in instance.members.all() if m.user_id is not None]
+        _send_game_end_notification(instance.id, instance.name, all_member_user_ids)
 
 
 _phase_status_cache = {}
@@ -114,18 +194,18 @@ def send_phase_resolved_notification(sender, instance, created, **kwargs):  # no
     old_status = _phase_status_cache.pop(instance.pk, None)
     if old_status == PhaseStatus.ACTIVE and instance.status == PhaseStatus.COMPLETED:
 
-        def send_notification():
+        def _send():
             user_ids = [member.user_id for member in instance.game.members.all() if member.user_id is not None]
 
             send_notification_to_users(
                 user_ids=user_ids,
-                title="Phase Resolved",
-                body=f"Phase '{instance.name}' has been resolved!",
+                title=instance.game.name,
+                body=f"{instance.name} has been resolved",
                 notification_type="phase_resolved",
                 data={
                     "game_id": str(instance.game.id),
-                    "link": f"https://diplicity.com/game/{instance.game.id}",
+                    "link": f"{settings.FRONTEND_URL}/game/{instance.game.id}",
                 },
             )
 
-        transaction.on_commit(send_notification)
+        transaction.on_commit(_send)

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -1,5 +1,8 @@
 import pytest
 from channel.models import Channel, ChannelMessage
+from common.constants import GameStatus
+from draw_proposal.models import DrawProposal
+from victory.models import Victory
 from notification.signals import _truncate_body
 
 
@@ -55,8 +58,11 @@ class TestTruncateBody:
         assert _truncate_body(text) == "x" * 200
 
 
-def _channel_message_jobs(connector):
-    return [j for j in connector.jobs.values() if j["task_name"] == "notification.send_notification"]
+def _notification_jobs(connector, notification_type=None):
+    jobs = [j for j in connector.jobs.values() if j["task_name"] == "notification.send_notification"]
+    if notification_type is not None:
+        jobs = [j for j in jobs if j["args"].get("notification_type") == notification_type]
+    return jobs
 
 
 @pytest.mark.django_db
@@ -66,7 +72,7 @@ def test_channel_message_notification_uses_display_name(active_game, in_memory_p
 
     ChannelMessage.objects.create(channel=channel, sender=sender_member, body="Hello everyone")
 
-    jobs = _channel_message_jobs(in_memory_procrastinate)
+    jobs = _notification_jobs(in_memory_procrastinate, "channel_message")
     assert len(jobs) == 1
     body = jobs[0]["args"]["body"]
     expected_prefix = f"{sender_member.name}: "
@@ -88,6 +94,150 @@ def test_channel_message_notification_deleted_user(active_game, in_memory_procra
 
     ChannelMessage.objects.create(channel=channel, sender=sender_member, body="Ghost message")
 
-    jobs = _channel_message_jobs(in_memory_procrastinate)
+    jobs = _notification_jobs(in_memory_procrastinate, "channel_message")
     assert len(jobs) == 1
     assert jobs[0]["args"]["body"].startswith("Deleted User: ")
+
+
+class TestDrawProposalNotification:
+
+    @pytest.mark.django_db
+    def test_active_member_notified_with_correct_content(
+        self,
+        make_draw_notification_game,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_draw_notification_game()
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert set(args["user_ids"]) == {secondary_user.id}
+        assert italy.name in args["body"]
+        assert args["title"] == game.name
+
+    @pytest.mark.django_db
+    def test_proposer_excluded_from_notification(
+        self,
+        make_draw_notification_game,
+        primary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_draw_notification_game()
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert primary_user.id not in jobs[0]["args"]["user_ids"]
+
+    @pytest.mark.django_db
+    def test_eliminated_member_not_notified(
+        self,
+        make_draw_notification_game,
+        tertiary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_draw_notification_game()
+        game.members.create(user=tertiary_user, eliminated=True)
+
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert tertiary_user.id not in jobs[0]["args"]["user_ids"]
+
+    @pytest.mark.django_db
+    def test_civil_disorder_member_not_notified(
+        self,
+        make_draw_notification_game,
+        tertiary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_draw_notification_game()
+        game.members.create(user=tertiary_user, civil_disorder=True)
+
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert tertiary_user.id not in jobs[0]["args"]["user_ids"]
+
+    @pytest.mark.django_db
+    def test_kicked_member_not_notified(
+        self,
+        make_draw_notification_game,
+        tertiary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_draw_notification_game()
+        game.members.create(user=tertiary_user, kicked=True)
+
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert tertiary_user.id not in jobs[0]["args"]["user_ids"]
+
+
+class TestGameEndNotifications:
+
+    @pytest.mark.django_db
+    def test_draw_notifies_all_members_with_draw_body(
+        self,
+        make_end_game_notification_game,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, phase, italy, germany = make_end_game_notification_game()
+        victory = Victory.objects.create(game=game, winning_phase=phase)
+        victory.members.add(italy, germany)
+
+        game.status = GameStatus.COMPLETED
+        game.save()
+
+        jobs = _notification_jobs(in_memory_procrastinate, "game_draw")
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert set(args["user_ids"]) == {primary_user.id, secondary_user.id}
+        assert italy.name in args["body"]
+        assert germany.name in args["body"]
+
+    @pytest.mark.django_db
+    def test_solo_win_sends_congratulations_to_winner(
+        self,
+        make_end_game_notification_game,
+        primary_user,
+        in_memory_procrastinate,
+    ):
+        game, phase, italy, germany = make_end_game_notification_game()
+        victory = Victory.objects.create(game=game, winning_phase=phase)
+        victory.members.add(italy)
+
+        game.status = GameStatus.COMPLETED
+        game.save()
+
+        jobs = _notification_jobs(in_memory_procrastinate, "game_solo_win")
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert primary_user.id in args["user_ids"]
+        assert "Congratulations" in args["body"]
+
+    @pytest.mark.django_db
+    def test_solo_win_sends_loser_message_to_non_winners(
+        self,
+        make_end_game_notification_game,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, phase, italy, germany = make_end_game_notification_game()
+        victory = Victory.objects.create(game=game, winning_phase=phase)
+        victory.members.add(italy)
+
+        game.status = GameStatus.COMPLETED
+        game.save()
+
+        jobs = _notification_jobs(in_memory_procrastinate, "game_solo_loss")
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert secondary_user.id in args["user_ids"]
+        assert italy.name in args["body"]
+        assert "Better luck" in args["body"]

--- a/service/phase/conftest.py
+++ b/service/phase/conftest.py
@@ -1,8 +1,10 @@
 import pytest
 from datetime import timedelta
 from django.utils import timezone
+from game.models import Game
+from member.models import Member
 from phase.models import Phase
-from common.constants import PhaseStatus, UnitType, OrderType, GameStatus, MovementPhaseDuration, DeadlineMode
+from common.constants import PhaseStatus, PhaseType, UnitType, OrderType, GameStatus, MovementPhaseDuration, DeadlineMode
 
 
 @pytest.fixture
@@ -20,9 +22,6 @@ def italy_vs_germany_phase_with_orders(
     primary_user,
     secondary_user,
 ):
-    from game.models import Game
-    from member.models import Member
-
     game = Game.objects.create(
         variant=italy_vs_germany_variant,
         name="Test Game",
@@ -156,8 +155,6 @@ def game_with_three_phases(
     primary_user,
     secondary_user,
 ):
-    from game.models import Game
-    from member.models import Member
     from order.models import OrderResolution
 
     game = Game.objects.create(
@@ -292,9 +289,6 @@ def game_with_three_phases(
 
 @pytest.fixture
 def phase_factory(db, classical_variant, primary_user, secondary_user):
-    from game.models import Game
-    from member.models import Member
-
     def _create_phase(
         scheduled_resolution=None,
         phase_states_config=None,
@@ -359,8 +353,6 @@ def multiple_games_with_phases(
     classical_england_nation,
     classical_france_nation,
 ):
-    from game.models import Game
-    from member.models import Member
 
     games_data = []
 
@@ -434,3 +426,72 @@ def multiple_games_with_phases(
         })
 
     return games_data
+
+
+@pytest.fixture
+def make_deadline_warning_game(
+    db,
+    italy_vs_germany_variant,
+    italy_vs_germany_italy_nation,
+    italy_vs_germany_germany_nation,
+    primary_user,
+    secondary_user,
+):
+    def _create(deadline_mode, scheduled_resolution):
+        game = Game.objects.create(
+            name=f"Test Game {deadline_mode}",
+            variant=italy_vs_germany_variant,
+            deadline_mode=deadline_mode,
+            movement_phase_duration="24h",
+        )
+        italy = game.members.create(nation=italy_vs_germany_italy_nation, user=primary_user)
+        germany = game.members.create(nation=italy_vs_germany_germany_nation, user=secondary_user)
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=scheduled_resolution,
+        )
+        return game, italy, germany, phase
+
+    return _create
+
+
+@pytest.fixture
+def add_italy_germany_units(
+    italy_vs_germany_italy_nation,
+    italy_vs_germany_germany_nation,
+    italy_vs_germany_venice_province,
+    italy_vs_germany_kiel_province,
+):
+    def _add(phase):
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.units.create(province=italy_vs_germany_kiel_province, type=UnitType.ARMY, nation=italy_vs_germany_germany_nation)
+
+    return _add
+
+
+@pytest.fixture
+def make_elimination_game(
+    db,
+    italy_vs_germany_variant,
+    italy_vs_germany_italy_nation,
+    italy_vs_germany_germany_nation,
+    primary_user,
+    secondary_user,
+):
+    def _create():
+        game = Game.objects.create(
+            name="Elimination Test",
+            variant=italy_vs_germany_variant,
+            status=GameStatus.ACTIVE,
+        )
+        italy = game.members.create(user=primary_user, nation=italy_vs_germany_italy_nation)
+        germany = game.members.create(user=secondary_user, nation=italy_vs_germany_germany_nation)
+        return game, italy, germany
+
+    return _create

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -5,7 +5,7 @@ from functools import cached_property
 import sentry_sdk
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import Q, Exists, OuterRef, Count
+from django.db.models import Q, Exists, OuterRef, Count, Prefetch
 from django.utils import timezone
 from opentelemetry import trace
 from common.models import BaseModel
@@ -14,13 +14,14 @@ from common.constants import PhaseStatus, PhaseType, GameStatus, DeadlineMode
 from adjudication.service import resolve
 from member.models import Member
 from order.models import OrderResolution, Order
-from phase.utils import transform_options
+from phase.utils import transform_options, format_time_remaining, format_deadline, build_notification_body
 from province.models import Province
 from supply_center.models import SupplyCenter
 from unit.models import Unit
 from victory.utils import check_for_solo_winner
 from victory.models import Victory
 from notification import utils as notification_utils
+from notification.tasks import send_notification
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -224,16 +225,18 @@ class PhaseManager(models.Manager):
             f"Applied NMR extensions for {len(members_with_extensions)} members in phase {phase.id}"
         )
 
+        deadline_str = format_deadline(phase.scheduled_resolution, phase.game.fixed_deadline_timezone)
+
         def send_notifications():
             for member in members_with_extensions:
                 if member.user_id is None:
                     continue
                 notification_utils.send_notification_to_users(
                     user_ids=[member.user_id],
-                    title="Extension Used",
-                    body=f"You used an automatic extension. {member.nmr_extensions_remaining} remaining.",
+                    title=phase.game.name,
+                    body=f"You did not submit orders and used an automatic extension ({member.nmr_extensions_remaining} remaining). The current phase is extended until {deadline_str}.",
                     notification_type="nmr_extension_used",
-                    data={"game_id": str(phase.game.id)},
+                    data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
                 )
 
             extension_ids = {m.user_id for m in members_with_extensions if m.user_id is not None}
@@ -244,10 +247,10 @@ class PhaseManager(models.Manager):
             if other_ids:
                 notification_utils.send_notification_to_users(
                     user_ids=other_ids,
-                    title="Deadline Extended",
-                    body="Some player(s) did not submit orders. Deadline extended.",
+                    title=phase.game.name,
+                    body=f"Some player(s) did not submit orders and used an extension. The current phase is extended until {deadline_str}.",
                     notification_type="nmr_extension_applied",
-                    data={"game_id": str(phase.game.id)},
+                    data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
                 )
 
         transaction.on_commit(send_notifications)
@@ -286,51 +289,77 @@ class PhaseManager(models.Manager):
                 Q(game__status=GameStatus.COMPLETED) | Q(game__status=GameStatus.ABANDONED)
             ).select_related('game').prefetch_related(
                 'phase_states__member__user',
-                'game__members'
+                'phase_states__member__nation',
+                'phase_states__orders',
+                Prefetch('units', queryset=Unit.objects.select_related('nation'), to_attr='prefetched_units'),
+                Prefetch('supply_centers', queryset=SupplyCenter.objects.select_related('nation'), to_attr='prefetched_supply_centers'),
             )
 
             notifications_sent = 0
 
             for phase in active_phases:
-                if not phase.scheduled_resolution:
-                    continue
-
                 duration_seconds = phase.game.get_phase_duration_seconds(phase.type)
                 warning_threshold = get_warning_threshold(duration_seconds)
-
                 time_until_deadline = (phase.scheduled_resolution - now).total_seconds()
 
                 if time_until_deadline <= 0 or time_until_deadline > warning_threshold:
                     continue
 
-                pending_states = [
-                    ps for ps in phase.phase_states.all()
-                    if ps.has_possible_orders
-                    and not ps.orders_confirmed
-                    and ps.deadline_warning_sent_for != phase.scheduled_resolution
-                ]
+                is_fixed_time = phase.game.deadline_mode == DeadlineMode.FIXED_TIME
+                time_left = format_time_remaining(time_until_deadline)
 
-                if not pending_states:
-                    continue
+                units_by_nation = {}
+                for unit in phase.prefetched_units:
+                    units_by_nation[unit.nation_id] = units_by_nation.get(unit.nation_id, 0) + 1
 
-                user_ids = [
-                    ps.member.user_id for ps in pending_states if ps.member.user_id is not None
-                ]
+                sc_by_nation = {}
+                for sc in phase.prefetched_supply_centers:
+                    sc_by_nation[sc.nation_id] = sc_by_nation.get(sc.nation_id, 0) + 1
 
-                if user_ids:
-                    notification_utils.send_notification_to_users(
-                        user_ids=user_ids,
-                        title="Deadline Approaching",
-                        body=f"You haven't confirmed your orders in {phase.game.name}.",
-                        notification_type="deadline_warning",
-                        data={"game_id": str(phase.game.id)},
+                warned_states = []
+
+                for ps in phase.phase_states.all():
+                    if not ps.has_possible_orders:
+                        continue
+                    if ps.deadline_warning_sent_for == phase.scheduled_resolution:
+                        continue
+
+                    nation_id = ps.member.nation_id
+                    unit_count = units_by_nation.get(nation_id, 0)
+
+                    if phase.type == PhaseType.ADJUSTMENT:
+                        sc_count = sc_by_nation.get(nation_id, 0)
+                        total_units = abs(sc_count - unit_count)
+                    else:
+                        total_units = unit_count
+
+                    if total_units == 0:
+                        continue
+
+                    body = build_notification_body(
+                        ps.orders_confirmed, is_fixed_time, len(ps.orders.all()), total_units, time_left,
+                        ps.member.nmr_extensions_remaining,
                     )
-                    notifications_sent += len(user_ids)
-                    logger.info(f"Sent deadline warning to {len(user_ids)} player(s) for game {phase.game.name}")
+                    if body is None:
+                        continue
 
-                for ps in pending_states:
+                    if ps.member.user_id is None:
+                        continue
+
+                    notification_utils.send_notification_to_users(
+                        user_ids=[ps.member.user_id],
+                        title=phase.game.name,
+                        body=body,
+                        notification_type="deadline_warning",
+                        data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
+                    )
                     ps.deadline_warning_sent_for = phase.scheduled_resolution
-                PhaseState.objects.bulk_update(pending_states, ["deadline_warning_sent_for"])
+                    warned_states.append(ps)
+                    notifications_sent += 1
+                    logger.info(f"Sent deadline warning to user {ps.member.user_id} for game {phase.game.name}")
+
+                if warned_states:
+                    PhaseState.objects.bulk_update(warned_states, ["deadline_warning_sent_for"])
 
             span.set_attribute("notifications.sent", notifications_sent)
             logger.info(f"Sent {notifications_sent} deadline warning notification(s)")
@@ -409,6 +438,47 @@ class PhaseManager(models.Manager):
 
         return newly_cd_members
 
+    def _check_eliminations(self, previous_phase, new_phase):
+        units_by_nation = {}
+        for unit in new_phase.units.all():
+            units_by_nation[unit.nation_id] = units_by_nation.get(unit.nation_id, 0) + 1
+
+        sc_by_nation = {}
+        for sc in new_phase.supply_centers.all():
+            sc_by_nation[sc.nation_id] = sc_by_nation.get(sc.nation_id, 0) + 1
+
+        candidates = list(
+            previous_phase.game.members.filter(
+                eliminated=False, kicked=False, nation__isnull=False
+            ).select_related("user", "nation")
+        )
+
+        newly_eliminated = [
+            m for m in candidates
+            if units_by_nation.get(m.nation_id, 0) == 0
+            and sc_by_nation.get(m.nation_id, 0) == 0
+        ]
+
+        if not newly_eliminated:
+            return
+
+        for m in newly_eliminated:
+            m.eliminated = True
+        Member.objects.bulk_update(newly_eliminated, ["eliminated"])
+
+        game = previous_phase.game
+
+        for member in newly_eliminated:
+            if member.user_id is None:
+                continue
+            send_notification.defer(
+                user_ids=[member.user_id],
+                title=game.name,
+                body="You've been eliminated. You are not required to enter any orders anymore. You can still chat with players. Better luck next time!",
+                notification_type="elimination",
+                data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+            )
+
     def _check_abandonment(self, game):
         if game.sandbox:
             return False
@@ -434,6 +504,7 @@ class PhaseManager(models.Manager):
                 with transaction.atomic():
                     self._check_civil_disorder(phase)
                     new_phase = self.create_from_adjudication_data(phase, adjudication_data)
+                    self._check_eliminations(phase, new_phase)
 
                     victory = Victory.objects.try_create_victory(new_phase)
 

--- a/service/phase/test_deadline_reminders.py
+++ b/service/phase/test_deadline_reminders.py
@@ -4,20 +4,23 @@ from unittest.mock import patch
 import pytest
 from django.utils import timezone
 
-from common.constants import DeadlineMode, GameStatus
+from common.constants import DeadlineMode, GameStatus, UnitType
 from phase.models import Phase
 
 
 class TestDeadlineReminderGuard:
 
     @pytest.mark.django_db
-    def test_sends_one_reminder_per_deadline(self, phase_factory, classical_england_nation):
+    def test_sends_one_reminder_per_deadline(
+        self, phase_factory, classical_england_nation, classical_edinburgh_province
+    ):
         phase = phase_factory(
             scheduled_resolution=timezone.now() + timedelta(minutes=30),
             phase_states_config=[
                 {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
             ],
         )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
 
         with patch("phase.models.notification_utils.send_notification_to_users") as mock_send:
             first = Phase.objects.send_deadline_warnings()
@@ -32,13 +35,16 @@ class TestDeadlineReminderGuard:
         assert phase_state.deadline_warning_sent_for == phase.scheduled_resolution
 
     @pytest.mark.django_db
-    def test_fresh_reminder_after_deadline_moves(self, phase_factory, classical_england_nation):
+    def test_fresh_reminder_after_deadline_moves(
+        self, phase_factory, classical_england_nation, classical_edinburgh_province
+    ):
         phase = phase_factory(
             scheduled_resolution=timezone.now() + timedelta(minutes=30),
             phase_states_config=[
                 {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
             ],
         )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
 
         with patch("phase.models.notification_utils.send_notification_to_users") as mock_send:
             Phase.objects.send_deadline_warnings()
@@ -53,7 +59,13 @@ class TestDeadlineReminderGuard:
 
     @pytest.mark.django_db
     def test_confirmed_player_not_reminded(
-        self, phase_factory, classical_england_nation, classical_france_nation, secondary_user
+        self,
+        phase_factory,
+        classical_england_nation,
+        classical_france_nation,
+        classical_edinburgh_province,
+        classical_paris_province,
+        secondary_user,
     ):
         phase = phase_factory(
             scheduled_resolution=timezone.now() + timedelta(minutes=30),
@@ -67,6 +79,8 @@ class TestDeadlineReminderGuard:
                 },
             ],
         )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
+        phase.units.create(type=UnitType.ARMY, nation=classical_france_nation, province=classical_paris_province)
 
         with patch("phase.models.notification_utils.send_notification_to_users") as mock_send:
             result = Phase.objects.send_deadline_warnings()
@@ -92,7 +106,7 @@ class TestDeadlineReminderGuard:
 
     @pytest.mark.django_db
     def test_fixed_time_game_reminds_players_with_orders(
-        self, phase_factory, classical_variant, classical_england_nation
+        self, phase_factory, classical_variant, classical_england_nation, classical_edinburgh_province
     ):
         from game.models import Game
 
@@ -102,13 +116,14 @@ class TestDeadlineReminderGuard:
             status=GameStatus.ACTIVE,
             deadline_mode=DeadlineMode.FIXED_TIME,
         )
-        phase_factory(
+        phase = phase_factory(
             game=game,
             scheduled_resolution=timezone.now() + timedelta(minutes=30),
             phase_states_config=[
                 {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
             ],
         )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
 
         with patch("phase.models.notification_utils.send_notification_to_users") as mock_send:
             result = Phase.objects.send_deadline_warnings()

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3747,3 +3747,552 @@ class TestPhaseToCanonicalGameStatePerformance:
         large_count = self._count_queries(large_phase)
 
         assert small_count == large_count
+
+
+class TestSendDeadlineWarnings:
+
+    @pytest.mark.django_db
+    def test_fixed_time_all_orders_no_notification(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_kiel_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+        germany_ps = phase.phase_states.create(member=germany, has_possible_orders=True)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+        germany_ps.orders.create(source=italy_vs_germany_kiel_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_fixed_time_some_orders_sends_partial_notification(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.units.create(province=italy_vs_germany_rome_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert call_kwargs["title"] == game.name
+        assert "1/2" in call_kwargs["body"]
+        assert "orders incomplete" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_fixed_time_no_orders_sends_no_orders_notification(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "no orders given" in call_kwargs["body"]
+        assert "stop waiting for you" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_duration_confirmed_no_notification(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_duration_all_orders_unconfirmed_sends_ready_notification(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        italy_vs_germany_venice_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert call_kwargs["title"] == game.name
+        assert "orders ready" in call_kwargs["body"]
+        assert "waiting confirmation" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_duration_some_orders_unconfirmed_sends_partial_notification(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.units.create(province=italy_vs_germany_rome_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "1/2" in call_kwargs["body"]
+        assert "orders incomplete" in call_kwargs["body"]
+        assert "standing orders will execute" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_duration_no_orders_sends_no_orders_notification(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "no orders given" in call_kwargs["body"]
+        assert "stop waiting for you" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_second_call_does_not_resend(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warnings()
+
+        assert mock_send_notification_to_users.call_count == 1
+
+    @pytest.mark.django_db
+    def test_marker_set_to_scheduled_resolution_after_send(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        ps.refresh_from_db()
+        assert ps.deadline_warning_sent_for == phase.scheduled_resolution
+
+    @pytest.mark.django_db
+    def test_deadline_extension_sends_fresh_warning(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(hours=1))
+        game.movement_phase_duration = "48 hours"
+        game.save()
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+        assert mock_send_notification_to_users.call_count == 1
+
+        game.status = GameStatus.ACTIVE
+        game.save()
+        game.extend_deadline("1 hour")
+
+        Phase.objects.send_deadline_warnings()
+        assert mock_send_notification_to_users.call_count == 2
+
+    @pytest.mark.django_db
+    def test_deadline_move_after_nmr_extension_sends_fresh_warning(
+        self,
+        make_deadline_warning_game,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(hours=1))
+        game.movement_phase_duration = "48 hours"
+        game.save()
+        add_italy_germany_units(phase)
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+        assert mock_send_notification_to_users.call_count == 1
+        ps.refresh_from_db()
+        assert ps.deadline_warning_sent_for == phase.scheduled_resolution
+
+        Phase.objects._check_and_apply_nmr_extensions(phase)
+
+        phase.refresh_from_db()
+        phase.scheduled_resolution = now + timedelta(minutes=30)
+        phase.save()
+
+        Phase.objects.send_deadline_warnings()
+        assert mock_send_notification_to_users.call_count == 2
+
+    @pytest.mark.django_db
+    def test_fixed_time_no_orders_with_extensions_shows_extension_message(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        italy.nmr_extensions_remaining = 2
+        italy.save()
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "deadline will extend" in call_kwargs["body"]
+        assert "lose an extension" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_fixed_time_no_orders_no_extensions_shows_stop_waiting_message(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "stop waiting for you" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_duration_no_orders_with_extensions_shows_extension_message(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "deadline will extend" in call_kwargs["body"]
+        assert "lose an extension" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_duration_no_orders_no_extensions_shows_stop_waiting_message(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.DURATION, now + timedelta(minutes=10))
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "stop waiting for you" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_no_notification_when_member_has_no_units_in_movement_phase(
+        self,
+        make_deadline_warning_game,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_no_notification_when_adjustment_phase_has_zero_net_builds(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game = Game.objects.create(
+            name="Adjustment Zero Test",
+            variant=italy_vs_germany_variant,
+            deadline_mode=DeadlineMode.FIXED_TIME,
+            movement_phase_duration="24h",
+        )
+        italy = game.members.create(nation=italy_vs_germany_italy_nation, user=primary_user)
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.ADJUSTMENT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=now + timedelta(minutes=10),
+        )
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.supply_centers.create(province=italy_vs_germany_venice_province, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+
+def _elimination_jobs(connector):
+    return [
+        j for j in connector.jobs.values()
+        if j["task_name"] == "notification.send_notification"
+        and j["args"].get("notification_type") == "elimination"
+    ]
+
+
+class TestCheckEliminations:
+
+    @pytest.mark.django_db
+    def test_member_eliminated_when_no_units_and_no_sc(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_kiel_province,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.units.create(province=italy_vs_germany_kiel_province, type=UnitType.ARMY, nation=italy_vs_germany_germany_nation)
+        new_phase.supply_centers.create(province=italy_vs_germany_kiel_province, nation=italy_vs_germany_germany_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        italy.refresh_from_db()
+        germany.refresh_from_db()
+        assert italy.eliminated is True
+        assert germany.eliminated is False
+
+    @pytest.mark.django_db
+    def test_member_not_eliminated_when_has_unit(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        italy.refresh_from_db()
+        assert italy.eliminated is False
+
+    @pytest.mark.django_db
+    def test_member_not_eliminated_when_has_sc_only(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.ADJUSTMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1902, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.supply_centers.create(province=italy_vs_germany_venice_province, nation=italy_vs_germany_italy_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        italy.refresh_from_db()
+        assert italy.eliminated is False
+
+    @pytest.mark.django_db
+    def test_already_eliminated_member_skipped(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_kiel_province,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        italy.eliminated = True
+        italy.save()
+
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.units.create(province=italy_vs_germany_kiel_province, type=UnitType.ARMY, nation=italy_vs_germany_germany_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        assert _elimination_jobs(in_memory_procrastinate) == []
+
+    @pytest.mark.django_db
+    def test_sends_elimination_notification_to_eliminated_member(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_kiel_province,
+        primary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.units.create(province=italy_vs_germany_kiel_province, type=UnitType.ARMY, nation=italy_vs_germany_germany_nation)
+        new_phase.supply_centers.create(province=italy_vs_germany_kiel_province, nation=italy_vs_germany_germany_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        jobs = _elimination_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert args["user_ids"] == [primary_user.id]
+        assert args["title"] == game.name
+
+    @pytest.mark.django_db
+    def test_no_notification_when_no_new_eliminations(
+        self,
+        make_elimination_game,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_kiel_province,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = make_elimination_game()
+        previous_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        new_phase = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        new_phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        new_phase.units.create(province=italy_vs_germany_kiel_province, type=UnitType.ARMY, nation=italy_vs_germany_germany_nation)
+
+        Phase.objects._check_eliminations(previous_phase, new_phase)
+
+        assert _elimination_jobs(in_memory_procrastinate) == []

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -1,9 +1,74 @@
 from datetime import timedelta
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.utils import timezone
 
 from common.constants import OrderType, PhaseFrequency, PhaseType, ProvinceType
+
+
+def format_time_remaining(seconds):
+    if seconds >= 2 * 3600:
+        return f"{int(seconds // 3600)} hours"
+    if seconds >= 3600:
+        return "1 hour"
+    if seconds >= 2 * 60:
+        return f"{int(seconds // 60)} minutes"
+    return "less than a minute"
+
+
+def format_deadline(dt, tz_name=None):
+    if tz_name:
+        try:
+            dt_local = dt.astimezone(ZoneInfo(tz_name))
+            return dt_local.strftime("%b %d, %Y at %I:%M %p") + f" {tz_name}"
+        except ZoneInfoNotFoundError:
+            pass
+    return dt.strftime("%b %d, %Y at %I:%M %p UTC")
+
+
+def build_notification_body(orders_confirmed, is_fixed_time, orders_given, total_units, time_left, extensions_remaining):
+    if extensions_remaining > 0:
+        nmr_suffix = "If no orders given, the deadline will extend, but you'll lose an extension."
+    else:
+        nmr_suffix = "If no orders given, the game will stop waiting for you for next turns."
+
+    if is_fixed_time:
+        if orders_given == total_units:
+            return None
+        if orders_given > 0:
+            return (
+                f"Deadline approaching - orders incomplete. "
+                f"{orders_given}/{total_units} units have an order. "
+                f"{time_left} to adjust your orders."
+            )
+        return (
+            f"Deadline approaching - no orders given. "
+            f"Your units have not received orders. "
+            f"{time_left} to adjust your orders. "
+            f"{nmr_suffix}"
+        )
+    else:
+        if orders_confirmed:
+            return None
+        if orders_given == total_units:
+            return (
+                f"Deadline approaching - orders ready, waiting confirmation. "
+                f"You have {time_left} to adjust your orders. "
+                f"If not confirmed, standing orders will execute."
+            )
+        if orders_given > 0:
+            return (
+                f"Deadline approaching - orders incomplete. "
+                f"{orders_given}/{total_units} units have an order. "
+                f"{time_left} to adjust your orders. "
+                f"If not confirmed, standing orders will execute."
+            )
+        return (
+            f"Deadline approaching - no orders given. "
+            f"Your units don't have orders yet. "
+            f"{time_left} to provide orders. "
+            f"{nmr_suffix}"
+        )
 
 
 def transform_options(raw_options):

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -245,6 +245,8 @@ APPLE_CLIENT_ID = os.getenv("APPLE_CLIENT_ID", "com.diplicity.app")
 
 SOCIAL_AUTH_PASSWORD = os.getenv("SOCIAL_AUTH_PASSWORD", "default_social_password")
 
+FRONTEND_URL = os.getenv("FRONTEND_URL", "https://diplicity.com")
+
 
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [


### PR DESCRIPTION
Depends on #537 (now merged). Rebased onto `main` and reconciled so it builds on the background-task work instead of duplicating it.

## What changed

- **Drops the duplicate dedup mechanism.** Removes the `deadline_warning_sent` boolean field, its migration, and every reset hook (unpause, extend deadline, NMR extension, new-phase creation). Deduplication now runs entirely off #537's `deadline_warning_sent_for` marker: at most one reminder per deadline, and an automatic fresh reminder when the deadline moves, with no reset hooks needed.
- **Keeps the per-member deadline-warning copy.** Layers #533's warning bodies on top of the marker-based `send_deadline_warnings`: distinct copy for fixed-time vs duration games, order/confirmation state, unit counts, an NMR-extension-aware suffix, and the timezone-aware `format_deadline()` helper.
- **Adds draw-proposal, elimination, and game-end notifications.** Solo wins send separate winner/loser messages; draws notify everyone with the drawing players' names. Each of these is dispatched via the background `send_notification` task (`send_notification.defer(...)`) rather than `transaction.on_commit`, consistent with #537. The game-status signal is now a single dispatcher covering both start and end.
- **Notification copy/links.** Game-name titles and `FRONTEND_URL`-based deep links across notifications; NMR-extension messages now include the new deadline.

## Tests

Draw/elimination/game-end tests assert a deferred `notification.send_notification` job via the `in_memory_procrastinate` fixture instead of mocking `send_notification_to_users`. Deadline-warning tests exercise the `deadline_warning_sent_for` marker (one reminder per deadline; a fresh one after the deadline moves). #537's reminder-guard tests now create units so they exercise the unit-aware per-member copy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)