### PR TITLE
Fix deadline bugs in FIXED_TIME games

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -19,7 +19,7 @@ from common.constants import (
 )
 from common.models import BaseModel
 from phase.models import Phase, PhaseState
-from phase.utils import calculate_next_fixed_deadline
+from phase.utils import calculate_next_fixed_deadline, FREQUENCY_INTERVALS
 from member.models import Member
 from unit.models import Unit
 from supply_center.models import SupplyCenter
@@ -387,6 +387,13 @@ class Game(BaseModel):
             return self.movement_phase_duration_seconds
         else:
             return self.retreat_phase_duration_seconds
+
+    def get_effective_phase_duration_seconds(self, phase_type):
+        if self.deadline_mode == DeadlineMode.FIXED_TIME:
+            frequency = self.get_phase_frequency(phase_type)
+            interval = FREQUENCY_INTERVALS.get(frequency) if frequency else None
+            return int(interval.total_seconds()) if interval else None
+        return self.get_phase_duration_seconds(phase_type)
 
     def get_phase_frequency(self, phase_type):
         if phase_type == PhaseType.MOVEMENT:

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -217,11 +217,11 @@ class PhaseManager(models.Manager):
         if not members_with_extensions:
             return None
 
-        duration = phase.game.get_phase_duration_seconds(phase.type)
-        if not duration:
+        new_resolution = phase.game.get_scheduled_resolution(phase.type)
+        if not new_resolution:
             return None
 
-        phase.scheduled_resolution = timezone.now() + timedelta(seconds=duration)
+        phase.scheduled_resolution = new_resolution
         phase.save()
 
         for member in members_with_extensions:
@@ -305,7 +305,7 @@ class PhaseManager(models.Manager):
             notifications_sent = 0
 
             for phase in active_phases:
-                duration_seconds = phase.game.get_phase_duration_seconds(phase.type)
+                duration_seconds = phase.game.get_effective_phase_duration_seconds(phase.type)
                 warning_threshold = get_warning_threshold(duration_seconds)
                 time_until_deadline = (phase.scheduled_resolution - now).total_seconds()
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -6,10 +6,10 @@ from django.urls import reverse
 from django.utils import timezone
 from django.test.utils import override_settings
 from django.db import connection
-from datetime import timedelta
+from datetime import timedelta, time
 from unittest.mock import patch, Mock
 from rest_framework import status
-from common.constants import PhaseStatus, PhaseType, OrderType, UnitType, GameStatus, DeadlineMode, ProvinceType
+from common.constants import PhaseStatus, PhaseType, OrderType, UnitType, GameStatus, DeadlineMode, ProvinceType, PhaseFrequency
 from game.models import Game
 from .models import Phase, PhaseState
 from .serializers import PhaseStateSerializer
@@ -4144,7 +4144,9 @@ class TestNMRExtensionsFixedTime:
         game, italy, germany, phase = make_deadline_warning_game(
             DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
         )
-        game.movement_phase_duration = "24 hours"
+        game.movement_frequency = PhaseFrequency.EVERY_2_DAYS
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
         game.save()
         italy.nmr_extensions_remaining = 1
         italy.save()
@@ -4160,6 +4162,8 @@ class TestNMRExtensionsFixedTime:
         assert result is not None
         italy.refresh_from_db()
         assert italy.nmr_extensions_remaining == 0
+        phase.refresh_from_db()
+        assert phase.scheduled_resolution > now + timedelta(hours=24)
 
     @pytest.mark.django_db
     def test_fixed_time_with_any_order_skips_extension(
@@ -4172,8 +4176,6 @@ class TestNMRExtensionsFixedTime:
         game, italy, germany, phase = make_deadline_warning_game(
             DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
         )
-        game.movement_phase_duration = "24 hours"
-        game.save()
         italy.nmr_extensions_remaining = 1
         italy.save()
         phase.units.create(


### PR DESCRIPTION
## Summary

- **NMR extension deadline**: When a player used an NMR extension in a FIXED_TIME game, the new deadline was always set to `now + movement_phase_duration` (defaulting to 24h) instead of the next proper fixed-time occurrence. For a 2-day game, the extension only added 24 hours. Fixed by using `get_scheduled_resolution()` which correctly calls `calculate_next_fixed_deadline()` for FIXED_TIME games.
- **Deadline warning threshold**: `send_deadline_warnings` used `get_phase_duration_seconds()` to determine how far in advance to warn players — which returned the `movement_phase_duration` default (24h) for FIXED_TIME games regardless of actual frequency. A 2-day game was therefore warning players only 1 hour before the deadline instead of 2 hours. Fixed by adding `get_effective_phase_duration_seconds()` on `Game`, which converts `movement_frequency` to seconds for FIXED_TIME games.

## Root cause

Both bugs had the same underlying cause: `get_phase_duration_seconds()` reads from the `movement_phase_duration` field, which defaults to `TWENTY_FOUR_HOURS` and is only meaningful for DURATION-mode games. FIXED_TIME games are scheduled via `movement_frequency` + `fixed_deadline_time` + `fixed_deadline_timezone`, which `get_phase_duration_seconds()` ignores entirely.

## Test plan

- [ ] `phase/tests.py::TestNMRExtensionsFixedTime::test_fixed_time_no_orders_applies_extension` — updated to configure a 2-day FIXED_TIME game and assert the extended deadline is > 24h out
- [ ] All `TestSendDeadlineWarnings` and `TestNMRExtensionsFixedTime` tests pass
- [ ] Manual: join a FIXED_TIME game with NMR extensions enabled and verify an extension sets the deadline to the next 2-day occurrence, not +24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)