### PR TITLE
Add non_playable flag to Nation for neutral unit support

### DIFF
--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -73,10 +73,15 @@ def start(phase) -> Dict[str, Any]:
         }
 
 
-def _should_skip(options, units, cd_nations, nation_name_by_id):
+def _should_skip(options, units, skip_nations, nation_name_by_id):
+    """Return True if the phase can be skipped — no human input is needed.
+
+    A phase is skippable when it has no options at all, or when every nation
+    with options is in `skip_nations` (civil disorder or non-playable).
+    """
     if not options:
         return True
-    if not cd_nations:
+    if not skip_nations:
         return False
     location_to_nation = {
         u.location: nation_name_by_id.get(u.nation, u.nation)
@@ -87,7 +92,7 @@ def _should_skip(options, units, cd_nations, nation_name_by_id):
         for opt in options
         if opt.source is not None and opt.source in location_to_nation
     }
-    return bool(option_nations) and option_nations.issubset(cd_nations)
+    return bool(option_nations) and option_nations.issubset(skip_nations)
 
 
 def resolve(phase) -> Dict[str, Any]:
@@ -104,6 +109,8 @@ def resolve(phase) -> Dict[str, Any]:
             .filter(civil_disorder=True)
             .values_list("nation__name", flat=True)
         )
+        non_playable_nations = {n.name for n in variant.nations if n.non_playable}
+        skip_nations = cd_nations | non_playable_nations
 
         states = Engine().adjudicate(state)
         resolved = states[0]
@@ -117,7 +124,7 @@ def resolve(phase) -> Dict[str, Any]:
         # here. Skipped phases are never persisted -- only the final
         # interactive phase is written by create_from_adjudication_data.
         next_options = get_options(next_state) if len(states) > 1 else []
-        while len(states) > 1 and _should_skip(next_options, next_state.units, cd_nations, nation_name_by_id):
+        while len(states) > 1 and _should_skip(next_options, next_state.units, skip_nations, nation_name_by_id):
             states = Engine().adjudicate(next_state)
             next_state = states[1] if len(states) > 1 else states[0]
             next_options = get_options(next_state) if len(states) > 1 else []

--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -52,6 +52,7 @@ class Nation:
     id: str
     name: str
     color: str
+    non_playable: bool = False
 
 
 @dataclass(frozen=True)

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -128,7 +128,8 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
     _validate_against_schema(data)
 
     nations = tuple(
-        Nation(id=n["id"], name=n["name"], color=n["color"]) for n in data["nations"]
+        Nation(id=n["id"], name=n["name"], color=n["color"], non_playable=n.get("non_playable", False))
+        for n in data["nations"]
     )
 
     provinces: Dict[str, Province] = {}

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -1056,10 +1056,20 @@ class NationView:
         )
 
     def allowed_builds(self) -> int:
+        if self._is_non_playable():
+            return 0
         return max(0, len(self.owned_supply_centers()) - self.standing_unit_count())
 
     def required_disbands(self) -> int:
+        if self._is_non_playable():
+            return 0
         return max(0, self.standing_unit_count() - len(self.owned_supply_centers()))
