### PR TITLE
Fix Apple web sign-in

### DIFF
--- a/packages/web/src/screens/Login.test.tsx
+++ b/packages/web/src/screens/Login.test.tsx
@@ -8,6 +8,7 @@ import { Login } from "./Login";
 const mockLogin = vi.fn();
 const mockMutateAsync = vi.fn();
 const mockAppleMutateAsync = vi.fn();
+const mockAppleInit = vi.fn();
 const mockAppleSignIn = vi.fn();
 
 vi.mock("@/auth", () => ({
@@ -47,8 +48,18 @@ const renderLogin = () =>
 describe("Login", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAppleSignIn.mockImplementation(() => {
+      document.dispatchEvent(
+        new CustomEvent("AppleIDSignInOnSuccess", {
+          detail: {
+            authorization: { id_token: "apple-id-token" },
+            user: { name: { firstName: "Ada", lastName: "Lovelace" } },
+          },
+        })
+      );
+    });
     vi.stubGlobal("AppleID", {
-      auth: { init: vi.fn(), signIn: mockAppleSignIn },
+      auth: { init: mockAppleInit, signIn: mockAppleSignIn },
     });
   });
 
@@ -121,10 +132,6 @@ describe("Login", () => {
   });
 
   it("signs in with Apple and stores tokens on success", async () => {
-    mockAppleSignIn.mockResolvedValue({
-      authorization: { id_token: "apple-id-token" },
-      user: { name: { firstName: "Ada", lastName: "Lovelace" } },
-    });
     mockAppleMutateAsync.mockResolvedValue({
       id: 2,
       email: "ada@example.com",

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -44,7 +44,7 @@ declare global {
           redirectURI: string;
           usePopup: boolean;
         }) => void;
-        signIn: () => Promise<AppleAuthResponse>;
+        signIn: () => void;
       };
     };
   }
@@ -170,19 +170,32 @@ const Login: React.FC = () => {
     }
   };
 
-  const handleWebAppleLogin = async () => {
-    try {
-      window.AppleID.auth.init({
-        clientId: import.meta.env.VITE_APPLE_WEB_CLIENT_ID,
-        scope: "name email",
-        redirectURI: import.meta.env.VITE_APPLE_REDIRECT_URI,
-        usePopup: true,
-      });
-      const response = await window.AppleID.auth.signIn();
-      await finishAppleLogin(parseAppleResponse(response));
-    } catch {
+  React.useEffect(() => {
+    if (isNativePlatform()) return;
+    window.AppleID.auth.init({
+      clientId: import.meta.env.VITE_APPLE_WEB_CLIENT_ID,
+      scope: "name email",
+      redirectURI: import.meta.env.VITE_APPLE_REDIRECT_URI,
+      usePopup: true,
+    });
+  }, []);
+
+  const handleWebAppleLogin = () => {
+    const onSuccess = (event: Event) => {
+      document.removeEventListener("AppleIDSignInOnSuccess", onSuccess);
+      document.removeEventListener("AppleIDSignInOnFailure", onFailure);
+      finishAppleLogin(parseAppleResponse((event as CustomEvent<AppleAuthResponse>).detail)).catch(
+        () => toast.error("Login failed")
+      );
+    };
+    const onFailure = () => {
+      document.removeEventListener("AppleIDSignInOnSuccess", onSuccess);
+      document.removeEventListener("AppleIDSignInOnFailure", onFailure);
       toast.error("Login failed");
-    }
+    };
+    document.addEventListener("AppleIDSignInOnSuccess", onSuccess);
+    document.addEventListener("AppleIDSignInOnFailure", onFailure);
+    window.AppleID.auth.signIn();
   };
 
   return (


### PR DESCRIPTION
Two fixes on top of #547:

- Replace `react-apple-signin-auth` with the official Apple JS SDK loaded via script tag, removing a dependency with a broken postinstall script on Alpine Linux.
- Switch from the `signIn()` Promise (which doesn't resolve in production — popup stays open indefinitely) to the `AppleIDSignInOnSuccess`/`AppleIDSignInOnFailure` document events, which is how the SDK actually delivers results.

<sub>Generated with [Claude Code](https://claude.ai/claude-code)</sub>