### PR TITLE
Fix Civil Disorder units not auto-disbanding in Retreat phases

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Diplicity React - Release Notes
 
+## Civil Disorder Retreat Fix (June 5, 2026)
+
+**Release Date:** June 5, 2026
+
+### Fix: Civil Disorder units now automatically disband during Retreat phases
+
+Units belonging to a nation in Civil Disorder are now automatically disbanded when a
+Retreat phase begins. Previously, games with a Civil Disorder player could stall waiting
+for a manual resolution step. The game now advances immediately to the next interactive
+phase without requiring any action.
+
 ## Sign in with Apple on the Web (June 2, 2026)
 
 **Release Date:** June 2, 2026

--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -73,6 +73,23 @@ def start(phase) -> Dict[str, Any]:
         }
 
 
+def _should_skip(options, units, cd_nations, nation_name_by_id):
+    if not options:
+        return True
+    if not cd_nations:
+        return False
+    location_to_nation = {
+        u.location: nation_name_by_id.get(u.nation, u.nation)
+        for u in units
+    }
+    option_nations = {
+        location_to_nation[opt.source]
+        for opt in options
+        if opt.source is not None and opt.source in location_to_nation
+    }
+    return bool(option_nations) and option_nations.issubset(cd_nations)
+
+
 def resolve(phase) -> Dict[str, Any]:
     logger.info(f"Resolving phase {phase.id} of game {phase.game.id}")
     with tracer.start_as_current_span("adjudication.resolve") as span:
@@ -81,23 +98,29 @@ def resolve(phase) -> Dict[str, Any]:
         span.set_attribute("variant.id", phase.variant.id)
 
         state, variant = _build_state(phase)
+        nation_name_by_id = {nation.id: nation.name for nation in variant.nations}
+        cd_nations = set(
+            phase.game.members
+            .filter(civil_disorder=True)
+            .values_list("nation__name", flat=True)
+        )
+
         states = Engine().adjudicate(state)
         resolved = states[0]
         next_state = states[1] if len(states) > 1 else resolved
 
         # Advance through phases nobody can act in (empty retreat / empty
-        # adjustment) so we land on the next phase that needs player input.
+        # adjustment, or retreat where every retreating nation is in Civil
+        # Disorder) so we land on the next phase that needs player input.
         # Engine.adjudicate advances one phase per call and keeps phase
         # skipping out of scope by contract, so skipping is orchestrated
         # here. Skipped phases are never persisted -- only the final
         # interactive phase is written by create_from_adjudication_data.
         next_options = get_options(next_state) if len(states) > 1 else []
-        while len(states) > 1 and not next_options:
+        while len(states) > 1 and _should_skip(next_options, next_state.units, cd_nations, nation_name_by_id):
             states = Engine().adjudicate(next_state)
             next_state = states[1] if len(states) > 1 else states[0]
             next_options = get_options(next_state) if len(states) > 1 else []
-
-        nation_name_by_id = {nation.id: nation.name for nation in variant.nations}
 
         if len(states) > 1:
             godip_options = python_options_to_godip_dict(

--- a/service/adjudication/tests.py
+++ b/service/adjudication/tests.py
@@ -901,6 +901,50 @@ class TestAdjudicationService:
         )
 
 
