### PR TITLE
Auto-advance UI to the newest phase when a phase resolves

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -39,7 +39,10 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
   }>();
 
   const { data: game } = useGameRetrieve(gameId, {
-    query: { refetchInterval: 30000 },
+    query: {
+      refetchInterval: (query) =>
+        query.state.data?.status === "active" ? 10000 : false,
+    },
   });
 
   const navItems = useMemo(() => {

--- a/packages/web/src/components/PhaseSelect.test.tsx
+++ b/packages/web/src/components/PhaseSelect.test.tsx
@@ -16,7 +16,7 @@ vi.mock("react-router", async () => {
 
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({
-    data: { isPaused: false },
+    data: { isPaused: false, currentPhaseId: 6, phases: [1, 2, 3, 4, 5, 6] },
   }),
   useGamePhaseRetrieveSuspense: () => ({
     data: {

--- a/packages/web/src/components/PhaseSelect.tsx
+++ b/packages/web/src/components/PhaseSelect.tsx
@@ -1,5 +1,7 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import { useNavigate, useLocation } from "react-router";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useRequiredParams } from "@/hooks";
 import {
@@ -18,24 +20,69 @@ export const PhaseSelect: React.FC = () => {
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: phase } = useGamePhaseRetrieveSuspense(gameId, Number(phaseId));
 
+  const isOnLatestPhase = !game.currentPhaseId || game.currentPhaseId === Number(phaseId);
+  const isOnFirstPhase = phase.previousPhaseId === null;
+
+  const getPathSuffix = () => {
+    const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
+    return location.pathname.slice(phasePrefix.length);
+  };
+
+  const goToFirstPhase = () => {
+    const firstPhaseId = game.phases[0];
+    if (!firstPhaseId) return;
+    navigate(`/game/${gameId}/phase/${firstPhaseId}${getPathSuffix()}`);
+  };
+
   const goToPreviousPhase = () => {
     if (phase.previousPhaseId) {
-      const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
-      const suffix = location.pathname.slice(phasePrefix.length);
-      navigate(`/game/${gameId}/phase/${phase.previousPhaseId}${suffix}`);
+      navigate(`/game/${gameId}/phase/${phase.previousPhaseId}${getPathSuffix()}`);
     }
   };
 
   const goToNextPhase = () => {
     if (phase.nextPhaseId) {
-      const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
-      const suffix = location.pathname.slice(phasePrefix.length);
-      navigate(`/game/${gameId}/phase/${phase.nextPhaseId}${suffix}`);
+      navigate(`/game/${gameId}/phase/${phase.nextPhaseId}${getPathSuffix()}`);
     }
   };
 
+  const goToLatestPhase = () => {
+    if (!game.currentPhaseId) return;
+    navigate(`/game/${gameId}/phase/${game.currentPhaseId}${getPathSuffix()}`);
+  };
+
+  const prevCurrentPhaseIdRef = useRef(game.currentPhaseId);
+
+  useEffect(() => {
+    const prevId = prevCurrentPhaseIdRef.current;
+    if (game.currentPhaseId !== prevId && prevId !== null) {
+      const newPhaseId = game.currentPhaseId;
+      if (newPhaseId) {
+        const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
+        const suffix = location.pathname.slice(phasePrefix.length);
+        toast.info("A new phase has started", {
+          action: {
+            label: "Jump to newest",
+            onClick: () => navigate(`/game/${gameId}/phase/${newPhaseId}${suffix}`),
+          },
+        });
+      }
+    }
+    prevCurrentPhaseIdRef.current = game.currentPhaseId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fire on currentPhaseId change
+  }, [game.currentPhaseId]);
+
   return (
     <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={goToFirstPhase}
+        disabled={isOnFirstPhase}
+        aria-label="First phase"
+      >
+        <ChevronsLeft className="h-4 w-4" />
+      </Button>
       <Button
         variant="ghost"
         size="icon"
@@ -45,7 +92,7 @@ export const PhaseSelect: React.FC = () => {
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
-      <div className="flex flex-col items-center min-w-32">
+      <div className="flex flex-col items-center">
         <span className="text-sm font-medium">{phase.name}</span>
         {phase.status === "active" && phase.scheduledResolution && (
           <RemainingTimeDisplay
@@ -64,6 +111,15 @@ export const PhaseSelect: React.FC = () => {
         aria-label="Next phase"
       >
         <ChevronRight className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={goToLatestPhase}
+        disabled={isOnLatestPhase}
+        aria-label="Latest phase"
+      >
+        <ChevronsRight className="h-4 w-4" />
       </Button>
     </div>
   );

--- a/packages/web/src/components/PhaseSelect.tsx
+++ b/packages/web/src/components/PhaseSelect.tsx
@@ -60,7 +60,8 @@ export const PhaseSelect: React.FC = () => {
       if (newPhaseId) {
         const phasePrefix = `/game/${gameId}/phase/${phaseId}`;
         const suffix = location.pathname.slice(phasePrefix.length);
-        toast.info("A new phase has started", {
+        toast.success("A new phase has started", {
+          duration: 10000,
           action: {
             label: "Jump to newest",
             onClick: () => navigate(`/game/${gameId}/phase/${newPhaseId}${suffix}`),
@@ -77,23 +78,25 @@ export const PhaseSelect: React.FC = () => {
       <Button
         variant="ghost"
         size="icon"
+        className="h-7 w-7"
         onClick={goToFirstPhase}
         disabled={isOnFirstPhase}
         aria-label="First phase"
       >
-        <ChevronsLeft className="h-4 w-4" />
+        <ChevronsLeft className="h-3.5 w-3.5" />
       </Button>
       <Button
         variant="ghost"
         size="icon"
+        className="h-7 w-7"
         onClick={goToPreviousPhase}
         disabled={phase.previousPhaseId === null}
         aria-label="Previous phase"
       >
-        <ChevronLeft className="h-4 w-4" />
+        <ChevronLeft className="h-3.5 w-3.5" />
       </Button>
       <div className="flex flex-col items-center">
-        <span className="text-sm font-medium">{phase.name}</span>
+        <span className="text-xs font-medium">{phase.name}</span>
         {phase.status === "active" && phase.scheduledResolution && (
           <RemainingTimeDisplay
             remainingTime={phase.remainingTime}
@@ -106,20 +109,22 @@ export const PhaseSelect: React.FC = () => {
       <Button
         variant="ghost"
         size="icon"
+        className="h-7 w-7"
         onClick={goToNextPhase}
         disabled={phase.nextPhaseId === null}
         aria-label="Next phase"
       >
-        <ChevronRight className="h-4 w-4" />
+        <ChevronRight className="h-3.5 w-3.5" />
       </Button>
       <Button
         variant="ghost"
         size="icon"
+        className="h-7 w-7"
         onClick={goToLatestPhase}
         disabled={isOnLatestPhase}
         aria-label="Latest phase"
       >
-        <ChevronsRight className="h-4 w-4" />
+        <ChevronsRight className="h-3.5 w-3.5" />
       </Button>
     </div>
   );


### PR DESCRIPTION
Closes #538.

Polls `game-retrieve` every 10s for active games (stopped for completed/abandoned). When `currentPhaseId` advances, a toast appears with a "Jump to newest" action regardless of which phase the user is viewing.

`PhaseSelect` gains `ChevronsLeft` and `ChevronsRight` buttons to jump directly to the first or latest phase, flanking the existing prev/next chevrons. The phase name div drops `min-w-32` so all four buttons fit on mobile.

<sub>Generated with [Claude Code](https://claude.ai/claude-code)</sub>