### PR TITLE
Show player's nation badge in game card and orders screen

### DIFF
--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -55,7 +55,7 @@ const renderGameCard = (props: React.ComponentProps<typeof GameCard>) => {
 };
 
 const defaultProps = {
-  variant: { name: "Classical Diplomacy", id: "Classical" },
+  variant: { name: "Classical Diplomacy", id: "Classical", nations: [] },
   phaseId: 1,
   map: <div data-testid="map" />,
 };
@@ -96,7 +96,7 @@ describe("GameCard", () => {
       mockUseIsMobile.mockReturnValue(true);
       const game = mockActiveGames[0];
       renderGameCard({ game, ...defaultProps });
-      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      await userEvent.click(screen.getByRole("button", { name: new RegExp(game.name) }));
       expect(mockNavigate).toHaveBeenCalledWith(
         `/game/${game.id}/phase/${game.currentPhaseId}`
       );
@@ -106,7 +106,7 @@ describe("GameCard", () => {
       mockUseIsMobile.mockReturnValue(false);
       const game = mockActiveGames[0];
       renderGameCard({ game, ...defaultProps });
-      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      await userEvent.click(screen.getByRole("button", { name: new RegExp(game.name) }));
       expect(mockNavigate).toHaveBeenCalledWith(
         `/game/${game.id}/phase/${game.currentPhaseId}/orders`
       );

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -12,6 +12,7 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 import { GameDropdownMenu } from "./GameDropdownMenu";
+import { findNationColor } from "./NationFlag";
 import { UserPlus, Lock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -29,7 +30,7 @@ import { useCheckNotificationPermission } from "@/hooks/useCheckNotificationPerm
 
 export interface GameCardProps {
   game: GameList;
-  variant: Pick<Variant, "name" | "id">;
+  variant: Pick<Variant, "name" | "id" | "nations">;
   map: React.ReactNode;
   className?: string;
 }
@@ -39,6 +40,8 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const phase = game.currentPhase;
+  const playerNation = game.members.find(m => m.isCurrentUser)?.nation ?? null;
+  const nationColor = findNationColor(variant.nations, playerNation);
   const joinGameMutation = useGameJoinCreate();
   const checkNotificationPermission = useCheckNotificationPermission();
 
@@ -105,6 +108,11 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                   {game.name}
                   {game.sandbox && (
                     <Badge variant="secondary">Sandbox</Badge>
+                  )}
+                  {!game.sandbox && playerNation && (
+                    <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined }}>
+                      {playerNation}
+                    </Badge>
                   )}
                 </CardTitle>
               </button>

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -22,7 +22,7 @@ import {
   useGameJoinCreate,
   getGamesListQueryKey,
 } from "../api/generated/endpoints";
-import { formatTimeAgo, getGameLandingPath } from "../util";
+import { formatTimeAgo, getGameLandingPath, getContrastColor } from "../util";
 import { Skeleton } from "./ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -110,7 +110,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                     <Badge variant="secondary">Sandbox</Badge>
                   )}
                   {!game.sandbox && playerNation && (
-                    <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined }}>
+                    <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined, color: getContrastColor(nationColor) }}>
                       {playerNation}
                     </Badge>
                   )}

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -341,7 +341,7 @@ const OrdersScreen: React.FC = () => {
                   nationGroups.find(g => g.member.isCurrentUser)?.nation ?? "",
                 ]}
               >
-                {nationGroups.map(({ nation, items }) => {
+                {nationGroups.map(({ nation, member, items }) => {
                   const nationColor = findNationColor(variant.nations, nation);
                   return (
                     <AccordionItem key={nation} value={nation}>
@@ -355,6 +355,12 @@ const OrdersScreen: React.FC = () => {
                           />
                           <span>{nation}</span>
                           <span className="text-muted-foreground">•</span>
+                          {member.isCurrentUser && (
+                            <>
+                              <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined }}>you</Badge>
+                              <span className="text-muted-foreground">•</span>
+                            </>
+                          )}
                           <span className="inline-flex items-center gap-1 text-muted-foreground">
                             <Star className="size-3" />
                             <span>{getSupplyCenterCount(nation)}</span>

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -64,6 +64,7 @@ import {
   Unit,
 } from "@/api/generated/endpoints";
 import { cn } from "../../lib/utils";
+import { getContrastColor } from "../../util";
 
 type NationGroup = {
   nation: string;
@@ -357,7 +358,7 @@ const OrdersScreen: React.FC = () => {
                           <span className="text-muted-foreground">•</span>
                           {member.isCurrentUser && (
                             <>
-                              <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined }}>you</Badge>
+                              <Badge className="leading-none" style={{ backgroundColor: nationColor ?? undefined, color: getContrastColor(nationColor) }}>you</Badge>
                               <span className="text-muted-foreground">•</span>
                             </>
                           )}

--- a/packages/web/src/util.ts
+++ b/packages/web/src/util.ts
@@ -191,4 +191,14 @@ function formatTimeAgo(djangoDatetime: string): string {
   return rtf.format(-diffYears, "year");
 }
 
-export { formatOrderText, formatDateTime, formatRemainingTime, formatTimeAgo, getCurrentPhaseId, getGameLandingPath };
+function getContrastColor(hexColor: string | null): string {
+  if (!hexColor) return "#ffffff";
+  const hex = hexColor.replace("#", "");
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "#000000" : "#ffffff";
+}
+
+export { formatOrderText, formatDateTime, formatRemainingTime, formatTimeAgo, getCurrentPhaseId, getGameLandingPath, getContrastColor };


### PR DESCRIPTION
## Summary

- Adds a coloured nation pill to the game card title (next to the game name), showing which nation the current player is assigned — hidden for sandbox and pending/forming games where no nation has been assigned yet
- Adds the same pill to the orders screen accordion header (`Germany • [you badge] • ☆ 3`), only on the current player's nation row

## Test plan

- [ ] Active game card shows a nation-coloured pill with the player's nation name next to the game title
- [ ] Sandbox game card shows no nation pill (Sandbox badge only)
- [ ] Pending/forming game card shows no nation pill (nation is null)
- [ ] Orders screen shows the "you" pill between the nation name and the supply centre count, on the current player's row only
- [ ] All GameCard tests pass (`npm run test GameCard.test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)