### PR TITLE
Draw proposals UX

### DIFF
--- a/packages/web/src/components/GameDropdownMenu.tsx
+++ b/packages/web/src/components/GameDropdownMenu.tsx
@@ -20,7 +20,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -35,8 +34,6 @@ import {
   MoreHorizontal,
   LogOut,
   Copy,
-  Handshake,
-  Vote,
   Clock,
   Pause,
   Play,
@@ -53,14 +50,11 @@ import {
   getGameRetrieveQueryKey,
   GameList,
   GameRetrieve,
-  useGamesDrawProposalsListSuspense,
-  DrawProposal,
   DurationEnum,
   getGamePhasesListQueryKey,
   getGamePhaseRetrieveQueryKey,
 } from "@/api/generated/endpoints";
 import { EXTEND_DURATION_OPTIONS } from "@/constants";
-import { Suspense } from "react";
 
 interface GameDropdownMenuProps {
   game: Pick<GameList, "id" | "sandbox" | "canLeave" | "canDelete" | "isPaused"> &
@@ -68,58 +62,6 @@ interface GameDropdownMenuProps {
   onNavigateToGameInfo: () => void;
   onNavigateToPlayerInfo: () => void;
 }
-
-interface DrawProposalBadgeProps {
-  gameId: string;
-  currentMemberId?: number;
-}
-
-const getPendingVotesCount = (
-  proposals: DrawProposal[],
-  currentMemberId?: number
-) => {
-  if (currentMemberId === undefined) return 0;
-  return proposals.filter(p => {
-    if (p.status !== "pending") return false;
-    if (!p.myVote) return false;
-    return p.myVote.accepted === null;
-  }).length;
-};
-
-const DrawProposalBadge: React.FC<DrawProposalBadgeProps> = ({
-  gameId,
-  currentMemberId,
-}) => {
-  const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
-  const pendingVotesCount = getPendingVotesCount(proposals, currentMemberId);
-
-  if (pendingVotesCount === 0) return null;
-
-  return (
-    <Badge variant="destructive" className="ml-auto h-5 w-5 p-0 justify-center">
-      {pendingVotesCount}
-    </Badge>
-  );
-};
-
-const DrawProposalTriggerBadge: React.FC<DrawProposalBadgeProps> = ({
-  gameId,
-  currentMemberId,
-}) => {
-  const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
-  const pendingVotesCount = getPendingVotesCount(proposals, currentMemberId);
-
-  if (pendingVotesCount === 0) return null;
-
-  return (
-    <Badge
-      variant="destructive"
-      className="absolute -top-1 -right-1 h-4 w-4 p-0 justify-center text-[10px]"
-    >
-      {pendingVotesCount}
-    </Badge>
-  );
-};
 
 export function GameDropdownMenu({
   game,
@@ -152,13 +94,6 @@ export function GameDropdownMenu({
     isCurrentUserGameMaster && isActiveGame && !game.isPaused;
   const canUnpauseGame =
     isCurrentUserGameMaster && isActiveGame && game.isPaused;
-  const isActiveOrFinishedGame =
-    game.status === "active" ||
-    game.status === "completed" ||
-    game.status === "abandoned";
-  const canProposeDraw = !game.sandbox && isActiveGame;
-  const canViewDrawProposals = !game.sandbox && isActiveOrFinishedGame;
-
   const handleLeaveGame = async () => {
     try {
       await leaveGameMutation.mutateAsync({ gameId: game.id });
@@ -196,14 +131,6 @@ export function GameDropdownMenu({
     }
   };
 
-  const handleNavigateToProposeDraw = () => {
-    navigate(`/game/${game.id}/phase/${phaseId}/propose-draw`);
-  };
-
-  const handleNavigateToDrawProposals = () => {
-    navigate(`/game/${game.id}/phase/${phaseId}/draw-proposals`);
-  };
-
   const handleExtendDeadlineDialogChange = (open: boolean) => {
     setShowExtendDeadlineDialog(open);
     if (!open) {
@@ -226,9 +153,11 @@ export function GameDropdownMenu({
       queryClient.invalidateQueries({
         queryKey: getGamePhasesListQueryKey(game.id),
       });
-      queryClient.invalidateQueries({
-        queryKey: getGamePhaseRetrieveQueryKey(game.id, Number(phaseId)),
-      });
+      if (phaseId !== undefined) {
+        queryClient.invalidateQueries({
+          queryKey: getGamePhaseRetrieveQueryKey(game.id, Number(phaseId)),
+        });
+      }
     } catch {
       toast.error("Failed to extend deadline");
     }
@@ -270,14 +199,6 @@ export function GameDropdownMenu({
           className="relative"
         >
           <MoreHorizontal />
-          {canViewDrawProposals && phaseId && (
-            <Suspense fallback={null}>
-              <DrawProposalTriggerBadge
-                gameId={game.id}
-                currentMemberId={currentMember?.id}
-              />
-            </Suspense>
-          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
@@ -291,11 +212,15 @@ export function GameDropdownMenu({
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={() => {
-            navigator.clipboard.writeText(
-              `https://diplicity.com/game/${game.id}`
-            );
-            toast.success("Link copied to clipboard");
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(
+                `https://diplicity.com/game/${game.id}`
+              );
+              toast.success("Link copied to clipboard");
+            } catch {
+              toast.error("Failed to copy link");
+            }
           }}
         >
           <Share />
@@ -329,30 +254,6 @@ export function GameDropdownMenu({
             <Play />
             Resume game
           </DropdownMenuItem>
-        )}
-        {canProposeDraw && phaseId && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={handleNavigateToProposeDraw}>
-              <Handshake />
-              Propose draw
-            </DropdownMenuItem>
-          </>
-        )}
-        {canViewDrawProposals && phaseId && (
-          <>
-            {!canProposeDraw && <DropdownMenuSeparator />}
-            <DropdownMenuItem onClick={handleNavigateToDrawProposals}>
-              <Vote />
-              Draw proposals
-              <Suspense fallback={null}>
-                <DrawProposalBadge
-                  gameId={game.id}
-                  currentMemberId={currentMember?.id}
-                />
-              </Suspense>
-            </DropdownMenuItem>
-          </>
         )}
         {game.canLeave && (
           <>

--- a/packages/web/src/components/GameStatusAlerts.tsx
+++ b/packages/web/src/components/GameStatusAlerts.tsx
@@ -35,7 +35,7 @@ export function GameStatusAlerts({ game, variant, action }: GameStatusAlertsProp
               {nationCount} players have joined.
             </AlertDescription>
             {action && (
-              <div className="[&>button]:w-full sm:[&>button]:w-auto sm:flex sm:items-center sm:h-[1lh] shrink-0">
+              <div className="shrink-0 w-full sm:w-auto">
                 {action}
               </div>
             )}
@@ -57,7 +57,7 @@ export function GameStatusAlerts({ game, variant, action }: GameStatusAlertsProp
           <Trophy className="size-4" />
           <AlertDescription>
             {game.victory.type === "solo"
-              ? `${game.victory.members[0]?.name} has won the game!`
+              ? `${game.victory.members[0]?.name ?? "A player"} has won the game!`
               : `The game ended in a draw between ${game.victory.members.length} players.`}
           </AlertDescription>
         </Alert>

--- a/packages/web/src/components/NationFlag.tsx
+++ b/packages/web/src/components/NationFlag.tsx
@@ -42,4 +42,12 @@ const findNationFlagUrl = (
   return nations.find((n) => n.name === nationName)?.flagUrl ?? null;
 };
 
-export { NationFlag, findNationFlagUrl };
+const findNationColor = (
+  nations: ReadonlyArray<{ name: string; color: string }>,
+  nationName: string | null | undefined
+): string | null => {
+  if (!nationName) return null;
+  return nations.find((n) => n.name === nationName)?.color ?? null;
+};
+
+export { NationFlag, findNationFlagUrl, findNationColor };

--- a/packages/web/src/components/NationFlag.tsx
+++ b/packages/web/src/components/NationFlag.tsx
@@ -5,6 +5,7 @@ interface NationFlagProps {
   flagUrl: string | null | undefined;
   alt?: string;
   size?: "sm" | "md" | "lg";
+  color?: string | null;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -19,6 +20,7 @@ const NationFlag: React.FC<NationFlagProps> = ({
   flagUrl,
   alt,
   size = "md",
+  color,
   className,
   style,
 }) => {
@@ -29,7 +31,7 @@ const NationFlag: React.FC<NationFlagProps> = ({
       src={flagUrl}
       alt={alt ?? ""}
       className={cn("rounded-full object-cover", sizeClasses[size], className)}
-      style={style}
+      style={color ? { boxShadow: `0 0 0 1px ${color}`, ...style } : style}
     />
   );
 };

--- a/packages/web/src/components/PhaseGuidance.tsx
+++ b/packages/web/src/components/PhaseGuidance.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Check } from "lucide-react";
 import { useRequiredParams } from "@/hooks";
 import {
@@ -10,7 +11,7 @@ import {
 type GuidanceResult = {
   text: string;
   isComplete: boolean;
-  isConfirmed: boolean;
+  isConfirmed?: boolean;
 } | null;
 
 function usePhaseGuidance(): GuidanceResult {
@@ -39,7 +40,8 @@ function usePhaseGuidance(): GuidanceResult {
   }
 
   const userNation = userMember.nation;
-  const isConfirmed = game.phaseConfirmed;
+  const confirmationApplies = !game.sandbox && game.deadlineMode !== "fixed_time";
+  const isConfirmed = confirmationApplies ? game.phaseConfirmed : undefined;
 
   switch (phase.type) {
     case "Movement": {
@@ -85,15 +87,40 @@ function usePhaseGuidance(): GuidanceResult {
       if (delta === 0) {
         return { text: "No adjustments needed", isComplete: true, isConfirmed };
       }
+
+      const requiredCount = Math.abs(delta);
+      const submittedCount = orders.filter(o => o.nation.name === userNation).length;
+
       if (delta > 0) {
+        if (submittedCount >= requiredCount) {
+          return { text: "All builds submitted", isComplete: true, isConfirmed };
+        }
+        if (submittedCount === 0) {
+          return {
+            text: `Build ${requiredCount} new unit${requiredCount > 1 ? "s" : ""}`,
+            isComplete: false,
+            isConfirmed,
+          };
+        }
         return {
-          text: `Build ${delta} new unit${delta > 1 ? "s" : ""}`,
+          text: `${submittedCount} of ${requiredCount} builds submitted`,
+          isComplete: false,
+          isConfirmed,
+        };
+      }
+
+      if (submittedCount >= requiredCount) {
+        return { text: "All disbands submitted", isComplete: true, isConfirmed };
+      }
+      if (submittedCount === 0) {
+        return {
+          text: `Disband ${requiredCount} unit${requiredCount > 1 ? "s" : ""}`,
           isComplete: false,
           isConfirmed,
         };
       }
       return {
-        text: `Disband ${Math.abs(delta)} unit${Math.abs(delta) > 1 ? "s" : ""}`,
+        text: `${submittedCount} of ${requiredCount} disbands submitted`,
         isComplete: false,
         isConfirmed,
       };
@@ -130,8 +157,12 @@ export const PhaseGuidance: React.FC = () => {
     <span className="text-xs text-muted-foreground inline-flex items-center gap-1">
       {guidance.text}
       {guidance.isComplete && <Check className="size-3" />}
-      <span>·</span>
-      <span>{guidance.isConfirmed ? "confirmed" : "not confirmed"}</span>
+      {guidance.isConfirmed !== undefined && (
+        <>
+          <span>·</span>
+          <span>{guidance.isConfirmed ? "confirmed" : "not confirmed"}</span>
+        </>
+      )}
     </span>
   );
 };

--- a/packages/web/src/components/PlayerInfoContent.test.tsx
+++ b/packages/web/src/components/PlayerInfoContent.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/api/generated/endpoints", () => ({
 vi.mock("@/components/NationFlag", () => ({
   NationFlag: () => null,
   findNationFlagUrl: () => null,
+  findNationColor: () => null,
 }));
 
 const renderPlayerInfo = () =>

--- a/packages/web/src/components/PlayerInfoContent.tsx
+++ b/packages/web/src/components/PlayerInfoContent.tsx
@@ -3,7 +3,7 @@ import { Shield, Star, Trophy } from "lucide-react";
 
 import { CivilDisorderBadge } from "@/components/CivilDisorderBadge";
 import { GameStatusAlerts } from "@/components/GameStatusAlerts";
-import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
+import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
@@ -61,6 +61,7 @@ export const PlayerInfoContent: React.FC = () => {
                     alt={member.nation}
                     size="lg"
                     className="size-8"
+                    color={findNationColor(variant.nations, member.nation)}
                   />
                 )}
 

--- a/packages/web/src/components/ui/accordion.tsx
+++ b/packages/web/src/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
           className
         )}
         {...props}

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -265,7 +265,7 @@ const ChannelScreen: React.FC = () => {
                               }
                               alt={item.sender.nationName}
                               size="lg"
-                              style={{ boxShadow: `0 0 0 1px ${item.sender.nationColor}` }}
+                              color={item.sender.nationColor}
                             />
                           </div>
                         ) : (

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   getGameRetrieveQueryKey: () => ["game"],
 }));
 
-vi.mock("@/components/NationFlag", () => ({ NationFlag: () => null, findNationFlagUrl: () => null }));
+vi.mock("@/components/NationFlag", () => ({ NationFlag: () => null, findNationFlagUrl: () => null, findNationColor: () => null }));
 
 const baseMember = (overrides = {}) => ({
   id: 1,

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -85,7 +85,7 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
         alt={proposal.createdBy.nation ?? ""}
         size="md"
         className="size-8 self-start"
-        style={nationColor ? { boxShadow: `0 0 0 1px ${nationColor}` } : undefined}
+        color={nationColor}
       />
       <ItemContent>
         <div className="flex items-center justify-between">

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
-import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
+import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import {
   Item,
   ItemContent,
@@ -74,6 +74,10 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
     .map(id => game.members.find(m => m.id === id))
     .filter((m): m is Member => Boolean(m));
 
+  const nationColor = variant
+    ? findNationColor(variant.nations, proposal.createdBy.nation)
+    : null;
+
   return (
     <Item className="border-b border-b-border">
       <NationFlag
@@ -81,6 +85,7 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
         alt={proposal.createdBy.nation ?? ""}
         size="md"
         className="size-8 self-start"
+        style={nationColor ? { boxShadow: `0 0 0 1px ${nationColor}` } : undefined}
       />
       <ItemContent>
         <div className="flex items-center justify-between">
@@ -120,11 +125,11 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
         <ItemDescription>
           {includedMembers.map(m => m.nation).join(", ")}
         </ItemDescription>
-        <div className="mt-2 text-sm text-muted-foreground">
+        <div className="text-sm text-muted-foreground">
           {proposal.acceptedCount} of {proposal.totalVotes} accepted
         </div>
         {proposal.myVote && proposal.myVote.accepted !== null && (
-          <div className="mt-1 text-sm">
+          <div className="text-sm">
             Your vote:{" "}
             {proposal.myVote.accepted ? (
               <span className="text-green-600">Accepted</span>
@@ -134,7 +139,7 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
           </div>
         )}
         {canVote && (
-          <div className="flex gap-2 mt-3">
+          <div className="flex gap-2">
             <Button
               size="sm"
               variant="outline"
@@ -244,8 +249,9 @@ const DrawProposalsScreen: React.FC = () => {
         onNavigateBack={handleBack}
         rightButton={
           canProposeDraw ? (
-            <Button variant="outline" size="icon" onClick={handleProposeDraw}>
+            <Button variant="outline" onClick={handleProposeDraw}>
               <Plus />
+              New proposal
             </Button>
           ) : undefined
         }

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -36,12 +36,17 @@ vi.mock("@/api/generated/endpoints", () => ({
   useGameOrdersDeleteDestroy: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameConfirmPhasePartialUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameResolvePhaseCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useGamesDrawProposalsListSuspense: () => ({ data: [] }),
   getGameRetrieveQueryKey: () => ["game"],
   getGameOrdersListQueryKey: () => ["orders"],
   getGameOptionsRetrieveQueryKey: () => ["options"],
 }));
 
-vi.mock("@/components/NationFlag", () => ({ NationFlag: () => null, findNationFlagUrl: () => null }));
+vi.mock("@/components/NationFlag", () => ({
+  NationFlag: () => null,
+  findNationFlagUrl: () => null,
+  findNationColor: () => null,
+}));
 vi.mock("@/components/PhaseSelect", () => ({ PhaseSelect: () => null }));
 vi.mock("@/components/PhaseGuidance", () => ({ PhaseGuidance: () => null }));
 vi.mock("@/components/GameDropdownMenu", () => ({ GameDropdownMenu: () => null }));

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -10,11 +10,13 @@ import {
   SearchX,
   Star,
   UserX,
+  Handshake,
 } from "lucide-react";
 import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -33,7 +35,7 @@ import {
   ItemSeparator,
 } from "@/components/ui/item";
 import { Notice } from "@/components/Notice";
-import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
+import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import { GameDropdownMenu } from "@/components/GameDropdownMenu";
 import { GameDetailAppBar } from "./AppBar";
 import { Panel } from "@/components/Panel";
@@ -52,20 +54,20 @@ import {
   useGameResolvePhaseCreate,
   useGameRetrieveSuspense,
   useVariantsListSuspense,
+  useGamesDrawProposalsListSuspense,
   getGameRetrieveQueryKey,
   getGameOrdersListQueryKey,
   getGamePhaseStatesListQueryKey,
   getGameOptionsRetrieveQueryKey,
   Order,
   GameRetrieve,
-  Member,
   Unit,
 } from "@/api/generated/endpoints";
 import { cn } from "../../lib/utils";
 
 type NationGroup = {
   nation: string;
-  member: Member;
+  member: { isCurrentUser: boolean };
   items: Array<{
     province: Province;
     order?: Order;
@@ -106,7 +108,7 @@ const buildNationGroups = (
 
   return Object.entries(ordersByNation).map(([nation, nationOrders]) => ({
     nation,
-    member: game.members.find(m => m.nation === nation)!,
+    member: game.members.find(m => m.nation === nation) ?? { isCurrentUser: false },
     items: nationOrders.map(order => ({
       province: order.source,
       order,
@@ -114,6 +116,28 @@ const buildNationGroups = (
         ?? phase.units.find(u => u.province.id === order.source.id),
     })),
   }));
+};
+
+const DrawProposalsBadge: React.FC<{ gameId: string; currentMemberId?: number }> = ({
+  gameId,
+  currentMemberId,
+}) => {
+  const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
+  const count =
+    currentMemberId === undefined
+      ? 0
+      : proposals.filter(
+          p => p.status === "pending" && !!p.myVote && p.myVote.accepted === null
+        ).length;
+  if (count === 0) return null;
+  return (
+    <Badge
+      variant="destructive"
+      className="absolute -top-1 -right-1 h-4 w-4 p-0 justify-center text-[10px]"
+    >
+      {count}
+    </Badge>
+  );
 };
 
 const OrdersScreen: React.FC = () => {
@@ -216,21 +240,37 @@ const OrdersScreen: React.FC = () => {
   );
   const hasContent = nationGroups.length > 0;
 
-  const footerButton = (() => {
+  const isActiveOrFinishedGame =
+    game.status === "active" ||
+    game.status === "completed" ||
+    game.status === "abandoned";
+  const showDrawProposalsButton = !game.sandbox && isActiveOrFinishedGame;
+
+  const handleNavigateToDrawProposals = () => {
+    navigate(`/game/${gameId}/phase/${phaseId}/draw-proposals`);
+  };
+
+  const rightFooterButton = (() => {
     if (!canModifyOrders) return null;
-    if (game.sandbox) return (
-      <Button disabled={resolvePhaseMutation.isPending} onClick={handleResolvePhase}>
-        <Play className="size-4" />
-        Resolve phase
-      </Button>
-    );
+    if (game.sandbox)
+      return (
+        <Button disabled={resolvePhaseMutation.isPending} onClick={handleResolvePhase}>
+          <Play className="size-4" />
+          Resolve phase
+        </Button>
+      );
     if (game.deadlineMode === "fixed_time") return null;
-    if (hasContent) return (
-      <Button disabled={confirmOrdersMutation.isPending} onClick={handleConfirmOrders}>
-        {game.phaseConfirmed ? <CheckSquare className="size-4" /> : <Square className="size-4" />}
-        {game.phaseConfirmed ? "Orders confirmed" : "Confirm orders"}
-      </Button>
-    );
+    if (hasContent)
+      return (
+        <Button disabled={confirmOrdersMutation.isPending} onClick={handleConfirmOrders}>
+          {game.phaseConfirmed ? (
+            <CheckSquare className="size-4" />
+          ) : (
+            <Square className="size-4" />
+          )}
+          {game.phaseConfirmed ? "Orders confirmed" : "Confirm orders"}
+        </Button>
+      );
     return (
       <Button disabled>
         <CheckSquare className="size-4" />
@@ -297,7 +337,9 @@ const OrdersScreen: React.FC = () => {
                   nationGroups.find(g => g.member.isCurrentUser)?.nation ?? "",
                 ]}
               >
-                {nationGroups.map(({ nation, items }) => (
+                {nationGroups.map(({ nation, items }) => {
+                  const nationColor = findNationColor(variant.nations, nation);
+                  return (
                   <AccordionItem key={nation} value={nation}>
                     <AccordionTrigger className="p-2 items-center">
                       <div className="flex items-center gap-2">
@@ -305,6 +347,7 @@ const OrdersScreen: React.FC = () => {
                           flagUrl={findNationFlagUrl(variant.nations, nation)}
                           alt={nation}
                           size="md"
+                          style={nationColor ? { boxShadow: `0 0 0 1px ${nationColor}` } : undefined}
                         />
                         <span>{nation}</span>
                         <span className="text-muted-foreground">•</span>
@@ -366,17 +409,36 @@ const OrdersScreen: React.FC = () => {
                       </ItemGroup>
                     </AccordionContent>
                   </AccordionItem>
-                ))}
+                  );
+                })}
               </Accordion>
             )}
           </Panel.Content>
 
-          {footerButton && (
+          {(rightFooterButton || showDrawProposalsButton) && (
             <>
               <Separator />
               <Panel.Footer>
-                <div className="flex gap-2 justify-end w-full">
-                  {footerButton}
+                <div className="flex w-full items-center">
+                  <div className="flex-1">
+                    {showDrawProposalsButton && (
+                      <Button
+                        variant="outline"
+                        onClick={handleNavigateToDrawProposals}
+                        className="relative"
+                      >
+                        <Handshake className="size-4" />
+                        Draw proposals
+                        <Suspense fallback={null}>
+                          <DrawProposalsBadge
+                            gameId={gameId}
+                            currentMemberId={currentMember?.id}
+                          />
+                        </Suspense>
+                      </Button>
+                    )}
+                  </div>
+                  {rightFooterButton}
                 </div>
               </Panel.Footer>
             </>

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -106,16 +106,22 @@ const buildNationGroups = (
     {} as Record<string, Order[]>
   );
 
-  return Object.entries(ordersByNation).map(([nation, nationOrders]) => ({
-    nation,
-    member: game.members.find(m => m.nation === nation) ?? { isCurrentUser: false },
-    items: nationOrders.map(order => ({
-      province: order.source,
-      order,
-      unit: phase.units.find(u => u.province.id === order.source.id && u.dislodged)
-        ?? phase.units.find(u => u.province.id === order.source.id),
-    })),
-  }));
+  return Object.entries(ordersByNation).map(([nation, nationOrders]) => {
+    const member = game.members.find(m => m.nation === nation);
+    if (!member && import.meta.env.DEV) {
+      console.warn(`buildNationGroups: no member found for nation "${nation}"`);
+    }
+    return {
+      nation,
+      member: member ?? { isCurrentUser: false },
+      items: nationOrders.map(order => ({
+        province: order.source,
+        order,
+        unit: phase.units.find(u => u.province.id === order.source.id && u.dislodged)
+          ?? phase.units.find(u => u.province.id === order.source.id),
+      })),
+    };
+  });
 };
 
 const DrawProposalsBadge: React.FC<{ gameId: string; currentMemberId?: number }> = ({
@@ -123,12 +129,10 @@ const DrawProposalsBadge: React.FC<{ gameId: string; currentMemberId?: number }>
   currentMemberId,
 }) => {
   const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
-  const count =
-    currentMemberId === undefined
-      ? 0
-      : proposals.filter(
-          p => p.status === "pending" && !!p.myVote && p.myVote.accepted === null
-        ).length;
+  if (currentMemberId === undefined) return null;
+  const count = proposals.filter(
+    p => p.status === "pending" && p.myVote !== null && p.myVote.accepted === null
+  ).length;
   if (count === 0) return null;
   return (
     <Badge
@@ -240,11 +244,11 @@ const OrdersScreen: React.FC = () => {
   );
   const hasContent = nationGroups.length > 0;
 
-  const isActiveOrFinishedGame =
+  const isStartedGame =
     game.status === "active" ||
     game.status === "completed" ||
     game.status === "abandoned";
-  const showDrawProposalsButton = !game.sandbox && isActiveOrFinishedGame;
+  const showDrawProposalsButton = !game.sandbox && isStartedGame;
 
   const handleNavigateToDrawProposals = () => {
     navigate(`/game/${gameId}/phase/${phaseId}/draw-proposals`);
@@ -340,75 +344,75 @@ const OrdersScreen: React.FC = () => {
                 {nationGroups.map(({ nation, items }) => {
                   const nationColor = findNationColor(variant.nations, nation);
                   return (
-                  <AccordionItem key={nation} value={nation}>
-                    <AccordionTrigger className="p-2 items-center">
-                      <div className="flex items-center gap-2">
-                        <NationFlag
-                          flagUrl={findNationFlagUrl(variant.nations, nation)}
-                          alt={nation}
-                          size="md"
-                          style={nationColor ? { boxShadow: `0 0 0 1px ${nationColor}` } : undefined}
-                        />
-                        <span>{nation}</span>
-                        <span className="text-muted-foreground">•</span>
-                        <span className="inline-flex items-center gap-1 text-muted-foreground">
-                          <Star className="size-3" />
-                          <span>{getSupplyCenterCount(nation)}</span>
-                        </span>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="p-0">
-                      <ItemGroup>
-                        {items.map((item, index) => (
-                          <React.Fragment key={item.province.id}>
-                            {index === 0 && <Separator />}
-                            <Item size="sm">
-                              <ItemContent>
-                                <ItemTitle>
-                                  {item.unit?.type} {item.province.name}
-                                </ItemTitle>
-                                <ItemDescription>
-                                  {item.order
-                                    ? item.order.summary
-                                    : "Order not provided"}
-                                </ItemDescription>
-                              </ItemContent>
-                              {canModifyOrders && item.order && (
-                                <ItemActions>
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    onClick={() =>
-                                      handleDeleteOrder(item.province.id)
-                                    }
-                                    disabled={deleteOrderMutation.isPending}
-                                  >
-                                    <Trash2 className="size-4" />
-                                  </Button>
-                                </ItemActions>
-                              )}
-                              {!isActivePhase &&
-                                item.order &&
-                                item.order.resolution?.status && (
-                                  <ItemContent
-                                    className={cn(
-                                      "text-xs",
-                                      item.order.resolution.status ===
-                                        "Succeeded"
-                                        ? "text-green-600"
-                                        : "text-red-600"
-                                    )}
-                                  >
-                                    {item.order.resolution.status}
-                                  </ItemContent>
+                    <AccordionItem key={nation} value={nation}>
+                      <AccordionTrigger className="p-2 items-center">
+                        <div className="flex items-center gap-2">
+                          <NationFlag
+                            flagUrl={findNationFlagUrl(variant.nations, nation)}
+                            alt={nation}
+                            size="md"
+                            color={nationColor}
+                          />
+                          <span>{nation}</span>
+                          <span className="text-muted-foreground">•</span>
+                          <span className="inline-flex items-center gap-1 text-muted-foreground">
+                            <Star className="size-3" />
+                            <span>{getSupplyCenterCount(nation)}</span>
+                          </span>
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent className="p-0">
+                        <ItemGroup>
+                          {items.map((item, index) => (
+                            <React.Fragment key={item.province.id}>
+                              {index === 0 && <Separator />}
+                              <Item size="sm">
+                                <ItemContent>
+                                  <ItemTitle>
+                                    {item.unit?.type} {item.province.name}
+                                  </ItemTitle>
+                                  <ItemDescription>
+                                    {item.order
+                                      ? item.order.summary
+                                      : "Order not provided"}
+                                  </ItemDescription>
+                                </ItemContent>
+                                {canModifyOrders && item.order && (
+                                  <ItemActions>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      onClick={() =>
+                                        handleDeleteOrder(item.province.id)
+                                      }
+                                      disabled={deleteOrderMutation.isPending}
+                                    >
+                                      <Trash2 className="size-4" />
+                                    </Button>
+                                  </ItemActions>
                                 )}
-                            </Item>
-                            {index < items.length - 1 && <ItemSeparator />}
-                          </React.Fragment>
-                        ))}
-                      </ItemGroup>
-                    </AccordionContent>
-                  </AccordionItem>
+                                {!isActivePhase &&
+                                  item.order &&
+                                  item.order.resolution?.status && (
+                                    <ItemContent
+                                      className={cn(
+                                        "text-xs",
+                                        item.order.resolution.status ===
+                                          "Succeeded"
+                                          ? "text-green-600"
+                                          : "text-red-600"
+                                      )}
+                                    >
+                                      {item.order.resolution.status}
+                                    </ItemContent>
+                                  )}
+                              </Item>
+                              {index < items.length - 1 && <ItemSeparator />}
+                            </React.Fragment>
+                          ))}
+                        </ItemGroup>
+                      </AccordionContent>
+                    </AccordionItem>
                   );
                 })}
               </Accordion>
@@ -416,32 +420,29 @@ const OrdersScreen: React.FC = () => {
           </Panel.Content>
 
           {(rightFooterButton || showDrawProposalsButton) && (
-            <>
-              <Separator />
-              <Panel.Footer>
-                <div className="flex w-full items-center">
-                  <div className="flex-1">
-                    {showDrawProposalsButton && (
-                      <Button
-                        variant="outline"
-                        onClick={handleNavigateToDrawProposals}
-                        className="relative"
-                      >
-                        <Handshake className="size-4" />
-                        Draw proposals
-                        <Suspense fallback={null}>
-                          <DrawProposalsBadge
-                            gameId={gameId}
-                            currentMemberId={currentMember?.id}
-                          />
-                        </Suspense>
-                      </Button>
-                    )}
-                  </div>
-                  {rightFooterButton}
+            <Panel.Footer divider>
+              <div className="flex w-full items-center">
+                <div className="flex-1">
+                  {showDrawProposalsButton && (
+                    <Button
+                      variant="outline"
+                      onClick={handleNavigateToDrawProposals}
+                      className="relative"
+                    >
+                      <Handshake className="size-4" />
+                      Draw proposals
+                      <Suspense fallback={null}>
+                        <DrawProposalsBadge
+                          gameId={gameId}
+                          currentMemberId={currentMember?.id}
+                        />
+                      </Suspense>
+                    </Button>
+                  )}
                 </div>
-              </Panel.Footer>
-            </>
+                {rightFooterButton}
+              </div>
+            </Panel.Footer>
           )}
         </Panel>
       </div>

--- a/packages/web/src/screens/GameDetail/ProposeDrawScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ProposeDrawScreen.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   getGamesDrawProposalsListQueryKey: () => ["drawList"],
 }));
 
-vi.mock("@/components/NationFlag", () => ({ NationFlag: () => null, findNationFlagUrl: () => null }));
+vi.mock("@/components/NationFlag", () => ({ NationFlag: () => null, findNationFlagUrl: () => null, findNationColor: () => null }));
 
 const baseMember = (overrides = {}) => ({
   id: 1,

--- a/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
-import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
+import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Item,
@@ -95,6 +95,7 @@ const ProposeDrawScreen: React.FC = () => {
                         alt={member.nation ?? ""}
                         size="md"
                         className="size-10"
+                        color={variant ? findNationColor(variant.nations, member.nation) : null}
                       />
                     </ItemMedia>
                     <ItemContent>
@@ -114,6 +115,7 @@ const ProposeDrawScreen: React.FC = () => {
                         alt={member.nation ?? ""}
                         size="md"
                         className="size-10"
+                        color={variant ? findNationColor(variant.nations, member.nation) : null}
                       />
                     </ItemMedia>
                     <ItemContent>

--- a/packages/web/src/screens/Home/GameInfo.test.tsx
+++ b/packages/web/src/screens/Home/GameInfo.test.tsx
@@ -88,7 +88,7 @@ describe("GameInfoScreen", () => {
 
       const content = screen.getByTestId("game-info-content");
       expect(
-        within(content).getByRole("button", { name: /leave game/i })
+        within(content).getByRole("button", { name: /^leave$/i })
       ).toBeInTheDocument();
     });
 
@@ -101,7 +101,7 @@ describe("GameInfoScreen", () => {
         within(content).queryByRole("button", { name: /join game/i })
       ).not.toBeInTheDocument();
       expect(
-        within(content).queryByRole("button", { name: /leave game/i })
+        within(content).queryByRole("button", { name: /^leave$/i })
       ).not.toBeInTheDocument();
     });
   });
@@ -132,12 +132,12 @@ describe("GameInfoScreen", () => {
   });
 
   describe("leave game", () => {
-    it("calls the leave mutation when 'Leave game' is clicked", async () => {
+    it("calls the leave mutation when 'Leave' is clicked", async () => {
       mockUseGameRetrieveSuspense.mockReturnValue({ data: pendingGameCanLeave });
       renderGameInfo(pendingGameCanLeave.id);
 
       await userEvent.click(
-        screen.getByRole("button", { name: /leave game/i })
+        screen.getByRole("button", { name: /^leave$/i })
       );
 
       expect(mockLeaveMutateAsync).toHaveBeenCalledWith({
@@ -150,7 +150,7 @@ describe("GameInfoScreen", () => {
       const { queryClient } = renderGameInfo(pendingGameCanLeave.id);
 
       await userEvent.click(
-        screen.getByRole("button", { name: /leave game/i })
+        screen.getByRole("button", { name: /^leave$/i })
       );
 
       expect(queryClient.invalidateQueries).toHaveBeenCalledWith({

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -74,6 +74,7 @@ const GameInfo: React.FC = () => {
       <Button
         onClick={handleJoinGame}
         disabled={joinGameMutation.isPending}
+        className="w-full sm:w-auto"
       >
         Join game
       </Button>

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -79,21 +79,19 @@ const GameInfo: React.FC = () => {
         Join game
       </Button>
     ) : (
-      <div className="flex flex-col gap-2 w-full">
+      <div className="flex gap-2 w-full sm:w-auto">
         <Button
           onClick={handleLeaveGame}
           disabled={leaveGameMutation.isPending}
           variant="outline"
-          className="w-full sm:w-auto"
+          className="flex-1 sm:flex-none"
         >
-          Leave game
+          Leave
         </Button>
-        <div className="flex items-center gap-2 justify-between sm:justify-end">
-          <span className="text-sm text-muted-foreground">Share this link to invite your friends</span>
-          <Button variant="outline" size="icon" onClick={handleShare}>
-            <Share className="size-4" />
-          </Button>
-        </div>
+        <Button variant="outline" className="flex-1 sm:flex-none" onClick={handleShare}>
+          <Share className="size-4" />
+          Share
+        </Button>
       </div>
     )
   ) : null;

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { Share } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRequiredParams } from "@/hooks";
 
@@ -51,6 +52,15 @@ const GameInfo: React.FC = () => {
     }
   };
 
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(`https://diplicity.com/game/${gameId}`);
+      toast.success("Link copied to clipboard");
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  };
+
   const handlePlayerInfo = () => {
     navigate(`/player-info/${gameId}`);
   };
@@ -68,13 +78,22 @@ const GameInfo: React.FC = () => {
         Join game
       </Button>
     ) : (
-      <Button
-        onClick={handleLeaveGame}
-        disabled={leaveGameMutation.isPending}
-        variant="outline"
-      >
-        Leave game
-      </Button>
+      <div className="flex flex-col gap-2 w-full">
+        <Button
+          onClick={handleLeaveGame}
+          disabled={leaveGameMutation.isPending}
+          variant="outline"
+          className="w-full sm:w-auto"
+        >
+          Leave game
+        </Button>
+        <div className="flex items-center gap-2 justify-between sm:justify-end">
+          <span className="text-sm text-muted-foreground">Share this link to invite your friends</span>
+          <Button variant="outline" size="icon" onClick={handleShare}>
+            <Share className="size-4" />
+          </Button>
+        </div>
+      </div>
     )
   ) : null;
 

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -90,7 +90,7 @@ const GameInfo: React.FC = () => {
         </Button>
         <Button variant="outline" className="flex-1 sm:flex-none" onClick={handleShare}>
           <Share className="size-4" />
-          Share
+          Share &amp; invite
         </Button>
       </div>
     )


### PR DESCRIPTION
## Summary

- Move draw proposals entry point to the orders screen footer with an unread-count badge
- Add nation colour rings to flag avatars in all screens (orders, draw proposals, propose draw, player info, chat)
- Extract `buildNationGroups` as a pure function and fix accordion indentation
- Add `color` prop to `NationFlag` so ring logic lives in one place
- Code review polish: use `Panel.Footer divider` prop, clarify `myVote !== null` null check, rename `isActiveOrFinishedGame` → `isStartedGame`

## Test plan

- [ ] Open an active game on the orders screen — "Draw proposals" button appears in the footer
- [ ] Confirm the unread badge appears when there are pending draw proposals awaiting your vote
- [ ] Navigate to draw proposals and vote — badge disappears
- [ ] Flags in orders, draw proposals, propose draw, and player info screens all show a nation colour ring
- [ ] Flag rings in chat are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)