+
+    def _is_non_playable(self) -> bool:
+        for nation in self._state.variant.nations:
+            if nation.id == self._nation:
+                return nation.non_playable
+        return False
 
     def civil_disorder_ranking(self) -> Tuple[Unit, ...]:
         """Units of this nation ordered for civil-disorder selection:

--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -89,7 +89,7 @@ class IsSpaceAvailable(BasePermission):
 
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
-        return game.members.count() < game.variant.nations.count()
+        return game.members.count() < game.variant.nations.filter(non_playable=False).count()
 
 
 class IsCurrentPhaseActive(BasePermission):

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -224,7 +224,7 @@ class GameManager(models.Manager):
         with transaction.atomic():
             game = self.create_from_template(variant, name=name, **kwargs)
 
-            nations_list = list(variant.nations.all())
+            nations_list = list(variant.nations.filter(non_playable=False))
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 
@@ -476,7 +476,7 @@ class Game(BaseModel):
             # Use prefetched nations if available, otherwise fetch
             # variant.nations.all() is already prefetched via with_game_creation_data()
             # Accessing .all() on a prefetched queryset doesn't trigger a new query
-            nations = list(self.variant.nations.all())
+            nations = list(self.variant.nations.filter(non_playable=False))
 
             if self.nation_assignment == NationAssignment.RANDOM:
                 import random

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -402,7 +402,7 @@ class GameCloneToSandboxSerializer(serializers.Serializer):
                 name=f"{source_game.name} (Sandbox)",
             )
 
-            nations_list = list(source_game.variant.nations.all())
+            nations_list = list(source_game.variant.nations.filter(non_playable=False))
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -20,7 +20,7 @@ class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
 
     def perform_create(self, serializer):
         member = serializer.save()
-        if member.game.variant.nations.count() == member.game.members.count():
+        if member.game.variant.nations.filter(non_playable=False).count() == member.game.members.count():
             member.game.start()
 
 

--- a/service/nation/migrations/0012_add_non_playable.py
+++ b/service/nation/migrations/0012_add_non_playable.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nation", "0011_backfill_bundled_flags"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nation",
+            name="non_playable",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/service/nation/models.py
+++ b/service/nation/models.py
@@ -9,6 +9,7 @@ class Nation(models.Model):
     nation_id = models.CharField(max_length=50)
     name = models.CharField(max_length=50)
     color = models.CharField(max_length=7)
+    non_playable = models.BooleanField(default=False)
     variant = models.ForeignKey("variant.Variant", on_delete=models.CASCADE, related_name="nations")
 
     class Meta:

--- a/service/nation/serializers.py
+++ b/service/nation/serializers.py
@@ -10,6 +10,7 @@ class NationSerializer(serializers.Serializer):
     nation_id = serializers.CharField()
     name = serializers.CharField()
     color = serializers.CharField()
+    non_playable = serializers.BooleanField()
     flag_url = serializers.SerializerMethodField()
 
     def get_flag_url(self, nation) -> Optional[str]:

--- a/service/variant.schema.yaml
+++ b/service/variant.schema.yaml
@@ -182,6 +182,15 @@ properties:
             ownership marker, and chat badge.
           examples:
             - "#F44336"
+        non_playable:
+          type: boolean
+          default: false
+          description: |
+            If true, no human player controls this nation. Its units hold
+            automatically every turn and are disbanded immediately if
+            dislodged. Non-playable nations must have as many units as
+            supply centers they own in initialState so the adjustment
+            phase stays balanced.
 
   provinces:
     type: array

--- a/service/variant/utils.py
+++ b/service/variant/utils.py
@@ -211,7 +211,7 @@ def variant_to_canonical_dict(variant):
         "adjudicationModifiers": variant.adjudication_modifiers,
         "phaseProgression": variant.phase_progression,
         "nations": [
-            {"id": nation.nation_id, "name": nation.name, "color": nation.color}
+            {"id": nation.nation_id, "name": nation.name, "color": nation.color, "non_playable": nation.non_playable}
             for nation in nations
         ],
         "provinces": canonical_provinces,
@@ -983,6 +983,7 @@ def apply_safe_replacement(variant, dvar, dsvg_text):
         nation = nation_by_id[payload["id"]]
         nation.name = payload["name"]
         nation.color = payload["color"]
+        nation.non_playable = payload.get("non_playable", False)
         nation.save()
     nation_by_id = {nation.nation_id: nation for nation in variant.nations.all()}
 
@@ -1067,6 +1068,7 @@ def _build_variant_children(variant, dvar):
             nation_id=nation["id"],
             name=nation["name"],
             color=nation["color"],
+            non_playable=nation.get("non_playable", False),
         )
         for nation in dvar["nations"]
     ]


### PR DESCRIPTION
Adds a `non_playable` boolean to `Nation` so variants can declare nations whose units hold automatically, are disbanded immediately if dislodged, and are never assigned to human players (e.g. the Neutral garrison units in Sengoku).

The flag defaults to `false` so all existing variants are unaffected.

**Adjudicator**

- `NationView.allowed_builds()` and `required_disbands()` return 0 for non-playable nations, preventing the civil-disorder reducer from auto-disbanding neutral units in the Adjustment phase.
- The phase-skip loop in `adjudication/service.py` now ignores options belonging to non-playable nations. A Retreat phase where only a neutral unit is dislodged is auto-adjudicated (neutral disbands by default) rather than persisted and waiting for a timer.

**Django game flow**

All five places that count or zip nations to members now filter with `.filter(non_playable=False)`:
- `Game.start()` — nation assignment zip
- `GameManager.create_sandbox` — member creation
- `GameCloneToSandboxSerializer` — clone member creation
- `IsSpaceAvailable` permission — join gate
- `MemberCreateView.perform_create` — game-start trigger

**API**

`non_playable` is exposed in `NationSerializer` so the frontend can correctly count player slots and distinguish neutral nations in the UI.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>