### PR TITLE
Show map preview on variant cards

### DIFF
--- a/packages/web/src/components/MapPreview.tsx
+++ b/packages/web/src/components/MapPreview.tsx
@@ -14,6 +14,7 @@ type VariantForPreview = Pick<Variant, "nations" | "svgUrl">;
 type MapPreviewProps = {
   variant: VariantForPreview;
   phase: PhaseRetrieve | VariantTemplatePhase;
+  cover?: boolean;
   style?: React.CSSProperties;
   className?: string;
 };
@@ -21,6 +22,7 @@ type MapPreviewProps = {
 const MapPreview: React.FC<MapPreviewProps> = ({
   variant,
   phase,
+  cover = false,
   style,
   className,
 }) => {
@@ -29,8 +31,15 @@ const MapPreview: React.FC<MapPreviewProps> = ({
   const svg = useMemo(() => {
     if (!dsvg) return null;
     const renderState = toRenderState(variant, phase, [], [], []);
-    return new DiplicityMap(dsvg).render(renderState);
-  }, [dsvg, variant, phase]);
+    const rendered = new DiplicityMap(dsvg).render(renderState);
+    if (cover) {
+      return rendered.replace(
+        "<svg ",
+        '<svg preserveAspectRatio="xMidYMid slice" width="100%" height="100%" '
+      );
+    }
+    return rendered;
+  }, [dsvg, variant, phase, cover]);
 
   if (!svg) {
     return <Skeleton className={className} style={style} />;

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -27,6 +27,7 @@ import {
   getVariantsListQueryKey,
   Variant,
 } from "@/api/generated/endpoints";
+import { MapPreview } from "@/components/MapPreview";
 import axiosInstance from "@/api/axiosInstance";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -96,65 +97,76 @@ const VariantRow: React.FC<VariantRowProps> = ({
 }) => {
   const navigate = useNavigate();
   return (
-    <div className="flex flex-col gap-2 border rounded-lg p-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="font-semibold">{variant.name}</h3>
-            <Badge variant={statusVariant[variant.status] ?? "outline"}>
-              {statusLabel[variant.status] ?? variant.status}
-            </Badge>
+    <div className="border rounded-lg overflow-hidden">
+      <div className="flex flex-col sm:flex-row">
+        {variant.svgUrl && (
+          <div className="sm:w-44 flex-shrink-0">
+            <MapPreview
+              variant={variant}
+              phase={variant.templatePhase}
+              className="w-full aspect-video sm:aspect-auto sm:h-full"
+            />
           </div>
-          <p className="text-xs text-muted-foreground">
-            id: {variant.id}
-            {variant.ownerUsername ? ` · owner: ${variant.ownerUsername}` : ""}
-          </p>
-          {variant.description && (
-            <p className="text-sm text-muted-foreground">{variant.description}</p>
-          )}
-        </div>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => downloadDvar(variant.id)}
-        >
-          <Download className="size-4" /> DVAR
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => downloadDsvg(variant)}
-        >
-          <Download className="size-4" /> DSVG
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onCreateSandbox(variant)}
-          disabled={isCreatingSandbox}
-        >
-          <Play className="size-4" /> Sandbox
-        </Button>
-        {variant.canEdit && (
-          <>
+        )}
+        <div className="flex flex-col gap-2 p-4 flex-1 min-w-0">
+          <div className="space-y-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="font-semibold">{variant.name}</h3>
+              <Badge variant={statusVariant[variant.status] ?? "outline"}>
+                {statusLabel[variant.status] ?? variant.status}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              id: {variant.id}
+              {variant.ownerUsername ? ` · owner: ${variant.ownerUsername}` : ""}
+            </p>
+            {variant.description && (
+              <p className="text-sm text-muted-foreground">{variant.description}</p>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => navigate(`/variants/${variant.id}/edit`)}
+              onClick={() => downloadDvar(variant.id)}
             >
-              <Pencil className="size-4" /> Edit
+              <Download className="size-4" /> DVAR
             </Button>
             <Button
-              variant="destructive"
+              variant="outline"
               size="sm"
-              onClick={() => onDelete(variant.id)}
+              onClick={() => downloadDsvg(variant)}
             >
-              <Trash2 className="size-4" /> Delete
+              <Download className="size-4" /> DSVG
             </Button>
-          </>
-        )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onCreateSandbox(variant)}
+              disabled={isCreatingSandbox}
+            >
+              <Play className="size-4" /> Sandbox
+            </Button>
+            {variant.canEdit && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigate(`/variants/${variant.id}/edit`)}
+                >
+                  <Pencil className="size-4" /> Edit
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onDelete(variant.id)}
+                >
+                  <Trash2 className="size-4" /> Delete
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -98,17 +98,18 @@ const VariantRow: React.FC<VariantRowProps> = ({
   const navigate = useNavigate();
   return (
     <div className="border rounded-lg overflow-hidden">
-      <div className="flex flex-col sm:flex-row">
+      <div className="flex flex-col sm:flex-row sm:h-44">
         {variant.svgUrl && (
-          <div className="sm:w-44 flex-shrink-0">
+          <div className="sm:w-44 flex-shrink-0 overflow-hidden">
             <MapPreview
               variant={variant}
               phase={variant.templatePhase}
+              cover
               className="w-full aspect-video sm:aspect-auto sm:h-full"
             />
           </div>
         )}
-        <div className="flex flex-col gap-2 p-4 flex-1 min-w-0">
+        <div className="flex flex-col gap-2 p-4 flex-1 min-w-0 overflow-hidden">
           <div className="space-y-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h3 className="font-semibold">{variant.name}</h3>
@@ -121,7 +122,7 @@ const VariantRow: React.FC<VariantRowProps> = ({
               {variant.ownerUsername ? ` · owner: ${variant.ownerUsername}` : ""}
             </p>
             {variant.description && (
-              <p className="text-sm text-muted-foreground">{variant.description}</p>
+              <p className="text-sm text-muted-foreground line-clamp-2">{variant.description}</p>
             )}
           </div>
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
Variant cards on the variants list now show a map preview. On mobile the preview spans the full card width above the content; on larger screens it sits to the left as a fixed-width column.

Variants without an SVG render without the preview section.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>