### PR TITLE
Allow empty list for adjudication_modifiers and dominance_rules in admin

### DIFF
--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -101,10 +101,10 @@ class Variant(BaseModel):
     description = models.TextField()
     author = models.CharField(max_length=200, blank=True)
     victory_conditions = models.JSONField(default=default_victory_conditions)
-    adjudication_modifiers = models.JSONField(default=list)
+    adjudication_modifiers = models.JSONField(default=list, blank=True)
     phase_progression = models.JSONField(default=default_phase_progression)
     rules = models.TextField(blank=True, default="")
-    dominance_rules = models.JSONField(default=list)
+    dominance_rules = models.JSONField(default=list, blank=True)
     status = models.CharField(
         max_length=20,
         choices=VariantStatus.STATUS_CHOICES,


### PR DESCRIPTION
`adjudication_modifiers` and `dominance_rules` are `JSONField(default=list)`, but without `blank=True` Django's form validation rejects an empty array (`[]`) as a required field. This caused a \"This field is required\" error when saving a variant in the Django admin with either field set to `[]`.

Added `blank=True` to both fields. No migration needed — `blank` is form-level only, not a database constraint.

<sub>Generated with [Claude Code](https://claude.ai/claude-code)</sub>