### PR TITLE
Add orders_outcome field to PhaseState for NMR analytics

### DIFF
--- a/service/phase/migrations/0014_phasestate_orders_outcome.py
+++ b/service/phase/migrations/0014_phasestate_orders_outcome.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('phase', '0013_phasestate_deadline_warning_sent_for'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='phasestate',
+            name='orders_outcome',
+            field=models.CharField(
+                blank=True,
+                choices=[('received', 'Received'), ('nmr', 'Nmr')],
+                default=None,
+                max_length=8,
+                null=True,
+            ),
+        ),
+    ]

--- a/service/phase/migrations/0015_backfill_orders_outcome.py
+++ b/service/phase/migrations/0015_backfill_orders_outcome.py
@@ -1,0 +1,44 @@
+from django.db import migrations
+from django.db.models import Count
+
+
+def backfill_orders_outcome(apps, schema_editor):
+    PhaseState = apps.get_model("phase", "PhaseState")
+
+    base_qs = PhaseState.objects.filter(
+        phase__status="completed",
+        has_possible_orders=True,
+    ).annotate(order_count=Count("orders"))
+
+    CHUNK = 1000
+    for outcome, qs in [
+        ("received", base_qs.filter(order_count__gt=0)),
+        ("nmr", base_qs.filter(order_count=0)),
+    ]:
+        ids = []
+        for ps_id in qs.values_list("id", flat=True).iterator():
+            ids.append(ps_id)
+            if len(ids) >= CHUNK:
+                PhaseState.objects.filter(id__in=ids).update(orders_outcome=outcome)
+                ids = []
+        if ids:
+            PhaseState.objects.filter(id__in=ids).update(orders_outcome=outcome)
+
+
+def reverse_backfill(apps, schema_editor):
+    PhaseState = apps.get_model("phase", "PhaseState")
+    PhaseState.objects.update(orders_outcome=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('phase', '0014_phasestate_orders_outcome'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_orders_outcome,
+            reverse_backfill,
+        ),
+    ]

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -373,6 +373,23 @@ class PhaseManager(models.Manager):
 
             return {"notifications_sent": notifications_sent}
 
+    def _set_orders_outcome(self, phase):
+        base_qs = phase.phase_states.filter(
+            has_possible_orders=True
+        ).annotate(order_count=Count("orders"))
+
+        received_ids = list(base_qs.filter(order_count__gt=0).values_list("id", flat=True))
+        nmr_ids = list(base_qs.filter(order_count=0).values_list("id", flat=True))
+
+        if received_ids:
+            PhaseState.objects.filter(id__in=received_ids).update(
+                orders_outcome=PhaseState.OrdersOutcome.RECEIVED
+            )
+        if nmr_ids:
+            PhaseState.objects.filter(id__in=nmr_ids).update(
+                orders_outcome=PhaseState.OrdersOutcome.NMR
+            )
+
     def _check_civil_disorder(self, phase):
         if phase.game.sandbox:
             return []
@@ -510,6 +527,7 @@ class PhaseManager(models.Manager):
             with tracer.start_as_current_span("phase.transaction_atomic"):
                 with transaction.atomic():
                     self._check_civil_disorder(phase)
+                    self._set_orders_outcome(phase)
                     new_phase = self.create_from_adjudication_data(phase, adjudication_data)
                     self._check_eliminations(phase, new_phase)
 
@@ -861,12 +879,19 @@ class Phase(BaseModel):
 
 
 class PhaseState(BaseModel):
+    class OrdersOutcome(models.TextChoices):
+        RECEIVED = "received"
+        NMR = "nmr"
+
     member = models.ForeignKey("member.Member", on_delete=models.CASCADE, related_name="phase_states")
     phase = models.ForeignKey(Phase, on_delete=models.CASCADE, related_name="phase_states")
     orders_confirmed = models.BooleanField(default=False)
     eliminated = models.BooleanField(default=False)
     has_possible_orders = models.BooleanField(default=False)
     deadline_warning_sent_for = models.DateTimeField(null=True, blank=True)
+    orders_outcome = models.CharField(
+        max_length=8, choices=OrdersOutcome, null=True, blank=True, default=None
+    )
 
     def __str__(self):
         username = self.member.user.username if self.member.user else "Deleted User"

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3203,6 +3203,127 @@ class TestCivilDisorderDetection:
         mock_send_notification_to_users.assert_not_called()
 
 
+class TestSetOrdersOutcome:
+
+    def _setup_phase(self, variant, italy_nation, germany_nation, primary_user, secondary_user):
+        game = Game.objects.create(
+            variant=variant,
+            name="Orders Outcome Test",
+            status=GameStatus.ACTIVE,
+        )
+        italy = Member.objects.create(nation=italy_nation, user=primary_user, game=game)
+        germany = Member.objects.create(nation=germany_nation, user=secondary_user, game=game)
+        phase = Phase.objects.create(
+            game=game,
+            variant=variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+        )
+        return phase, italy, germany
+
+    @pytest.mark.django_db
+    def test_no_possible_orders_stays_null(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=False)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome is None
+
+    @pytest.mark.django_db
+    def test_orders_submitted_gets_received(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+        ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome == PhaseState.OrdersOutcome.RECEIVED
+
+    @pytest.mark.django_db
+    def test_no_orders_gets_nmr(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome == PhaseState.OrdersOutcome.NMR
+
+    @pytest.mark.django_db
+    def test_civil_disorder_member_with_no_orders_gets_nmr(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+    ):
+        """Civil disorder auto-sets orders_confirmed=True, but outcome must still be nmr."""
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+        italy.civil_disorder = True
+        italy.save()
+        ps = phase.phase_states.create(
+            member=italy, has_possible_orders=True, orders_confirmed=True
+        )
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome == PhaseState.OrdersOutcome.NMR
+
+
 class TestCivilDisorderAutoConfirm:
 
     @pytest.mark.django_db


### PR DESCRIPTION
`orders_confirmed` cannot be used to identify NMRs after the fact. Unconfirmed orders are still adjudicated (overcounting), and civil disorder auto-sets `orders_confirmed=True` on all subsequent phases (undercounting NMRs for exactly the players who NMR most).

This adds `orders_outcome` to `PhaseState`, written once at resolution time and never mutated:

- `null` — seat had no possible orders (`has_possible_orders=False`); excluded from NMR rate queries
- `'received'` — had possible orders and submitted at least one
- `'nmr'` — had possible orders and submitted none

The value is determined from actual `order_order` rows, which is the same mechanism already used by `_check_civil_disorder` and the FIXED_TIME path of `_check_and_apply_nmr_extensions`. No discrepancy.

The backfill migration reconstructs outcomes for all historical resolved phases from the immutable orders table, in 1000-row chunks.

<sub>Generated with [Claude Code](https://claude.ai/claude-code)</sub>