### PR TITLE
Show gunboat icon on game cards

### DIFF
--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -165,6 +165,24 @@ describe("GameCard", () => {
     });
   });
 
+  describe("gunboat icon", () => {
+    it("shows gunboat icon when pressType is no_press", () => {
+      renderGameCard({
+        game: { ...mockGames[0], pressType: "no_press" },
+        ...defaultProps,
+      });
+      expect(screen.getByLabelText("Gunboat")).toBeInTheDocument();
+    });
+
+    it("does not show gunboat icon when pressType is full_press", () => {
+      renderGameCard({
+        game: { ...mockGames[0], pressType: "full_press" },
+        ...defaultProps,
+      });
+      expect(screen.queryByLabelText("Gunboat")).not.toBeInTheDocument();
+    });
+  });
+
   describe("sandbox visual treatment", () => {
     it("displays a Sandbox badge when game.sandbox is true", () => {
       renderGameCard({

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -12,7 +12,7 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 import { GameDropdownMenu } from "./GameDropdownMenu";
-import { UserPlus, Lock } from "lucide-react";
+import { UserPlus, Lock, MessageSquareOff } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { RemainingTimeDisplay } from "./RemainingTimeDisplay";
@@ -103,6 +103,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
               >
                 <CardTitle className="flex items-center gap-2">
                   {game.name}
+                  {game.pressType === "no_press" && <MessageSquareOff className="h-3 w-3" aria-label="Gunboat" />}
                   {game.sandbox && (
                     <Badge variant="secondary">Sandbox</Badge>
                   )}


### PR DESCRIPTION
## Summary
- Adds a `MessageSquareOff` icon to the game card title for no-press (gunboat) games
- Icon appears after the game name and before the Sandbox badge
- Consistent with the existing gunboat indicator in `GameInfoContent`

## Test plan
- [ ] Gunboat icon appears on cards where `pressType` is `no_press`
- [ ] Icon does not appear on standard (`full_press`) game cards
- [ ] Icon position: after game name, before Sandbox badge
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)