### PR TITLE
Fix NMR extensions firing for all players on turn 1

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -452,53 +452,54 @@ class Game(BaseModel):
         if self.status != GameStatus.PENDING:
             raise ValueError("Game is not pending")
 
-        # Use provided phase/members to avoid unnecessary queries, or fetch if not provided
-        if current_phase is None:
-            current_phase = self.current_phase
-        if members is None:
-            members = list(self.members.all())
+        with transaction.atomic():
+            # Use provided phase/members to avoid unnecessary queries, or fetch if not provided
+            if current_phase is None:
+                current_phase = self.current_phase
+            if members is None:
+                members = list(self.members.all())
 
-        adjudication_data = adjudication_service.start(current_phase)
+            adjudication_data = adjudication_service.start(current_phase)
 
-        current_phase.status = PhaseStatus.ACTIVE
-        current_phase.options = adjudication_data["options"]
-        current_phase.scheduled_resolution = self.get_scheduled_resolution(current_phase.type, is_first_phase=True)
-        current_phase.save()
+            current_phase.status = PhaseStatus.ACTIVE
+            current_phase.options = adjudication_data["options"]
+            current_phase.scheduled_resolution = self.get_scheduled_resolution(current_phase.type, is_first_phase=True)
+            current_phase.save()
 
-        # Use prefetched nations if available, otherwise fetch
-        # variant.nations.all() is already prefetched via with_game_creation_data()
-        # Accessing .all() on a prefetched queryset doesn't trigger a new query
-        nations = list(self.variant.nations.all())
+            # Use prefetched nations if available, otherwise fetch
+            # variant.nations.all() is already prefetched via with_game_creation_data()
+            # Accessing .all() on a prefetched queryset doesn't trigger a new query
+            nations = list(self.variant.nations.all())
 
-        if self.nation_assignment == NationAssignment.RANDOM:
-            import random
+            if self.nation_assignment == NationAssignment.RANDOM:
+                import random
 
-            random.shuffle(members)
-        elif self.nation_assignment == NationAssignment.ORDERED:
-            members.sort(key=lambda m: m.id)
+                random.shuffle(members)
+            elif self.nation_assignment == NationAssignment.ORDERED:
+                members.sort(key=lambda m: m.id)
 
-        now = timezone.now()
-        for member, nation in zip(members, nations):
-            member.nation = nation
-            member.nmr_extensions_remaining = self.nmr_extensions_allowed
-            member.updated_at = now
+            now = timezone.now()
+            for member, nation in zip(members, nations):
+                member.nation = nation
+                member.nmr_extensions_remaining = self.nmr_extensions_allowed
+                member.updated_at = now
 
-        # Use bulk_update to avoid n+1 queries
-        Member.objects.bulk_update(members, ["nation", "nmr_extensions_remaining", "updated_at"])
+            # Use bulk_update to avoid n+1 queries
+            Member.objects.bulk_update(members, ["nation", "nmr_extensions_remaining", "updated_at"])
 
-        nations_with_orders = current_phase.nations_with_possible_orders
-        phase_states_to_create = [
-            PhaseState(
-                phase=current_phase,
-                member=member,
-                has_possible_orders=member.nation.name in nations_with_orders,
-            )
-            for member in members
-        ]
-        PhaseState.objects.bulk_create(phase_states_to_create)
+            nations_with_orders = current_phase.nations_with_possible_orders
+            phase_states_to_create = [
+                PhaseState(
+                    phase=current_phase,
+                    member=member,
+                    has_possible_orders=member.nation.name in nations_with_orders,
+                )
+                for member in members
+            ]
+            PhaseState.objects.bulk_create(phase_states_to_create)
 
-        self.status = GameStatus.ACTIVE
-        self.save()
+            self.status = GameStatus.ACTIVE
+            self.save()
 
     def pause(self):
         if self.status != GameStatus.ACTIVE:

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -2148,7 +2148,7 @@ class TestSandboxGameCreateViewPerformance:
         for i, query in enumerate(connection.queries, 1):
             print(f"\nQuery {i}: {query['sql']}")
 