+    @pytest.mark.django_db
+    def test_resolve_cd_retreat_phase_is_skipped(
+        self,
+        phase_spring_1901_movement,
+        member_italy,
+        member_germany,
+    ):
+        """
+        When the only nation with retreat orders is in Civil Disorder, the
+        Retreat phase is skipped: resolve() returns the next interactive
+        phase (Fall Movement) and the dislodged unit is removed from the board.
+
+        Italian Army Berlin moves to Kiel (supported by Munich).
+        German Fleet Kiel holds — dislodged, but Germany is in Civil Disorder.
+        """
+        member_germany.civil_disorder = True
+        member_germany.save()
+
+        phase_state_italy = phase_spring_1901_movement.phase_states.create(member=member_italy)
+        phase_state_germany = phase_spring_1901_movement.phase_states.create(member=member_germany)
+
+        create_supply_center(phase_state_italy, "ber")
+        create_supply_center(phase_state_italy, "mun")
+        create_supply_center(phase_state_germany, "kie")
+
+        create_unit(phase_state_italy, "ber", "Army")
+        create_unit(phase_state_italy, "mun", "Army")
+        create_unit(phase_state_germany, "kie", "Fleet")
+
+        create_order(phase_state_italy, "ber", OrderType.MOVE, "kie")
+        create_order(phase_state_italy, "mun", OrderType.SUPPORT, "kie", "ber")
+
+        data = adjudication_service.resolve(phase_spring_1901_movement)
+
+        assert data["year"] == 1901
+        assert data["season"] == "Fall"
+        assert data["type"] == "Movement"
+
+        # The dislodged German fleet was disbanded automatically — no Germany
+        # units remain on the board going into Fall Movement.
+        germany_units = [u for u in data["units"] if u["nation"] == "Germany"]
+        assert germany_units == []
+
+
 class TestUserUploadedVariant:
     """Regression: prior to dropping the godip HTTP adjudicator, creating a
     sandbox game with a freshly-uploaded variant (any id godip doesn't ship

--- a/service/integration/tests.py
+++ b/service/integration/tests.py
@@ -15,9 +15,13 @@ from common.constants import (
     NationAssignment,
     OrderCreationStep,
     OrderResolutionStatus,
+    OrderType,
     PhaseStatus,
     UnitType,
 )
+from phase.models import Phase
+from supply_center.models import SupplyCenter
+from unit.models import Unit
 
 resolve_all_url = reverse("phase-resolve-all")
 
@@ -753,6 +757,76 @@ def test_empty_adjustment_phase_is_skipped(
 
     assert not active_game.phases.filter(year=1901, type="Retreat").exists()
     assert not active_game.phases.filter(year=1901, type="Adjustment").exists()
+
+
+@pytest.mark.django_db
+def test_cd_only_retreat_phase_is_skipped(
+    authenticated_client,
+    authenticated_client_for_secondary_user,
+    italy_vs_germany_variant,
+    primary_user,
+    secondary_user,
+    mock_send_notification_to_users,
+    mock_immediate_on_commit,
+):
+    """When the only nation with retreat orders is in Civil Disorder, the
+    Retreat phase is never persisted. After a Spring 1901 Movement where
+    Italy dislodges Germany's fleet and Germany is in Civil Disorder, the
+    game advances directly to Fall 1901 Movement."""
+    active_game = create_active_game(
+        authenticated_client, authenticated_client_for_secondary_user, italy_vs_germany_variant
+    )
+    phase = active_game.current_phase
+
+    germany_member = active_game.members.get(user=primary_user)
+    italy_member = active_game.members.get(user=secondary_user)
+    germany_nation = germany_member.nation
+    italy_nation = italy_member.nation
+
+    variant = phase.variant
+    ber = variant.provinces.get(province_id="ber")
+    mun = variant.provinces.get(province_id="mun")
+    kie = variant.provinces.get(province_id="kie")
+
+    # Replace the initial units with a conflict scenario:
+    # Italy at Berlin + Munich attacks Kiel; Germany fleet holds Kiel.
+    phase.units.all().delete()
+    Unit.objects.create(phase=phase, nation=italy_nation, type=UnitType.ARMY, province=ber)
+    Unit.objects.create(phase=phase, nation=italy_nation, type=UnitType.ARMY, province=mun)
+    Unit.objects.create(phase=phase, nation=germany_nation, type=UnitType.FLEET, province=kie)
+
+    phase.supply_centers.all().delete()
+    SupplyCenter.objects.create(phase=phase, nation=italy_nation, province=ber)
+    SupplyCenter.objects.create(phase=phase, nation=italy_nation, province=mun)
+    SupplyCenter.objects.create(phase=phase, nation=germany_nation, province=kie)
+
+    # Italy attacks Kiel from Berlin, supported by Munich.
+    italy_ps = phase.phase_states.get(member=italy_member)
+    italy_ps.orders.create(source=ber, order_type=OrderType.MOVE, target=kie)
+    italy_ps.orders.create(source=mun, order_type=OrderType.SUPPORT, target=kie, aux=ber)
+
+    # Germany is in Civil Disorder — no orders, confirmed automatically.
+    germany_member.civil_disorder = True
+    germany_member.save()
+
+    # Confirm both sides so filter_due_phases picks up the phase.
+    italy_ps.orders_confirmed = True
+    italy_ps.save()
+    germany_ps = phase.phase_states.get(member=germany_member)
+    germany_ps.orders_confirmed = True
+    germany_ps.save()
+
+    Phase.objects.resolve(phase)
+
+    # Landed directly on Fall 1901 Movement — no Retreat phase persisted.
+    new_phase = active_game.current_phase
+    assert new_phase.season == "Fall"
+    assert new_phase.year == 1901
+    assert new_phase.type == "Movement"
+    assert not active_game.phases.filter(type="Retreat").exists()
+
+    # Germany's dislodged fleet was auto-disbanded; no Germany units remain.
+    assert not new_phase.units.filter(nation=germany_nation).exists()
 
 
 def create_active_hundred_game(

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -505,11 +505,11 @@ class PhaseManager(models.Manager):
             if extension_members:
                 return phase
 
+            self._check_civil_disorder(phase)
             adjudication_data = resolve(phase)
 
             with tracer.start_as_current_span("phase.transaction_atomic"):
                 with transaction.atomic():
-                    self._check_civil_disorder(phase)
                     new_phase = self.create_from_adjudication_data(phase, adjudication_data)
                     self._check_eliminations(phase, new_phase)
 


### PR DESCRIPTION
Fixes #568.

When all nations with possible retreat orders are in Civil Disorder, the Retreat phase is now skipped entirely rather than being persisted and waiting for a resolution trigger. The adjudicator runs on the phase with no orders (auto-disbanding all CD units via the existing default `DisbandOrder` behaviour), and the game advances directly to the next interactive phase.

The fix extends the phase-skipping loop in `adjudication/service.py` — the same loop that already skips empty Retreat and Adjustment phases — to also skip when every nation with options is in Civil Disorder. This is consistent with the existing "skip phases where no user interaction is required" pattern.

`_check_civil_disorder` is also moved to run before adjudication (previously it ran inside the transaction after adjudication returned) so players entering CD for the first time in the current resolution cycle are covered immediately rather than from the next cycle onward.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>