### PR TITLE
Redesign create game page

### DIFF
--- a/packages/web/src/components/DeadlineSummary.test.tsx
+++ b/packages/web/src/components/DeadlineSummary.test.tsx
@@ -16,7 +16,7 @@ describe("DeadlineSummary", () => {
         <DeadlineSummary game={{ movementPhaseDuration: "24 hours" }} />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
 
@@ -30,7 +30,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 48 hours/)
+        screen.getByText(/Phases are at least 48 hours/)
       ).toBeInTheDocument();
     });
 
@@ -62,7 +62,7 @@ describe("DeadlineSummary", () => {
         <DeadlineSummary game={{ movementPhaseDuration: duration }} />
       );
       expect(
-        screen.getByText(new RegExp(`Phases resolve every ${duration}`))
+        screen.getByText(new RegExp(`Phases are at least ${duration}`))
       ).toBeInTheDocument();
     });
 
@@ -76,7 +76,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
 
@@ -90,7 +90,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
   });

--- a/packages/web/src/components/DeadlineSummary.tsx
+++ b/packages/web/src/components/DeadlineSummary.tsx
@@ -161,8 +161,8 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
   ) {
     return (
       <span>
-        Phases resolve every {movementPhaseDuration}, but earlier if all players
-        confirmed their orders.
+        Phases are at least {movementPhaseDuration}, but can resolve earlier if
+        all players confirmed their orders.
       </span>
     );
   }

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -230,7 +230,7 @@ describe("CreateGame — find-similar intervention", () => {
   });
 
   const switchToDurationMode = async (user: ReturnType<typeof userEvent.setup>) => {
-    await user.click(screen.getByRole("tab", { name: /duration/i }));
+    await user.click(screen.getByRole("button", { name: /^duration$/i }));
   };
 
   const submit = async (user: ReturnType<typeof userEvent.setup>) => {

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -441,7 +441,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                 <p className="text-sm text-muted-foreground">
                   {field.value === "fixed_time"
                     ? "Deadlines are always at the fixed time, turns are always the same length."
-                    : "Turns can resolve earlier if all players confirm their orders, which means the deadline time can shift."}
+                    : "Phases can resolve earlier if all players confirm their orders, meaning the deadline time can shift."}
                 </p>
                 <FormMessage />
               </FormItem>

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -3,12 +3,23 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { BookOpen, Calendar, Clock, Map, User, Users } from "lucide-react";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  Lock,
+  Map,
+  MessageSquare,
+  Monitor,
+  Sailboat,
+  Timer,
+  User,
+  Users,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CardDescription } from "@/components/ui/card";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { ScreenHeader } from "@/components/ui/screen-header";
@@ -17,6 +28,7 @@ import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
 
 import {
   Select,
@@ -110,6 +122,56 @@ const modeToBackendFields = (mode: StandardGameFormValues["mode"]) => ({
   pressType: mode === "gunboat" ? "no_press" : "full_press",
 } as const);
 
+interface RadioCardOption<T extends string> {
+  value: T;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface RadioCardGroupProps<T extends string> {
+  options: RadioCardOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  size?: "default" | "large";
+}
+
+const RadioCardGroup = <T extends string>({
+  options,
+  value,
+  onChange,
+  disabled,
+  size = "default",
+}: RadioCardGroupProps<T>) => {
+  return (
+    <div
+      className="grid gap-x-2 gap-y-0.5"
+      style={{ gridTemplateColumns: `repeat(${options.length}, 1fr)` }}
+    >
+      {options.map(option => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => !disabled && onChange(option.value)}
+          className={cn(
+            "flex flex-col items-center gap-2 rounded-lg border-2 cursor-pointer transition-colors",
+            size === "large" ? "px-4 py-1" : "px-3 py-1",
+            value === option.value
+              ? "border-primary bg-primary/5 text-primary"
+              : "border-border text-muted-foreground hover:border-muted-foreground hover:text-foreground",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          {option.icon}
+          <span className={cn("font-medium", size === "large" ? "text-base" : "text-sm")}>
+            {option.label}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
 interface MetadataRow {
   label: string;
   value?: string | React.ReactNode;
@@ -170,7 +232,6 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
         name={name}
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Variant</FormLabel>
             <Select
               onValueChange={field.onChange}
               value={field.value}
@@ -184,7 +245,7 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
               <SelectContent>
                 {variants?.map(variant => (
                   <SelectItem key={variant.id} value={variant.id}>
-                    {variant.name}
+                    {variant.name} ({variant.nations.length} players)
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -277,39 +338,37 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="mode"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <RadioCardGroup
+                options={[
+                  {
+                    value: "standard" as const,
+                    label: "Full press",
+                    icon: <MessageSquare className="size-5" />,
+                  },
+                  {
+                    value: "gunboat" as const,
+                    label: "Gunboat (no press)",
+                    icon: <Sailboat className="size-5" />,
+                  },
+                ]}
+                value={field.value}
+                onChange={field.onChange}
+                disabled={isSubmitting}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <hr className="border-t" />
+
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">General</h2>
-
-          <FormField
-            control={form.control}
-            name="mode"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Mode</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={isSubmitting}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="standard">Standard</SelectItem>
-                    <SelectItem value="gunboat">Gunboat</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  {field.value === "gunboat"
-                    ? "Player names are anonymized and messaging is disabled"
-                    : "Standard play"}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
 
           <FormField
             control={form.control}
@@ -338,10 +397,12 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">
-                  <FormLabel>Private</FormLabel>
+                  <FormLabel className="flex items-center gap-1.5">
+                    <Lock className="h-3 w-3" />
+                    Private
+                  </FormLabel>
                   <FormDescription>
-                    Make this game private (only accessible via direct link, not
-                    shown in public listings)
+                    Private games are hidden from public listings and only accessible via direct link that can be shared.
                   </FormDescription>
                 </div>
               </FormItem>
@@ -358,214 +419,225 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
             control={form.control}
             name="deadlineMode"
             render={({ field }) => (
-              <FormItem>
-                <Tabs
+              <FormItem className="space-y-3">
+                <RadioCardGroup
+                  options={[
+                    {
+                      value: "fixed_time" as const,
+                      label: "Fixed time",
+                      icon: <Clock className="size-5" />,
+                    },
+                    {
+                      value: "duration" as const,
+                      label: "Duration",
+                      icon: <Timer className="size-5" />,
+                    },
+                  ]}
                   value={field.value}
-                  onValueChange={field.onChange}
-                  className="w-full"
-                >
-                  <TabsList className="w-full">
-                    <TabsTrigger value="fixed_time" className="flex-1">
-                      Fixed Time
-                    </TabsTrigger>
-                    <TabsTrigger value="duration" className="flex-1">
-                      Duration
-                    </TabsTrigger>
-                  </TabsList>
-
-                  <TabsContent value="duration" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementPhaseDuration"
-                        render={({ field: durationField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={durationField.onChange}
-                              value={durationField.value}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="retreatPhaseDuration"
-                        render={({ field: retreatField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatField.onChange}
-                              value={retreatField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
-
-                  <TabsContent value="fixed_time" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTime"
-                        render={({ field: timeField }) => (
-                          <FormItem>
-                            <FormLabel>Time</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="time"
-                                className="appearance-none"
-                                value={timeField.value ?? ""}
-                                onChange={timeField.onChange}
-                                disabled={isSubmitting}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTimezone"
-                        render={({ field: tzField }) => (
-                          <FormItem>
-                            <FormLabel>Timezone</FormLabel>
-                            <Select
-                              onValueChange={tzField.onChange}
-                              value={tzField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                            <FormControl>
-                              <SelectTrigger className="w-full">
-                                <SelectValue placeholder="Select" />
-                              </SelectTrigger>
-                            </FormControl>
-                              <SelectContent>
-                                {TIMEZONE_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementFrequency"
-                        render={({ field: freqField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={freqField.onChange}
-                              value={freqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="retreatFrequency"
-                        render={({ field: retreatFreqField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatFreqField.onChange}
-                              value={retreatFreqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                  onChange={field.onChange}
+                  disabled={isSubmitting}
+                />
+                <p className="text-sm text-muted-foreground">
+                  {field.value === "fixed_time"
+                    ? "Deadlines are always at the fixed time, turns are always the same length."
+                    : "Turns can resolve earlier if all players confirm their orders, which means the deadline time can shift."}
+                </p>
+                <FormMessage />
               </FormItem>
             )}
           />
+
+          {deadlineMode === "duration" && (
+            <div className="grid w-full grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="movementPhaseDuration"
+                render={({ field: durationField }) => (
+                  <FormItem>
+                    <FormLabel>Movement</FormLabel>
+                    <Select
+                      onValueChange={durationField.onChange}
+                      value={durationField.value}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {DURATION_OPTIONS.map(option => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="retreatPhaseDuration"
+                render={({ field: retreatField }) => (
+                  <FormItem>
+                    <FormLabel>Retreat/Adjustment</FormLabel>
+                    <Select
+                      onValueChange={retreatField.onChange}
+                      value={retreatField.value ?? undefined}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                          <SelectValue placeholder="Same as movement" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {DURATION_OPTIONS.map(option => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+
+          {deadlineMode === "fixed_time" && (
+            <>
+              <div className="grid w-full grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="fixedDeadlineTime"
+                  render={({ field: timeField }) => (
+                    <FormItem>
+                      <FormLabel>Time</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="time"
+                          className="appearance-none"
+                          value={timeField.value ?? ""}
+                          onChange={timeField.onChange}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="fixedDeadlineTimezone"
+                  render={({ field: tzField }) => (
+                    <FormItem>
+                      <FormLabel>Timezone</FormLabel>
+                      <Select
+                        onValueChange={tzField.onChange}
+                        value={tzField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Select" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {TIMEZONE_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid w-full grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="movementFrequency"
+                  render={({ field: freqField }) => (
+                    <FormItem>
+                      <FormLabel>Movement</FormLabel>
+                      <Select
+                        onValueChange={freqField.onChange}
+                        value={freqField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {FREQUENCY_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="retreatFrequency"
+                  render={({ field: retreatFreqField }) => (
+                    <FormItem>
+                      <FormLabel>Retreat/Adjustment</FormLabel>
+                      <Select
+                        onValueChange={retreatFreqField.onChange}
+                        value={retreatFreqField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                            <SelectValue placeholder="Same as movement" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {FREQUENCY_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </>
+          )}
 
           <Alert className="mt-4">
             <Clock className="h-4 w-4" />
@@ -614,28 +686,19 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
             control={form.control}
             name="nmrExtensionsAllowed"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Automatic Extensions</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
+              <FormItem className="space-y-3">
+                <FormLabel>Automatic extensions</FormLabel>
+                <RadioCardGroup
+                  options={NMR_EXTENSION_OPTIONS.map(option => ({
+                    value: option.value,
+                    label: option.label,
+                  }))}
                   value={field.value}
+                  onChange={field.onChange}
                   disabled={isSubmitting}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {NMR_EXTENSION_OPTIONS.map(option => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                />
                 <FormDescription>
-                  Automatic extensions when players miss the deadline
+                  If a player does not submit orders, an extension resets the deadline and gives them extra time to respond before they are marked as having left the game.
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -741,26 +804,25 @@ const CreateGame: React.FC = () => {
   const [pendingFormData, setPendingFormData] =
     useState<StandardGameFormValues | null>(null);
 
-  const getInitialTab = (): "standard" | "sandbox" => {
+  const getInitialGameType = (): "standard" | "sandbox" => {
     return searchParams.get("sandbox") === "true" ? "sandbox" : "standard";
   };
 
-  const [currentTab, setCurrentTab] = useState<"standard" | "sandbox">(
-    getInitialTab()
+  const [gameType, setGameType] = useState<"standard" | "sandbox">(
+    getInitialGameType()
   );
 
   useEffect(() => {
-    const newTab = getInitialTab();
-    setCurrentTab(newTab);
+    const newType = getInitialGameType();
+    setGameType(newType);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  const handleTabChange = (value: string) => {
-    const newTab = value as "standard" | "sandbox";
-    setCurrentTab(newTab);
+  const handleGameTypeChange = (value: "standard" | "sandbox") => {
+    setGameType(value);
 
     const newSearchParams = new URLSearchParams(searchParams);
-    if (newTab === "sandbox") {
+    if (value === "sandbox") {
       newSearchParams.set("sandbox", "true");
     } else {
       newSearchParams.delete("sandbox");
@@ -873,40 +935,44 @@ const CreateGame: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <Tabs value={currentTab} onValueChange={handleTabChange}>
-        <TabsList className="w-full">
-          <TabsTrigger value="standard" className="flex-1">
-            Standard
-          </TabsTrigger>
-          <TabsTrigger value="sandbox" className="flex-1">
-            Sandbox
-          </TabsTrigger>
-        </TabsList>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Type</h2>
+        <RadioCardGroup
+          options={[
+            {
+              value: "standard" as const,
+              label: "vs Humans",
+            icon: <Users className="size-6" />,
+          },
+          {
+            value: "sandbox" as const,
+            label: "Sandbox",
+            icon: <Monitor className="size-6" />,
+          },
+        ]}
+        value={gameType}
+          onChange={handleGameTypeChange}
+          size="large"
+        />
+      </div>
 
-        <TabsContent value="standard">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateStandardGameForm
-                onSubmit={handleStandardGameSubmit}
-                isSubmitting={createGameMutation.isPending}
-                variants={variants}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-
-        <TabsContent value="sandbox">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateSandboxGameForm
-                onSubmit={handleSandboxGameSubmit}
-                isSubmitting={createSandboxGameMutation.isPending}
-                variants={variants}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-      </Tabs>
+      <ScreenCard>
+        <ScreenCardContent>
+          {gameType === "standard" ? (
+            <CreateStandardGameForm
+              onSubmit={handleStandardGameSubmit}
+              isSubmitting={createGameMutation.isPending}
+              variants={variants}
+            />
+          ) : (
+            <CreateSandboxGameForm
+              onSubmit={handleSandboxGameSubmit}
+              isSubmitting={createSandboxGameMutation.isPending}
+              variants={variants}
+            />
+          )}
+        </ScreenCardContent>
+      </ScreenCard>
 
       <AlertDialog
         open={similarMatch !== null}

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -10,8 +10,9 @@ import {
   Lock,
   Map,
   MessageSquare,
+  MessageSquareOff,
   Monitor,
-  Sailboat,
+
   Timer,
   User,
   Users,
@@ -353,7 +354,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                   {
                     value: "gunboat" as const,
                     label: "Gunboat (no press)",
-                    icon: <Sailboat className="size-5" />,
+                    icon: <MessageSquareOff className="size-5" />,
                   },
                 ]}
                 value={field.value}

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -440,7 +440,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                 />
                 <p className="text-sm text-muted-foreground">
                   {field.value === "fixed_time"
-                    ? "Deadlines are always at the fixed time, turns are always the same length."
+                    ? "Deadlines are always at the fixed time, phases are always the same length."
                     : "Phases can resolve earlier if all players confirm their orders, meaning the deadline time can shift."}
                 </p>
                 <FormMessage />


### PR DESCRIPTION
## Summary
- Replaces tab-based game type switcher with icon radio cards (vs Humans / Sandbox)
- Moves Press type (Full press / Gunboat) to the top of the form, below the game type selector
- Converts deadline mode and advanced settings (NMR extensions) to card-style radio selectors
- Adds player count to variant dropdown items (e.g. "Classical (7 players)")
- Updates private field description and deadline mode description blurbs
- Uses `MessageSquareOff` icon for Gunboat (no press) to pair visually with `MessageSquare` for Full press

## Test plan
- [ ] Create a standard game with fixed time deadline
- [ ] Create a standard game with duration deadline — verify similar game modal still works
- [ ] Create a private game — verify find-similar is skipped
- [ ] Create a gunboat game — verify anonymous + no_press fields are sent correctly
- [ ] Create a sandbox game — verify sandbox form is unchanged
- [ ] Switch between vs Humans / Sandbox — verify URL param updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)