### PR TITLE
Channel chat UI polish: nation-coloured avatars, message bubbles, and unread divider

### DIFF
--- a/packages/web/src/components/NationFlag.tsx
+++ b/packages/web/src/components/NationFlag.tsx
@@ -6,6 +6,7 @@ interface NationFlagProps {
   alt?: string;
   size?: "sm" | "md" | "lg";
   className?: string;
+  style?: React.CSSProperties;
 }
 
 const sizeClasses = {
@@ -19,6 +20,7 @@ const NationFlag: React.FC<NationFlagProps> = ({
   alt,
   size = "md",
   className,
+  style,
 }) => {
   if (!flagUrl) return null;
 
@@ -27,6 +29,7 @@ const NationFlag: React.FC<NationFlagProps> = ({
       src={flagUrl}
       alt={alt ?? ""}
       className={cn("rounded-full object-cover", sizeClasses[size], className)}
+      style={style}
     />
   );
 };

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -10,15 +10,17 @@ const SCALE = 1.2;
 type XAlign = "left" | "center" | "right";
 type YAlign = "top" | "center" | "bottom";
 
-const imgX = (d: number, xa: XAlign, xb: number): number =>
-  xa === "left"   ? xb - d :
-  xa === "right"  ? xb     :
-  xb - d / 2;
+const imgX = (d: number, xa: XAlign, xb: number): number => {
+  if (xa === "left") return xb - d;
+  if (xa === "right") return xb;
+  return xb - d / 2;
+};
 
-const imgY = (d: number, ya: YAlign, yb: number): number =>
-  ya === "top"    ? yb - d :
-  ya === "bottom" ? yb     :
-  yb - d / 2;
+const imgY = (d: number, ya: YAlign, yb: number): number => {
+  if (ya === "top") return yb - d;
+  if (ya === "bottom") return yb;
+  return yb - d / 2;
+};
 
 interface FlagImg { url: string; x: number; y: number; d: number }
 
@@ -35,29 +37,29 @@ const buildImgs = (count: number, flag: (i: number) => string | null): FlagImg[]
   const TT = 2 * THIRD;
 
   if (count === 2) {
-    add(0, d2, "left",  HALF, "center", HALF);
+    add(0, d2, "left", HALF, "center", HALF);
     add(1, d2, "right", HALF, "center", HALF);
   } else if (count <= 4) {
-    add(0, d2, "left",  HALF, "top",    HALF);
-    add(1, d2, "right", HALF, "top",    HALF);
-    add(2, d2, "left",  HALF, "bottom", HALF);
+    add(0, d2, "left", HALF, "top", HALF);
+    add(1, d2, "right", HALF, "top", HALF);
+    add(2, d2, "left", HALF, "bottom", HALF);
     add(3, d2, "right", HALF, "bottom", HALF);
   } else if (count === 5) {
-    add(0, d3, "center", HALF,  "top",    T);
-    add(1, d3, "left",   T,     "center", HALF);
-    add(2, d3, "center", HALF,  "center", HALF);
-    add(3, d3, "right",  TT,    "center", HALF);
-    add(4, d3, "center", HALF,  "bottom", TT);
+    add(0, d3, "center", HALF, "top", T);
+    add(1, d3, "left", T, "center", HALF);
+    add(2, d3, "center", HALF, "center", HALF);
+    add(3, d3, "right", TT, "center", HALF);
+    add(4, d3, "center", HALF, "bottom", TT);
   } else {
-    add(0, d3, "left",   T,    "top",    T);
-    add(1, d3, "center", HALF, "top",    T);
-    add(2, d3, "right",  TT,   "top",    T);
-    add(3, d3, "left",   T,    "center", HALF);
+    add(0, d3, "left", T, "top", T);
+    add(1, d3, "center", HALF, "top", T);
+    add(2, d3, "right", TT, "top", T);
+    add(3, d3, "left", T, "center", HALF);
     add(4, d3, "center", HALF, "center", HALF);
-    add(5, d3, "right",  TT,   "center", HALF);
-    add(6, d3, "left",   T,    "bottom", TT);
+    add(5, d3, "right", TT, "center", HALF);
+    add(6, d3, "left", T, "bottom", TT);
     add(7, d3, "center", HALF, "bottom", TT);
-    add(8, d3, "right",  TT,   "bottom", TT);
+    add(8, d3, "right", TT, "bottom", TT);
   }
 
   return imgs;
@@ -109,7 +111,7 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
         ) : (
           buildImgs(count, flag).map((img, i) => (
             <img
-              key={i}
+              key={`grid-${i}`}
               src={img.url}
               alt=""
               style={{

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -56,7 +56,7 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
 
   let content: React.ReactNode;
 
-  if (count === 1) {
+  if (isSingle) {
     content = <FlagCell url={flags[0]} w={SIZE} h={SIZE} />;
   } else if (count === 2) {
     content = <FlagRow flags={flags} w={HALF} h={SIZE} />;

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -97,14 +97,12 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
     <div
       className={cn(
         "rounded-full overflow-hidden flex-shrink-0",
-        isSingle ? "bg-muted" : "bg-background"
+        isSingle ? "bg-muted" : "bg-background dark:bg-black ring-1 ring-black dark:ring-white"
       )}
       style={{
         width: SIZE,
         height: SIZE,
-        boxShadow: isSingle
-          ? `0 0 0 1px ${items[0].color}`
-          : "0 0 0 1px hsl(var(--foreground))",
+        boxShadow: isSingle ? `0 0 0 1px ${items[0].color}` : undefined,
       }}
     >
       {content}

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { cn } from "@/lib/utils";
+import { ChannelNation } from "./channelUtils";
 
 const SIZE = 40;
 const HALF = SIZE / 2;
@@ -40,14 +42,17 @@ const FlagRow: React.FC<{
 );
 
 interface ChannelAvatarProps {
-  flagUrls: (string | null)[];
+  nations: ChannelNation[];
 }
 
-const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ flagUrls }) => {
-  const flags = flagUrls.slice(0, 9);
-  const count = flags.length;
+const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
+  const items = nations.slice(0, 9);
+  const count = items.length;
 
   if (count === 0) return null;
+
+  const flags = items.map(n => n.flagUrl);
+  const isSingle = count === 1;
 
   let content: React.ReactNode;
 
@@ -82,8 +87,17 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ flagUrls }) => {
 
   return (
     <div
-      className="rounded-full overflow-hidden bg-muted flex-shrink-0"
-      style={{ width: SIZE, height: SIZE }}
+      className={cn(
+        "rounded-full overflow-hidden flex-shrink-0",
+        isSingle ? "bg-muted" : "bg-background"
+      )}
+      style={{
+        width: SIZE,
+        height: SIZE,
+        boxShadow: isSingle
+          ? `0 0 0 1px ${items[0].color}`
+          : "0 0 0 1px hsl(var(--foreground))",
+      }}
     >
       {content}
     </div>

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -59,7 +59,15 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
   if (isSingle) {
     content = <FlagCell url={flags[0]} w={SIZE} h={SIZE} />;
   } else if (count === 2) {
-    content = <FlagRow flags={flags} w={HALF} h={SIZE} />;
+    content = (
+      <div style={{ display: "flex", width: SIZE, height: SIZE, alignItems: "center", justifyContent: "center" }}>
+        {flags.slice(0, 2).map((url, i) => (
+          <div key={i} style={{ width: HALF, height: HALF, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
+            {url && <img src={url} alt="" style={{ width: HALF, height: HALF, objectFit: "cover", display: "block" }} />}
+          </div>
+        ))}
+      </div>
+    );
   } else if (count <= 4) {
     content = (
       <>

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -10,52 +10,58 @@ const SCALE = 1.2;
 type XAlign = "left" | "center" | "right";
 type YAlign = "top" | "center" | "bottom";
 
-const FlagCell: React.FC<{
-  url: string | null;
-  w: number;
-  xAlign: XAlign;
-  yAlign: YAlign;
-}> = ({ url, w, xAlign, yAlign }) => {
-  const d = w * SCALE;
-  const centerOffset = (w - d) / 2; // negative half-overflow for centering
+const imgX = (d: number, xa: XAlign, xb: number): number =>
+  xa === "left"   ? xb - d :
+  xa === "right"  ? xb     :
+  xb - d / 2;
 
-  const xPos: React.CSSProperties =
-    xAlign === "left"   ? { right: 0 } :
-    xAlign === "right"  ? { left: 0 } :
-    { left: centerOffset };
+const imgY = (d: number, ya: YAlign, yb: number): number =>
+  ya === "top"    ? yb - d :
+  ya === "bottom" ? yb     :
+  yb - d / 2;
 
-  const yPos: React.CSSProperties =
-    yAlign === "top"    ? { bottom: 0 } :
-    yAlign === "bottom" ? { top: 0 } :
-    { top: centerOffset };
+interface FlagImg { url: string; x: number; y: number; d: number }
 
-  return (
-    <div style={{ width: w, height: w, flexShrink: 0, position: "relative" }}>
-      {url && (
-        <img
-          src={url}
-          alt=""
-          style={{
-            width: d,
-            height: d,
-            objectFit: "cover",
-            display: "block",
-            borderRadius: "50%",
-            position: "absolute",
-            ...xPos,
-            ...yPos,
-          }}
-        />
-      )}
-    </div>
-  );
+const buildImgs = (count: number, flag: (i: number) => string | null): FlagImg[] => {
+  const imgs: FlagImg[] = [];
+  const add = (fi: number, d: number, xa: XAlign, xb: number, ya: YAlign, yb: number) => {
+    const url = flag(fi);
+    if (url) imgs.push({ url, x: imgX(d, xa, xb), y: imgY(d, ya, yb), d });
+  };
+
+  const d2 = HALF * SCALE;
+  const d3 = THIRD * SCALE;
+  const T = THIRD;
+  const TT = 2 * THIRD;
+
+  if (count === 2) {
+    add(0, d2, "left",  HALF, "center", HALF);
+    add(1, d2, "right", HALF, "center", HALF);
+  } else if (count <= 4) {
+    add(0, d2, "left",  HALF, "top",    HALF);
+    add(1, d2, "right", HALF, "top",    HALF);
+    add(2, d2, "left",  HALF, "bottom", HALF);
+    add(3, d2, "right", HALF, "bottom", HALF);
+  } else if (count === 5) {
+    add(0, d3, "center", HALF,  "top",    T);
+    add(1, d3, "left",   T,     "center", HALF);
+    add(2, d3, "center", HALF,  "center", HALF);
+    add(3, d3, "right",  TT,    "center", HALF);
+    add(4, d3, "center", HALF,  "bottom", TT);
+  } else {
+    add(0, d3, "left",   T,    "top",    T);
+    add(1, d3, "center", HALF, "top",    T);
+    add(2, d3, "right",  TT,   "top",    T);
+    add(3, d3, "left",   T,    "center", HALF);
+    add(4, d3, "center", HALF, "center", HALF);
+    add(5, d3, "right",  TT,   "center", HALF);
+    add(6, d3, "left",   T,    "bottom", TT);
+    add(7, d3, "center", HALF, "bottom", TT);
+    add(8, d3, "right",  TT,   "bottom", TT);
+  }
+
+  return imgs;
 };
-
-const Row: React.FC<{ h: number; children: React.ReactNode }> = ({ h, children }) => (
-  <div style={{ display: "flex", width: SIZE, height: h }}>
-    {children}
-  </div>
-);
 
 interface ChannelAvatarProps {
   nations: ChannelNation[];
@@ -67,67 +73,9 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
 
   if (count === 0) return null;
 
-  const f = items.map(n => n.flagUrl);
-  const flag = (i: number): string | null => f[i] ?? null;
+  const flag = (i: number): string | null => items[i]?.flagUrl ?? null;
   const isSingle = count === 1;
-
-  let content: React.ReactNode;
-
-  if (isSingle) {
-    content = f[0] ? (
-      <img
-        src={f[0]}
-        alt=""
-        style={{ width: SIZE, height: SIZE, objectFit: "cover", display: "block" }}
-      />
-    ) : null;
-  } else if (count === 2) {
-    // 2×1: two cells side-by-side, vertically centred in parent
-    content = (
-      <div style={{ display: "flex", width: SIZE, height: SIZE, alignItems: "center", justifyContent: "center" }}>
-        <FlagCell url={flag(0)} w={HALF} xAlign="left"  yAlign="center" />
-        <FlagCell url={flag(1)} w={HALF} xAlign="right" yAlign="center" />
-      </div>
-    );
-  } else if (count <= 4) {
-    // 2×2 grid
-    content = (
-      <>
-        <Row h={HALF}>
-          <FlagCell url={flag(0)} w={HALF} xAlign="left"  yAlign="top" />
-          <FlagCell url={flag(1)} w={HALF} xAlign="right" yAlign="top" />
-        </Row>
-        <Row h={HALF}>
-          <FlagCell url={flag(2)} w={HALF} xAlign="left"  yAlign="bottom" />
-          <FlagCell url={flag(3)} w={HALF} xAlign="right" yAlign="bottom" />
-        </Row>
-      </>
-    );
-  } else {
-    // 3×3 grid.
-    // 5 nations: cross pattern (TC, ML, MC, MR, BC) — corners empty.
-    // 6–9 nations: fill left-to-right, top-to-bottom.
-    const cells: (string | null)[] = count === 5
-      ? [null, flag(0), null, flag(1), flag(2), flag(3), null, flag(4), null]
-      : [0, 1, 2, 3, 4, 5, 6, 7, 8].map(flag);
-
-    const xs: XAlign[] = ["left", "center", "right", "left", "center", "right", "left", "center", "right"];
-    const ys: YAlign[] = ["top", "top", "top", "center", "center", "center", "bottom", "bottom", "bottom"];
-
-    content = (
-      <>
-        <Row h={THIRD}>
-          {[0, 1, 2].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
-        </Row>
-        <Row h={THIRD}>
-          {[3, 4, 5].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
-        </Row>
-        <Row h={THIRD}>
-          {[6, 7, 8].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
-        </Row>
-      </>
-    );
-  }
+  const singleUrl = isSingle ? flag(0) : null;
 
   return (
     <div
@@ -143,9 +91,40 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
     >
       <div
         className={isSingle ? "bg-muted" : "bg-background dark:bg-black"}
-        style={{ width: SIZE, height: SIZE, clipPath: "circle(50% at 50% 50%)" }}
+        style={{
+          width: SIZE,
+          height: SIZE,
+          position: "relative",
+          clipPath: "circle(50% at 50% 50%)",
+        }}
       >
-        {content}
+        {isSingle ? (
+          singleUrl && (
+            <img
+              src={singleUrl}
+              alt=""
+              style={{ width: SIZE, height: SIZE, objectFit: "cover", display: "block" }}
+            />
+          )
+        ) : (
+          buildImgs(count, flag).map((img, i) => (
+            <img
+              key={i}
+              src={img.url}
+              alt=""
+              style={{
+                position: "absolute",
+                left: img.x,
+                top: img.y,
+                width: img.d,
+                height: img.d,
+                objectFit: "cover",
+                display: "block",
+                borderRadius: "50%",
+              }}
+            />
+          ))
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -20,12 +20,12 @@ const FlagCell: React.FC<{ url: string | null; w: number; h: number }> = ({
         alt=""
         style={{
           width: w * SCALE,
-          height: h * SCALE,
+          height: w * SCALE,
           objectFit: "cover",
           display: "block",
           borderRadius: "50%",
           position: "absolute",
-          top: -(h * OVERFLOW),
+          top: -(w * OVERFLOW),
           left: -(w * OVERFLOW),
         }}
       />
@@ -68,7 +68,13 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
   let content: React.ReactNode;
 
   if (isSingle) {
-    content = <FlagCell url={flags[0]} w={SIZE} h={SIZE} />;
+    content = flags[0] ? (
+      <img
+        src={flags[0]}
+        alt=""
+        style={{ width: SIZE, height: SIZE, objectFit: "cover", display: "block" }}
+      />
+    ) : null;
   } else if (count === 2) {
     content = (
       <div style={{ display: "flex", width: SIZE, height: SIZE, alignItems: "center", justifyContent: "center" }}>

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+const SIZE = 40;
+const HALF = SIZE / 2;
+const THIRD = SIZE / 3;
+
+const FlagCell: React.FC<{ url: string | null; w: number; h: number }> = ({
+  url,
+  w,
+  h,
+}) => (
+  <div style={{ width: w, height: h, flexShrink: 0 }}>
+    {url && (
+      <img
+        src={url}
+        alt=""
+        style={{ width: w, height: h, objectFit: "cover", display: "block" }}
+      />
+    )}
+  </div>
+);
+
+const FlagRow: React.FC<{
+  flags: (string | null)[];
+  w: number;
+  h: number;
+}> = ({ flags, w, h }) => (
+  <div
+    style={{
+      display: "flex",
+      width: SIZE,
+      height: h,
+      justifyContent: "center",
+    }}
+  >
+    {flags.map((url, i) => (
+      <FlagCell key={i} url={url} w={w} h={h} />
+    ))}
+  </div>
+);
+
+interface ChannelAvatarProps {
+  flagUrls: (string | null)[];
+}
+
+const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ flagUrls }) => {
+  const flags = flagUrls.slice(0, 9);
+  const count = flags.length;
+
+  if (count === 0) return null;
+
+  let content: React.ReactNode;
+
+  if (count === 1) {
+    content = <FlagCell url={flags[0]} w={SIZE} h={SIZE} />;
+  } else if (count === 2) {
+    content = <FlagRow flags={flags} w={HALF} h={SIZE} />;
+  } else if (count <= 4) {
+    content = (
+      <>
+        <FlagRow flags={flags.slice(0, 2)} w={HALF} h={HALF} />
+        <FlagRow flags={flags.slice(2, 4)} w={HALF} h={HALF} />
+      </>
+    );
+  } else if (count === 5) {
+    content = (
+      <>
+        <FlagRow flags={[flags[0]]} w={THIRD} h={THIRD} />
+        <FlagRow flags={flags.slice(1, 4)} w={THIRD} h={THIRD} />
+        <FlagRow flags={[flags[4]]} w={THIRD} h={THIRD} />
+      </>
+    );
+  } else {
+    content = (
+      <>
+        <FlagRow flags={flags.slice(0, 3)} w={THIRD} h={THIRD} />
+        <FlagRow flags={flags.slice(3, 6)} w={THIRD} h={THIRD} />
+        <FlagRow flags={flags.slice(6, 9)} w={THIRD} h={THIRD} />
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-full overflow-hidden bg-muted flex-shrink-0"
+      style={{ width: SIZE, height: SIZE }}
+    >
+      {content}
+    </div>
+  );
+};
+
+export { ChannelAvatar };

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -5,50 +5,58 @@ import { ChannelNation } from "./channelUtils";
 const SIZE = 40;
 const HALF = SIZE / 2;
 const THIRD = SIZE / 3;
-const OVERFLOW = 0.2; // each circle bleeds 20% of its cell size past the cell edge
-const SCALE = 1 + 2 * OVERFLOW;
+const SCALE = 1.2;
 
-const FlagCell: React.FC<{ url: string | null; w: number; h: number }> = ({
-  url,
-  w,
-  h,
-}) => (
-  <div style={{ width: w, height: h, flexShrink: 0, position: "relative" }}>
-    {url && (
-      <img
-        src={url}
-        alt=""
-        style={{
-          width: w * SCALE,
-          height: w * SCALE,
-          objectFit: "cover",
-          display: "block",
-          borderRadius: "50%",
-          position: "absolute",
-          top: -(w * OVERFLOW),
-          left: -(w * OVERFLOW),
-        }}
-      />
-    )}
-  </div>
-);
+type XAlign = "left" | "center" | "right";
+type YAlign = "top" | "center" | "bottom";
 
-const FlagRow: React.FC<{
-  flags: (string | null)[];
+// Each circle is SCALE times the cell size, positioned so its inner edge(s) align
+// with the cell's inner boundary. The outer 20% bleeds past the parent boundary
+// and is clipped by the parent's overflow-hidden rounded-full.
+const FlagCell: React.FC<{
+  url: string | null;
   w: number;
-  h: number;
-}> = ({ flags, w, h }) => (
-  <div
-    style={{
-      display: "flex",
-      width: SIZE,
-      height: h,
-      justifyContent: "center",
-    }}
-  >
-    {flags.map((url, i) => (
-      <FlagCell key={i} url={url} w={w} h={h} />
-    ))}
+  xAlign: XAlign;
+  yAlign: YAlign;
+}> = ({ url, w, xAlign, yAlign }) => {
+  const d = w * SCALE;
+  const centerOffset = (w - d) / 2; // negative half-overflow for centering
+
+  const xPos: React.CSSProperties =
+    xAlign === "left"   ? { right: 0 } :
+    xAlign === "right"  ? { left: 0 } :
+    { left: centerOffset };
+
+  const yPos: React.CSSProperties =
+    yAlign === "top"    ? { bottom: 0 } :
+    yAlign === "bottom" ? { top: 0 } :
+    { top: centerOffset };
+
+  return (
+    <div style={{ width: w, height: w, flexShrink: 0, position: "relative" }}>
+      {url && (
+        <img
+          src={url}
+          alt=""
+          style={{
+            width: d,
+            height: d,
+            objectFit: "cover",
+            display: "block",
+            borderRadius: "50%",
+            position: "absolute",
+            ...xPos,
+            ...yPos,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const Row: React.FC<{ h: number; children: React.ReactNode }> = ({ h, children }) => (
+  <div style={{ display: "flex", width: SIZE, height: h }}>
+    {children}
   </div>
 );
 
@@ -62,47 +70,64 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
 
   if (count === 0) return null;
 
-  const flags = items.map(n => n.flagUrl);
+  const f = items.map(n => n.flagUrl);
+  const flag = (i: number): string | null => f[i] ?? null;
   const isSingle = count === 1;
 
   let content: React.ReactNode;
 
   if (isSingle) {
-    content = flags[0] ? (
+    content = f[0] ? (
       <img
-        src={flags[0]}
+        src={f[0]}
         alt=""
         style={{ width: SIZE, height: SIZE, objectFit: "cover", display: "block" }}
       />
     ) : null;
   } else if (count === 2) {
+    // 2×1: two cells side-by-side, vertically centred in parent
     content = (
       <div style={{ display: "flex", width: SIZE, height: SIZE, alignItems: "center", justifyContent: "center" }}>
-        <FlagCell url={flags[0]} w={HALF} h={HALF} />
-        <FlagCell url={flags[1]} w={HALF} h={HALF} />
+        <FlagCell url={flag(0)} w={HALF} xAlign="left"  yAlign="center" />
+        <FlagCell url={flag(1)} w={HALF} xAlign="right" yAlign="center" />
       </div>
     );
   } else if (count <= 4) {
+    // 2×2 grid
     content = (
       <>
-        <FlagRow flags={flags.slice(0, 2)} w={HALF} h={HALF} />
-        <FlagRow flags={flags.slice(2, 4)} w={HALF} h={HALF} />
-      </>
-    );
-  } else if (count === 5) {
-    content = (
-      <>
-        <FlagRow flags={[flags[0]]} w={THIRD} h={THIRD} />
-        <FlagRow flags={flags.slice(1, 4)} w={THIRD} h={THIRD} />
-        <FlagRow flags={[flags[4]]} w={THIRD} h={THIRD} />
+        <Row h={HALF}>
+          <FlagCell url={flag(0)} w={HALF} xAlign="left"  yAlign="top" />
+          <FlagCell url={flag(1)} w={HALF} xAlign="right" yAlign="top" />
+        </Row>
+        <Row h={HALF}>
+          <FlagCell url={flag(2)} w={HALF} xAlign="left"  yAlign="bottom" />
+          <FlagCell url={flag(3)} w={HALF} xAlign="right" yAlign="bottom" />
+        </Row>
       </>
     );
   } else {
+    // 3×3 grid.
+    // 5 nations: cross pattern (TC, ML, MC, MR, BC) — corners empty.
+    // 6–9 nations: fill left-to-right, top-to-bottom.
+    const cells: (string | null)[] = count === 5
+      ? [null, flag(0), null, flag(1), flag(2), flag(3), null, flag(4), null]
+      : [0, 1, 2, 3, 4, 5, 6, 7, 8].map(flag);
+
+    const xs: XAlign[] = ["left", "center", "right", "left", "center", "right", "left", "center", "right"];
+    const ys: YAlign[] = ["top", "top", "top", "center", "center", "center", "bottom", "bottom", "bottom"];
+
     content = (
       <>
-        <FlagRow flags={flags.slice(0, 3)} w={THIRD} h={THIRD} />
-        <FlagRow flags={flags.slice(3, 6)} w={THIRD} h={THIRD} />
-        <FlagRow flags={flags.slice(6, 9)} w={THIRD} h={THIRD} />
+        <Row h={THIRD}>
+          {[0, 1, 2].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
+        </Row>
+        <Row h={THIRD}>
+          {[3, 4, 5].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
+        </Row>
+        <Row h={THIRD}>
+          {[6, 7, 8].map(i => <FlagCell key={i} url={cells[i]} w={THIRD} xAlign={xs[i]} yAlign={ys[i]} />)}
+        </Row>
       </>
     );
   }

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -5,18 +5,29 @@ import { ChannelNation } from "./channelUtils";
 const SIZE = 40;
 const HALF = SIZE / 2;
 const THIRD = SIZE / 3;
+const OVERFLOW = 0.2; // each circle bleeds 20% of its cell size past the cell edge
+const SCALE = 1 + 2 * OVERFLOW;
 
 const FlagCell: React.FC<{ url: string | null; w: number; h: number }> = ({
   url,
   w,
   h,
 }) => (
-  <div style={{ width: w, height: h, flexShrink: 0 }}>
+  <div style={{ width: w, height: h, flexShrink: 0, position: "relative" }}>
     {url && (
       <img
         src={url}
         alt=""
-        style={{ width: w, height: h, objectFit: "cover", display: "block" }}
+        style={{
+          width: w * SCALE,
+          height: h * SCALE,
+          objectFit: "cover",
+          display: "block",
+          borderRadius: "50%",
+          position: "absolute",
+          top: -(h * OVERFLOW),
+          left: -(w * OVERFLOW),
+        }}
       />
     )}
   </div>
@@ -61,11 +72,8 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
   } else if (count === 2) {
     content = (
       <div style={{ display: "flex", width: SIZE, height: SIZE, alignItems: "center", justifyContent: "center" }}>
-        {flags.slice(0, 2).map((url, i) => (
-          <div key={i} style={{ width: HALF, height: HALF, borderRadius: "50%", overflow: "hidden", flexShrink: 0 }}>
-            {url && <img src={url} alt="" style={{ width: HALF, height: HALF, objectFit: "cover", display: "block" }} />}
-          </div>
-        ))}
+        <FlagCell url={flags[0]} w={HALF} h={HALF} />
+        <FlagCell url={flags[1]} w={HALF} h={HALF} />
       </div>
     );
   } else if (count <= 4) {

--- a/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelAvatar.tsx
@@ -10,9 +10,6 @@ const SCALE = 1.2;
 type XAlign = "left" | "center" | "right";
 type YAlign = "top" | "center" | "bottom";
 
-// Each circle is SCALE times the cell size, positioned so its inner edge(s) align
-// with the cell's inner boundary. The outer 20% bleeds past the parent boundary
-// and is clipped by the parent's overflow-hidden rounded-full.
 const FlagCell: React.FC<{
   url: string | null;
   w: number;
@@ -135,8 +132,8 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
   return (
     <div
       className={cn(
-        "rounded-full overflow-hidden flex-shrink-0",
-        isSingle ? "bg-muted" : "bg-background dark:bg-black ring-1 ring-black dark:ring-white"
+        "rounded-full flex-shrink-0",
+        !isSingle && "ring-1 ring-black dark:ring-white"
       )}
       style={{
         width: SIZE,
@@ -144,7 +141,12 @@ const ChannelAvatar: React.FC<ChannelAvatarProps> = ({ nations }) => {
         boxShadow: isSingle ? `0 0 0 1px ${items[0].color}` : undefined,
       }}
     >
-      {content}
+      <div
+        className={isSingle ? "bg-muted" : "bg-background dark:bg-black"}
+        style={{ width: SIZE, height: SIZE, clipPath: "circle(50% at 50% 50%)" }}
+      >
+        {content}
+      </div>
     </div>
   );
 };

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
@@ -23,10 +23,19 @@ const mockChannelsData = vi.fn();
 
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({
-    data: { sandbox: false },
+    data: {
+      sandbox: false,
+      pressType: "public_press",
+      status: "active",
+      variantId: "standard",
+      members: [],
+    },
   }),
   useGamesChannelsListSuspense: () => ({
     data: mockChannelsData(),
+  }),
+  useVariantsListSuspense: () => ({
+    data: [],
   }),
 }));
 

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -23,6 +23,7 @@ import {
   useGameRetrieveSuspense,
   useGamesChannelsListSuspense,
 } from "@/api/generated/endpoints";
+import { getChannelDisplayName } from "./channelUtils";
 
 const getLatestMessagePreview = (
   messages: readonly ChannelMessage[]
@@ -33,17 +34,6 @@ const getLatestMessagePreview = (
     ? "You"
     : latestMessage.sender.nation.name;
   return `${senderLabel}: ${latestMessage.body}`;
-};
-
-const getChannelDisplayName = (
-  channel: { name: string; private: boolean },
-  currentNationName: string | undefined
-): string => {
-  if (!channel.private || !currentNationName) return channel.name;
-  const others = channel.name
-    .split(", ")
-    .filter(n => n !== currentNationName);
-  return others.join(", ");
 };
 
 const ChannelListScreen: React.FC = () => {

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -29,7 +29,21 @@ const getLatestMessagePreview = (
 ): string => {
   if (messages.length === 0) return "No messages";
   const latestMessage = messages[messages.length - 1];
-  return `${latestMessage.sender.nation.name}: ${latestMessage.body}`;
+  const senderLabel = latestMessage.sender.isCurrentUser
+    ? "You"
+    : latestMessage.sender.nation.name;
+  return `${senderLabel}: ${latestMessage.body}`;
+};
+
+const getChannelDisplayName = (
+  channel: { name: string; private: boolean },
+  currentNationName: string | undefined
+): string => {
+  if (!channel.private || !currentNationName) return channel.name;
+  const others = channel.name
+    .split(", ")
+    .filter(n => n !== currentNationName);
+  return others.join(", ");
 };
 
 const ChannelListScreen: React.FC = () => {
@@ -40,6 +54,8 @@ const ChannelListScreen: React.FC = () => {
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: channels } = useGamesChannelsListSuspense(gameId);
 
+  const currentNationName =
+    game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
   const isSandboxGame = game.sandbox;
   const isNoPressActiveGame =
     game.pressType === "no_press" &&
@@ -81,7 +97,7 @@ const ChannelListScreen: React.FC = () => {
                       >
                         <ItemContent>
                           <ItemTitle>
-                            {channel.name}
+                            {getChannelDisplayName(channel, currentNationName)}
                             {!channel.private && (
                               <Badge variant="outline">Public</Badge>
                             )}

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -90,7 +90,7 @@ const ChannelListScreen: React.FC = () => {
                         className="text-foreground no-underline"
                       >
                         <ChannelAvatar
-                          flagUrls={getChannelFlagUrls(
+                          nations={getChannelFlagUrls(
                             channel,
                             game.members,
                             currentNationName,

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -22,8 +22,10 @@ import {
   ChannelMessage,
   useGameRetrieveSuspense,
   useGamesChannelsListSuspense,
+  useVariantsListSuspense,
 } from "@/api/generated/endpoints";
-import { getChannelDisplayName } from "./channelUtils";
+import { getChannelDisplayName, getChannelFlagUrls } from "./channelUtils";
+import { ChannelAvatar } from "./ChannelAvatar";
 
 const getLatestMessagePreview = (
   messages: readonly ChannelMessage[]
@@ -43,9 +45,11 @@ const ChannelListScreen: React.FC = () => {
   }>();
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: channels } = useGamesChannelsListSuspense(gameId);
+  const { data: variants } = useVariantsListSuspense();
 
   const currentNationName =
     game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
+  const variantNations = variants.find(v => v.id === game.variantId)?.nations ?? [];
   const isSandboxGame = game.sandbox;
   const isNoPressActiveGame =
     game.pressType === "no_press" &&
@@ -85,6 +89,14 @@ const ChannelListScreen: React.FC = () => {
                         to={`/game/${gameId}/phase/${phaseId}/chat/channel/${channel.id}`}
                         className="text-foreground no-underline"
                       >
+                        <ChannelAvatar
+                          flagUrls={getChannelFlagUrls(
+                            channel,
+                            game.members,
+                            currentNationName,
+                            variantNations
+                          )}
+                        />
                         <ItemContent>
                           <ItemTitle>
                             {getChannelDisplayName(channel, currentNationName)}

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -84,7 +84,7 @@ const ChannelListScreen: React.FC = () => {
               <ItemGroup>
                 {channels.map(channel => (
                   <React.Fragment key={channel.id}>
-                    <Item asChild size="sm">
+                    <Item asChild size="sm" className="py-2">
                       <Link
                         to={`/game/${gameId}/phase/${phaseId}/chat/channel/${channel.id}`}
                         className="text-foreground no-underline"
@@ -97,7 +97,7 @@ const ChannelListScreen: React.FC = () => {
                             variantNations
                           )}
                         />
-                        <ItemContent>
+                        <ItemContent className="gap-0.5">
                           <ItemTitle>
                             {getChannelDisplayName(channel, currentNationName)}
                             {!channel.private && (

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -266,6 +266,7 @@ const ChannelScreen: React.FC = () => {
                           <div className="w-8 flex-shrink-0" />
                         )}
                         <MessageContent
+                          className={item.isCurrentUser ? "rounded-tr-none" : "rounded-tl-none"}
                           style={{
                             backgroundColor: item.sender.nationColor + BUBBLE_ALPHA_HEX,
                             border: brightnessByColor(item.sender.nationColor) > 128

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -100,6 +100,14 @@ const ChannelScreen: React.FC = () => {
   if (!channel) throw new Error("Channel not found");
 
   const currentMember = game.members.find(m => m.isCurrentUser);
+  const currentNation = currentMember?.nation ?? undefined;
+  const channelDisplayName =
+    !channel.private || !currentNation
+      ? channel.name
+      : channel.name
+          .split(", ")
+          .filter(n => n !== currentNation)
+          .join(", ");
 
   useEffect(() => {
     if (currentMember) {
@@ -165,7 +173,7 @@ const ChannelScreen: React.FC = () => {
     return (
       <div className="flex flex-col flex-1 min-h-0">
         <GameDetailAppBar
-          title={channel.name}
+          title={channelDisplayName}
           onNavigateBack={() =>
             navigate(`/game/${gameId}/phase/${phaseId}/chat`)
           }
@@ -189,7 +197,7 @@ const ChannelScreen: React.FC = () => {
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <GameDetailAppBar
-        title={channel.name}
+        title={channelDisplayName}
         onNavigateBack={() => navigate(`/game/${gameId}/phase/${phaseId}/chat`)}
         variant="secondary"
       />

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -81,6 +81,8 @@ const buildMessageItems = (
   });
 };
 
+const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
+
 const NewMessagesDivider: React.FC = () => (
   <div className="flex items-center gap-2 my-1">
     <div className="flex-1 h-px bg-border" />
@@ -120,12 +122,13 @@ const ChannelScreen: React.FC = () => {
 
   const currentNationName =
     game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
+  const variant = variants.find(v => v.id === game.variantId);
   const channelDisplayName = getChannelDisplayName(channel, currentNationName);
   const channelFlagUrls = getChannelFlagUrls(
     channel,
     game.members,
     currentNationName,
-    variants.find(v => v.id === game.variantId)?.nations ?? []
+    variant?.nations ?? []
   );
   const channelTitle = (
     <div className="flex items-center justify-start gap-2">
@@ -146,7 +149,7 @@ const ChannelScreen: React.FC = () => {
         queryKey: getGameRetrieveQueryKey(gameId),
       });
     }).catch(() => {});
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- markReadMutation is stable, fire once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation object excluded per project convention (not referentially stable); fire once on mount
   }, [gameId, channelId]);
 
   useEffect(() => {
@@ -185,8 +188,6 @@ const ChannelScreen: React.FC = () => {
     game.pressType === "no_press" &&
     game.status !== "completed" &&
     game.status !== "abandoned";
-
-  const variant = variants.find(v => v.id === game.variantId);
 
   const messageItems = buildMessageItems(channel.messages);
 
@@ -271,9 +272,8 @@ const ChannelScreen: React.FC = () => {
                           <div className="w-8" />
                         )}
                         <MessageContent
-                          className="bg-transparent"
                           style={{
-                            backgroundColor: item.sender.nationColor + "26",
+                            backgroundColor: item.sender.nationColor + BUBBLE_ALPHA_HEX,
                             border: brightnessByColor(item.sender.nationColor) > 128
                               ? `1px solid ${item.sender.nationColor}`
                               : undefined,

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -250,7 +250,7 @@ const ChannelScreen: React.FC = () => {
                         }
                       >
                         {item.showAvatar ? (
-                          <div className="flex flex-col items-center gap-0.5">
+                          <div className="w-8 flex-shrink-0 flex justify-center">
                             <NationFlag
                               flagUrl={
                                 variant
@@ -261,15 +261,9 @@ const ChannelScreen: React.FC = () => {
                               size="lg"
                               style={{ boxShadow: `0 0 0 1px ${item.sender.nationColor}` }}
                             />
-                            <span
-                              className="text-xs font-medium"
-                              style={{ color: item.sender.nationColor }}
-                            >
-                              {item.sender.nationName}
-                            </span>
                           </div>
                         ) : (
-                          <div className="w-8" />
+                          <div className="w-8 flex-shrink-0" />
                         )}
                         <MessageContent
                           style={{
@@ -280,9 +274,23 @@ const ChannelScreen: React.FC = () => {
                           }}
                         >
                           {item.body}
-                          <MessageTimestamp>
-                            {item.formattedTime}
-                          </MessageTimestamp>
+                          {item.showAvatar ? (
+                            <div className="flex items-center justify-between gap-2 mt-1">
+                              <span
+                                className="text-xs font-medium"
+                                style={{ color: item.sender.nationColor }}
+                              >
+                                {item.sender.nationName}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {item.formattedTime}
+                              </span>
+                            </div>
+                          ) : (
+                            <MessageTimestamp>
+                              {item.formattedTime}
+                            </MessageTimestamp>
+                          )}
                         </MessageContent>
                       </Message>
                     </React.Fragment>

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useEffect, useState } from "react";
+import React, { Suspense, useRef, useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
@@ -17,7 +17,7 @@ import {
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
 import { GameDetailAppBar } from "./AppBar";
-import { getChannelDisplayName, getChannelFlagUrls, brightnessByColor } from "./channelUtils";
+import { getChannelDisplayName, getChannelFlagUrls, brightnessByColor, toHex6 } from "./channelUtils";
 import { ChannelAvatar } from "./ChannelAvatar";
 import { Panel } from "@/components/Panel";
 import {
@@ -120,8 +120,8 @@ const ChannelScreen: React.FC = () => {
     return idx > 0 ? idx : null;
   });
 
-  const currentNationName =
-    game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
+  const currentMember = game.members.find(m => m.isCurrentUser);
+  const currentNationName = currentMember?.nation ?? undefined;
   const variant = variants.find(v => v.id === game.variantId);
   const channelDisplayName = getChannelDisplayName(channel, currentNationName);
   const channelFlagUrls = getChannelFlagUrls(
@@ -138,6 +138,7 @@ const ChannelScreen: React.FC = () => {
   );
 
   useEffect(() => {
+    if (!currentMember) return;
     markReadMutation.mutateAsync({
       gameId,
       channelId: parseInt(channelId),
@@ -148,7 +149,9 @@ const ChannelScreen: React.FC = () => {
       queryClient.invalidateQueries({
         queryKey: getGameRetrieveQueryKey(gameId),
       });
-    }).catch(() => {});
+    }).catch(() => {
+      // Fire-and-forget: silently ignore mark-read failures
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mutation object excluded per project convention (not referentially stable); fire once on mount
   }, [gameId, channelId]);
 
@@ -189,7 +192,10 @@ const ChannelScreen: React.FC = () => {
     game.status !== "completed" &&
     game.status !== "abandoned";
 
-  const messageItems = buildMessageItems(channel.messages);
+  const messageItems = useMemo(
+    () => buildMessageItems(channel.messages),
+    [channel.messages]
+  );
 
   if (isNoPressActiveGame) {
     return (
@@ -201,7 +207,7 @@ const ChannelScreen: React.FC = () => {
           }
           variant="secondary"
         />
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-hidden">
           <Panel>
             <Panel.Content>
               <Notice
@@ -266,9 +272,9 @@ const ChannelScreen: React.FC = () => {
                           <div className="w-8 flex-shrink-0" />
                         )}
                         <MessageContent
-                          className={item.isCurrentUser ? "rounded-tr-none" : "rounded-tl-none"}
+                          className={`py-1.5 px-2 ${item.isCurrentUser ? "rounded-tr-none" : "rounded-tl-none"}`}
                           style={{
-                            backgroundColor: item.sender.nationColor + BUBBLE_ALPHA_HEX,
+                            backgroundColor: toHex6(item.sender.nationColor) + BUBBLE_ALPHA_HEX,
                             border: brightnessByColor(item.sender.nationColor) > 128
                               ? `1px solid ${item.sender.nationColor}`
                               : undefined,
@@ -276,7 +282,7 @@ const ChannelScreen: React.FC = () => {
                         >
                           {item.body}
                           {item.showAvatar ? (
-                            <div className="flex items-center justify-between gap-2 mt-1">
+                            <div className="flex items-center justify-between gap-2 mt-0.5">
                               <span
                                 className="text-xs font-medium"
                                 style={{ color: item.sender.nationColor }}
@@ -288,7 +294,7 @@ const ChannelScreen: React.FC = () => {
                               </span>
                             </div>
                           ) : (
-                            <MessageTimestamp>
+                            <MessageTimestamp className="mt-0.5">
                               {item.formattedTime}
                             </MessageTimestamp>
                           )}

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -111,9 +111,9 @@ const ChannelScreen: React.FC = () => {
     variants.find(v => v.id === game.variantId)?.nations ?? []
   );
   const channelTitle = (
-    <div className="flex items-center justify-center gap-2">
+    <div className="flex items-center justify-start gap-2">
       <ChannelAvatar flagUrls={channelFlagUrls} />
-      <h1 className="text-lg font-semibold truncate">{channelDisplayName}</h1>
+      <span className="text-lg font-semibold truncate text-left">{channelDisplayName}</span>
     </div>
   );
 

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -129,7 +129,7 @@ const ChannelScreen: React.FC = () => {
   );
   const channelTitle = (
     <div className="flex items-center justify-start gap-2">
-      <ChannelAvatar flagUrls={channelFlagUrls} />
+      <ChannelAvatar nations={channelFlagUrls} />
       <span className="text-lg font-semibold truncate text-left">{channelDisplayName}</span>
     </div>
   );

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -258,6 +258,7 @@ const ChannelScreen: React.FC = () => {
                               }
                               alt={item.sender.nationName}
                               size="lg"
+                              style={{ boxShadow: `0 0 0 1px ${item.sender.nationColor}` }}
                             />
                             <span
                               className="text-xs font-medium"

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -17,6 +17,7 @@ import {
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
 import { GameDetailAppBar } from "./AppBar";
+import { getChannelDisplayName } from "./channelUtils";
 import { Panel } from "@/components/Panel";
 import {
   useGameRetrieveSuspense,
@@ -99,34 +100,24 @@ const ChannelScreen: React.FC = () => {
   const channel = channels.find(c => c.id === parseInt(channelId));
   if (!channel) throw new Error("Channel not found");
 
-  const currentMember = game.members.find(m => m.isCurrentUser);
-  const currentNation = currentMember?.nation ?? undefined;
-  const channelDisplayName =
-    !channel.private || !currentNation
-      ? channel.name
-      : channel.name
-          .split(", ")
-          .filter(n => n !== currentNation)
-          .join(", ");
+  const currentNationName =
+    game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
+  const channelDisplayName = getChannelDisplayName(channel, currentNationName);
 
   useEffect(() => {
-    if (currentMember) {
-      markReadMutation.mutateAsync({
-        gameId,
-        channelId: parseInt(channelId),
-      }).then(() => {
-        queryClient.invalidateQueries({
-          queryKey: getGamesChannelsListQueryKey(gameId),
-        });
-        queryClient.invalidateQueries({
-          queryKey: getGameRetrieveQueryKey(gameId),
-        });
-      }).catch(() => {
-        // Fire-and-forget: silently ignore mark-read failures
+    markReadMutation.mutateAsync({
+      gameId,
+      channelId: parseInt(channelId),
+    }).then(() => {
+      queryClient.invalidateQueries({
+        queryKey: getGamesChannelsListQueryKey(gameId),
       });
-    }
+      queryClient.invalidateQueries({
+        queryKey: getGameRetrieveQueryKey(gameId),
+      });
+    }).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps -- markReadMutation is stable, fire once on mount
-  }, [gameId, channelId, currentMember]);
+  }, [gameId, channelId]);
 
   useEffect(() => {
     if (messagesContainerRef.current) {
@@ -201,7 +192,7 @@ const ChannelScreen: React.FC = () => {
         onNavigateBack={() => navigate(`/game/${gameId}/phase/${phaseId}/chat`)}
         variant="secondary"
       />
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-hidden">
         <Panel>
           <Panel.Content>
             <div className="h-full flex flex-col">

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useEffect } from "react";
+import React, { Suspense, useRef, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
@@ -17,7 +17,7 @@ import {
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
 import { GameDetailAppBar } from "./AppBar";
-import { getChannelDisplayName, getChannelFlagUrls } from "./channelUtils";
+import { getChannelDisplayName, getChannelFlagUrls, brightnessByColor } from "./channelUtils";
 import { ChannelAvatar } from "./ChannelAvatar";
 import { Panel } from "@/components/Panel";
 import {
@@ -37,6 +37,7 @@ type MessageDisplayItem = {
   createdAt: string;
   sender: {
     nationName: string;
+    nationColor: string;
     picture: string | null;
   };
   isCurrentUser: boolean;
@@ -70,6 +71,7 @@ const buildMessageItems = (
       createdAt: msg.createdAt,
       sender: {
         nationName: msg.sender.nation.name,
+        nationColor: msg.sender.nation.color,
         picture: msg.sender.picture,
       },
       isCurrentUser: msg.sender.isCurrentUser,
@@ -78,6 +80,14 @@ const buildMessageItems = (
     };
   });
 };
+
+const NewMessagesDivider: React.FC = () => (
+  <div className="flex items-center gap-2 my-1">
+    <div className="flex-1 h-px bg-border" />
+    <span className="text-xs text-muted-foreground font-medium">New messages</span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);
 
 const ChannelScreen: React.FC = () => {
   const { gameId, phaseId, channelId } = useRequiredParams<{
@@ -100,6 +110,13 @@ const ChannelScreen: React.FC = () => {
 
   const channel = channels.find(c => c.id === parseInt(channelId));
   if (!channel) throw new Error("Channel not found");
+
+  const [firstUnreadIndex] = useState<number | null>(() => {
+    const count = channel.unreadMessageCount;
+    if (count <= 0) return null;
+    const idx = channel.messages.length - count;
+    return idx > 0 ? idx : null;
+  });
 
   const currentNationName =
     game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
@@ -221,38 +238,53 @@ const ChannelScreen: React.FC = () => {
                   ref={messagesContainerRef}
                   className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2 p-2"
                 >
-                  {messageItems.map(item => (
-                    <Message
-                      key={item.id}
-                      className={
-                        item.isCurrentUser ? "flex-row-reverse" : undefined
-                      }
-                    >
-                      {item.showAvatar ? (
-                        <div className="flex flex-col items-center gap-0.5">
-                          <NationFlag
-                            flagUrl={
-                              variant
-                                ? findNationFlagUrl(variant.nations, item.sender.nationName)
-                                : null
-                            }
-                            alt={item.sender.nationName}
-                            size="lg"
-                          />
-                          <span className="text-xs text-muted-foreground">
-                            {item.sender.nationName}
-                          </span>
-                        </div>
-                      ) : (
-                        <div className="w-8" />
+                  {messageItems.map((item, index) => (
+                    <React.Fragment key={item.id}>
+                      {firstUnreadIndex !== null && index === firstUnreadIndex && (
+                        <NewMessagesDivider />
                       )}
-                      <MessageContent>
-                        {item.body}
-                        <MessageTimestamp>
-                          {item.formattedTime}
-                        </MessageTimestamp>
-                      </MessageContent>
-                    </Message>
+                      <Message
+                        className={
+                          item.isCurrentUser ? "flex-row-reverse" : undefined
+                        }
+                      >
+                        {item.showAvatar ? (
+                          <div className="flex flex-col items-center gap-0.5">
+                            <NationFlag
+                              flagUrl={
+                                variant
+                                  ? findNationFlagUrl(variant.nations, item.sender.nationName)
+                                  : null
+                              }
+                              alt={item.sender.nationName}
+                              size="lg"
+                            />
+                            <span
+                              className="text-xs font-medium"
+                              style={{ color: item.sender.nationColor }}
+                            >
+                              {item.sender.nationName}
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="w-8" />
+                        )}
+                        <MessageContent
+                          className="bg-transparent"
+                          style={{
+                            backgroundColor: item.sender.nationColor + "26",
+                            border: brightnessByColor(item.sender.nationColor) > 128
+                              ? `1px solid ${item.sender.nationColor}`
+                              : undefined,
+                          }}
+                        >
+                          {item.body}
+                          <MessageTimestamp>
+                            {item.formattedTime}
+                          </MessageTimestamp>
+                        </MessageContent>
+                      </Message>
+                    </React.Fragment>
                   ))}
                 </div>
               )}

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -17,7 +17,8 @@ import {
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
 import { GameDetailAppBar } from "./AppBar";
-import { getChannelDisplayName } from "./channelUtils";
+import { getChannelDisplayName, getChannelFlagUrls } from "./channelUtils";
+import { ChannelAvatar } from "./ChannelAvatar";
 import { Panel } from "@/components/Panel";
 import {
   useGameRetrieveSuspense,
@@ -103,6 +104,18 @@ const ChannelScreen: React.FC = () => {
   const currentNationName =
     game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
   const channelDisplayName = getChannelDisplayName(channel, currentNationName);
+  const channelFlagUrls = getChannelFlagUrls(
+    channel,
+    game.members,
+    currentNationName,
+    variants.find(v => v.id === game.variantId)?.nations ?? []
+  );
+  const channelTitle = (
+    <div className="flex items-center justify-center gap-2">
+      <ChannelAvatar flagUrls={channelFlagUrls} />
+      <h1 className="text-lg font-semibold truncate">{channelDisplayName}</h1>
+    </div>
+  );
 
   useEffect(() => {
     markReadMutation.mutateAsync({
@@ -164,7 +177,7 @@ const ChannelScreen: React.FC = () => {
     return (
       <div className="flex flex-col flex-1 min-h-0">
         <GameDetailAppBar
-          title={channelDisplayName}
+          title={channelTitle}
           onNavigateBack={() =>
             navigate(`/game/${gameId}/phase/${phaseId}/chat`)
           }
@@ -188,7 +201,7 @@ const ChannelScreen: React.FC = () => {
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <GameDetailAppBar
-        title={channelDisplayName}
+        title={channelTitle}
         onNavigateBack={() => navigate(`/game/${gameId}/phase/${phaseId}/chat`)}
         variant="secondary"
       />

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -2,8 +2,17 @@ import { Channel, Member } from "@/api/generated/endpoints";
 
 export type ChannelNation = { flagUrl: string | null; color: string };
 
+// Normalise any hex colour to 6-digit form (#RRGGBB). Falls back to grey for
+// non-hex values (e.g. rgb()) so callers can safely concatenate an alpha byte.
+export const toHex6 = (color: string): string => {
+  const short = /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/.exec(color);
+  if (short) return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`;
+  if (/^#[0-9a-fA-F]{6}$/.test(color)) return color;
+  return "#808080";
+};
+
 export const brightnessByColor = (hex: string): number => {
-  const match = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(hex);
+  const match = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(toHex6(hex));
   if (!match) return 128;
   const r = parseInt(match[1], 16);
   const g = parseInt(match[2], 16);
@@ -11,13 +20,15 @@ export const brightnessByColor = (hex: string): number => {
   return (r * 299 + g * 587 + b * 114) / 1000;
 };
 
+// Private channel names are formatted by the backend as "Nation1, Nation2, ..."
 export const getChannelDisplayName = (
   channel: Channel,
   currentNationName: string | undefined
 ): string => {
   if (!channel.private || !currentNationName) return channel.name;
   const others = channel.name
-    .split(", ")
+    .split(",")
+    .map(s => s.trim())
     .filter(n => n !== currentNationName);
   return others.length > 0 ? others.join(", ") : channel.name;
 };
@@ -29,7 +40,7 @@ export const getChannelFlagUrls = (
   variantNations: ReadonlyArray<{ name: string; flagUrl: string | null; color: string }>
 ): ChannelNation[] => {
   const nationNames = channel.private
-    ? channel.name.split(", ").filter(n => n !== currentNationName)
+    ? channel.name.split(",").map(s => s.trim()).filter(n => n !== currentNationName)
     : members
         .map(m => m.nation)
         .filter((n): n is string => n !== null);

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -3,9 +3,11 @@ import { Channel, Member } from "@/api/generated/endpoints";
 export type ChannelNation = { flagUrl: string | null; color: string };
 
 export const brightnessByColor = (hex: string): number => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const match = /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/.exec(hex);
+  if (!match) return 128;
+  const r = parseInt(match[1], 16);
+  const g = parseInt(match[2], 16);
+  const b = parseInt(match[3], 16);
   return (r * 299 + g * 587 + b * 114) / 1000;
 };
 
@@ -30,7 +32,7 @@ export const getChannelFlagUrls = (
     ? channel.name.split(", ").filter(n => n !== currentNationName)
     : members
         .map(m => m.nation)
-        .filter((n): n is string => n !== null && n !== currentNationName);
+        .filter((n): n is string => n !== null);
   return nationNames.map(name => {
     const vn = variantNations.find(n => n.name === name);
     return { flagUrl: vn?.flagUrl ?? null, color: vn?.color ?? "#808080" };

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -17,8 +17,11 @@ export const getChannelFlagUrls = (
   members: readonly Member[],
   currentNationName: string | undefined,
   variantNations: ReadonlyArray<{ name: string; flagUrl: string | null }>
-): (string | null)[] =>
-  channel.memberIds
-    .map(id => members.find(m => m.id === id)?.nation ?? null)
-    .filter((nation): nation is string => nation !== null && nation !== currentNationName)
-    .map(nation => findNationFlagUrl(variantNations, nation));
+): (string | null)[] => {
+  const nations = channel.private
+    ? channel.name.split(", ").filter(n => n !== currentNationName)
+    : members
+        .map(m => m.nation)
+        .filter((n): n is string => n !== null && n !== currentNationName);
+  return nations.map(nation => findNationFlagUrl(variantNations, nation));
+};

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -1,5 +1,6 @@
 import { Channel, Member } from "@/api/generated/endpoints";
-import { findNationFlagUrl } from "@/components/NationFlag";
+
+export type ChannelNation = { flagUrl: string | null; color: string };
 
 export const brightnessByColor = (hex: string): number => {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -23,12 +24,15 @@ export const getChannelFlagUrls = (
   channel: Channel,
   members: readonly Member[],
   currentNationName: string | undefined,
-  variantNations: ReadonlyArray<{ name: string; flagUrl: string | null }>
-): (string | null)[] => {
-  const nations = channel.private
+  variantNations: ReadonlyArray<{ name: string; flagUrl: string | null; color: string }>
+): ChannelNation[] => {
+  const nationNames = channel.private
     ? channel.name.split(", ").filter(n => n !== currentNationName)
     : members
         .map(m => m.nation)
         .filter((n): n is string => n !== null && n !== currentNationName);
-  return nations.map(nation => findNationFlagUrl(variantNations, nation));
+  return nationNames.map(name => {
+    const vn = variantNations.find(n => n.name === name);
+    return { flagUrl: vn?.flagUrl ?? null, color: vn?.color ?? "#808080" };
+  });
 };

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -1,0 +1,12 @@
+import { Channel } from "@/api/generated/endpoints";
+
+export const getChannelDisplayName = (
+  channel: Channel,
+  currentNationName: string | undefined
+): string => {
+  if (!channel.private || !currentNationName) return channel.name;
+  const others = channel.name
+    .split(", ")
+    .filter(n => n !== currentNationName);
+  return others.length > 0 ? others.join(", ") : channel.name;
+};

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -1,4 +1,5 @@
-import { Channel } from "@/api/generated/endpoints";
+import { Channel, Member } from "@/api/generated/endpoints";
+import { findNationFlagUrl } from "@/components/NationFlag";
 
 export const getChannelDisplayName = (
   channel: Channel,
@@ -10,3 +11,14 @@ export const getChannelDisplayName = (
     .filter(n => n !== currentNationName);
   return others.length > 0 ? others.join(", ") : channel.name;
 };
+
+export const getChannelFlagUrls = (
+  channel: Channel,
+  members: readonly Member[],
+  currentNationName: string | undefined,
+  variantNations: ReadonlyArray<{ name: string; flagUrl: string | null }>
+): (string | null)[] =>
+  channel.memberIds
+    .map(id => members.find(m => m.id === id)?.nation ?? null)
+    .filter((nation): nation is string => nation !== null && nation !== currentNationName)
+    .map(nation => findNationFlagUrl(variantNations, nation));

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -1,6 +1,13 @@
 import { Channel, Member } from "@/api/generated/endpoints";
 import { findNationFlagUrl } from "@/components/NationFlag";
 
+export const brightnessByColor = (hex: string): number => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+};
+
 export const getChannelDisplayName = (
   channel: Channel,
   currentNationName: string | undefined


### PR DESCRIPTION
## Summary

This PR polishes the channel chat UI with nation-colour theming throughout, and adds a few quality-of-life improvements to the channel list and message view.

### Channel list
- Each channel now shows a **\`ChannelAvatar\`** — a circular grid of nation flags for the other participants in that channel (up to 9), with a nation-colour ring for single-flag channels and a foreground ring for multi-flag ones
- Channel names now **hide the current player's own nation** — so a private chat between England and France shows as "France" when you're England, not "England, France"
- The latest-message preview labels the sender as **"You"** instead of the nation name for messages sent by the current player

### Channel screen (message view)
- The AppBar title now shows the same **\`ChannelAvatar\`** + display name as the channel list, consistent across both screens
- Message **sender avatars** get a **nation-colour ring** (\`box-shadow: 0 0 0 1px <color>\`)
- The **sender's nation name** appears inside the first bubble of each group, left-aligned alongside the timestamp — this keeps the avatar column a fixed width (\`w-8\`) so all messages in a group indent consistently, regardless of how long the nation name is
- Message **bubbles** are tinted with the sender's nation colour at 15% opacity (\`#rrggbb26\`); light-coloured nations also get a 1px colour border so the bubble is visible against a white background
- A **"New messages" divider** appears above the first unread message when opening a channel with unread messages

### Utilities / correctness
- Extracted shared channel logic into **\`channelUtils.ts\`**: \`getChannelDisplayName\`, \`getChannelFlagUrls\`, \`brightnessByColor\`
- \`brightnessByColor\` now validates the hex string with a regex before parsing, returning a neutral \`128\` for malformed input instead of producing \`NaN\`
- \`BUBBLE_ALPHA_HEX\` constant moved to module scope

## Test plan
- [ ] Open a game with multiple active channels; verify each shows the correct flags and display name in the list
- [ ] Open a private channel; verify your own nation is excluded from the avatar and title
- [ ] Open a press (public) channel; verify all nations appear in the avatar
- [ ] Send a message; verify the bubble is tinted with your nation colour
- [ ] Open a channel with unread messages; verify the "New messages" divider appears at the right position
- [ ] Open a channel with no unread messages; verify no divider appears
- [ ] Open a channel with a long nation name (e.g. "Kingdom of the Netherlands"); verify follow-up messages align at the same indent as the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)