-        assert query_count == 51
+        assert query_count == 53
 
     @pytest.mark.django_db
     def test_create_sandbox_game_query_count_large_variant(
@@ -2174,7 +2174,7 @@ class TestSandboxGameCreateViewPerformance:
         for i, query in enumerate(connection.queries, 1):
             print(f"\nQuery {i}: {query['sql']}")
 
-        assert query_count == 51
+        assert query_count == 53
 
 
 class TestSandboxGameFiltering:

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -3,8 +3,9 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework import status
 from game.models import Game
+from phase.models import Phase
 from user_profile.models import UserProfile
-from common.constants import GameStatus
+from common.constants import GameStatus, NationAssignment
 
 User = get_user_model()
 
@@ -297,3 +298,33 @@ def test_game_has_exactly_one_game_master(
     game_masters = game.members.filter(is_game_master=True)
     assert game_masters.count() == 1
     assert game_masters.first().user == secondary_user
+
+
+@pytest.mark.django_db
+def test_game_start_phase_not_immediately_resolvable(classical_variant, primary_user):
+    # After game.start(), the active phase must NOT appear in filter_due_phases()
+    # for a duration-based game with a future deadline.
+    #
+    # Before the fix, game.start() was not wrapped in transaction.atomic(). Between
+    # current_phase.save() and PhaseState.objects.bulk_create(), the phase was ACTIVE
+    # with no phase states — making all_confirmed vacuously True and the phase appear
+    # immediately due to any concurrent sweep task. The transaction.atomic() wrapper
+    # ensures the intermediate state (phase active, no phase states) is never committed
+    # and therefore never visible to concurrent resolvers.
+    from common.constants import MovementPhaseDuration, DeadlineMode
+
+    game = Game.objects.create_from_template(
+        classical_variant,
+        name="Test Duration Game",
+        nation_assignment=NationAssignment.ORDERED,
+        deadline_mode=DeadlineMode.DURATION,
+        movement_phase_duration=MovementPhaseDuration.TWENTY_FOUR_HOURS,
+    )
+    for _ in classical_variant.nations.all():
+        game.members.create(user=primary_user)
+    game.start()
+
+    phase = game.current_phase
+    assert phase.status == "active"
+    assert phase.phase_states.exists()
+    assert phase not in Phase.objects.filter_due_phases()

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -198,9 +198,16 @@ class PhaseManager(models.Manager):
         return self.resolve_due_phases(canary=True)
 
     def _check_and_apply_nmr_extensions(self, phase):
-        unconfirmed = phase.phase_states.filter(
-            has_possible_orders=True, orders_confirmed=False
-        ).select_related('member')
+        if phase.game.deadline_mode == DeadlineMode.FIXED_TIME:
+            unconfirmed = phase.phase_states.filter(
+                has_possible_orders=True,
+            ).annotate(order_count=Count('orders')).filter(
+                order_count=0,
+            ).select_related('member')
+        else:
+            unconfirmed = phase.phase_states.filter(
+                has_possible_orders=True, orders_confirmed=False
+            ).select_related('member')
 
         members_with_extensions = [
             ps.member for ps in unconfirmed

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -2074,6 +2074,24 @@ class TestFilterDuePhasesBasicFiltering:
 
         assert phase in phases
 
+    @pytest.mark.django_db
+    def test_filter_due_phases_duration_game_no_phase_states_is_due(self, phase_factory):
+        # A duration-mode phase with no phase states is vacuously "all confirmed"
+        # (the Exists() subquery returns no rows, so ~Exists is True), making it
+        # appear immediately resolvable. This is the intermediate DB state that
+        # exists inside game.start() between current_phase.save() and
+        # PhaseState.objects.bulk_create(). Wrapping game.start() in
+        # transaction.atomic() ensures this intermediate state is never committed
+        # and therefore never visible to concurrent sweep tasks.
+        phase = phase_factory(
+            scheduled_resolution=timezone.now() + timedelta(hours=24),
+            phase_states_config=None,
+        )
+
+        phases = Phase.objects.filter_due_phases()
+
+        assert phase in phases
+
 
 class TestPhaseAdminQueryPerformance:
 
@@ -4111,6 +4129,66 @@ class TestSendDeadlineWarnings:
         Phase.objects.send_deadline_warnings()
 
         mock_send_notification_to_users.assert_not_called()
+
+
+class TestNMRExtensionsFixedTime:
+
+    @pytest.mark.django_db
+    def test_fixed_time_no_orders_applies_extension(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(
+            DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
+        )
+        game.movement_phase_duration = "24 hours"
+        game.save()
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        result = Phase.objects._check_and_apply_nmr_extensions(phase)
+
+        assert result is not None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 0
+
+    @pytest.mark.django_db
+    def test_fixed_time_with_any_order_skips_extension(
+        self,
+        make_deadline_warning_game,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = make_deadline_warning_game(
+            DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
+        )
+        game.movement_phase_duration = "24 hours"
+        game.save()
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+        ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        result = Phase.objects._check_and_apply_nmr_extensions(phase)
+
+        assert result is None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 1
 
 
 def _elimination_jobs(connector):


### PR DESCRIPTION
## Summary

- **Bug 1 (duration games):** `game.start()` performed multiple DB commits without `transaction.atomic()`. Between `current_phase.save()` and `PhaseState.objects.bulk_create()`, the phase was `ACTIVE` with no phase states, so `filter_due_phases()` treated it as vacuously "all confirmed". If the `sweep_due_phases` cron fired in that ~50ms window, it resolved the phase immediately with no orders — turn 2 then carried all extensions, which fired simultaneously at the next deadline.
- **Bug 2 (fixed-time games):** `_check_and_apply_nmr_extensions()` used `orders_confirmed=False` to detect absent players. Fixed-time games have no "Confirm orders" button, so `orders_confirmed` is always `False` for everyone. The check now uses absence of any submitted orders (`order_count=0`) for fixed-time games — a player who submitted even one order is adjudicated normally.

## Test plan

- [ ] `phase/tests.py::TestFilterDuePhasesBasicFiltering::test_filter_due_phases_duration_game_no_phase_states_is_due` — documents the vacuous-due-phase vulnerability
- [ ] `member/tests.py::test_game_start_phase_not_immediately_resolvable` — verifies the active phase with a future deadline is not immediately resolvable after `game.start()`
- [ ] `phase/tests.py::TestNMRExtensionsFixedTime::test_fixed_time_no_orders_applies_extension` — extension fires for a fixed-time player who sent no orders
- [ ] `phase/tests.py::TestNMRExtensionsFixedTime::test_fixed_time_with_any_order_skips_extension` — extension skipped for a fixed-time player who submitted at least one order

🤖 Generated with [Claude Code](https://claude.com/claude-code)