### PR TITLE
Allow private games to be created from draft variants

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - diplicity-network
     depends_on:
       - db
+      - service
 
   worker:
     container_name: diplicity-worker

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/packages/web/src/components/HomeLayout.tsx
+++ b/packages/web/src/components/HomeLayout.tsx
@@ -23,7 +23,7 @@ const navigationItems = [
   { label: "My Games", icon: Home, path: "/" },
   { label: "Find Games", icon: Search, path: "/find-games" },
   { label: "Create Game", icon: PlusCircle, path: "/create-game" },
-  { label: "Community", icon: MessageCircle, path: "/community", badge: "New" },
+  { label: "Community", icon: MessageCircle, path: "/community" },
 ];
 
 interface HomeLayoutProps {

--- a/packages/web/src/screens/Home/Community.tsx
+++ b/packages/web/src/screens/Home/Community.tsx
@@ -39,19 +39,13 @@ const GitHubIcon: React.FC<{ className?: string }> = ({ className }) => (
   </svg>
 );
 
+const openDiscord = () => window.open(DISCORD_URL, "_blank", "noopener,noreferrer");
+const openVariantCreator = () =>
+  window.open(VARIANT_CREATOR_URL, "_blank", "noopener,noreferrer");
+const openDiscussions = () =>
+  window.open(GITHUB_DISCUSSIONS_URL, "_blank", "noopener,noreferrer");
+
 const Community: React.FC = () => {
-  const handleOpenVariantCreator = () => {
-    window.open(VARIANT_CREATOR_URL, "_blank", "noopener,noreferrer");
-  };
-
-  const handleOpenDiscord = () => {
-    window.open(DISCORD_URL, "_blank", "noopener,noreferrer");
-  };
-
-  const handleOpenDiscussions = () => {
-    window.open(GITHUB_DISCUSSIONS_URL, "_blank", "noopener,noreferrer");
-  };
-
   return (
     <div className="space-y-4">
       <ScreenCard>
@@ -66,7 +60,7 @@ const Community: React.FC = () => {
             the game or a seasoned veteran, there's a place for you — and you
             can chat directly with the developers.
           </p>
-          <Button onClick={handleOpenDiscord} className="w-full">
+          <Button onClick={openDiscord} className="w-full">
             <ExternalLink className="size-4" />
             Open Discord
           </Button>
@@ -87,7 +81,7 @@ const Community: React.FC = () => {
             strongly advised to join the Discord so you can get guidance and
             help.
           </p>
-          <Button onClick={handleOpenVariantCreator} className="w-full">
+          <Button onClick={openVariantCreator} className="w-full">
             <ExternalLink className="size-4" />
             Open Variant Creator
           </Button>
@@ -108,7 +102,7 @@ const Community: React.FC = () => {
             report and suggestion genuinely helps. You can also browse the code
             and contribute directly, or with our help.
           </p>
-          <Button onClick={handleOpenDiscussions} className="w-full">
+          <Button onClick={openDiscussions} className="w-full">
             <ExternalLink className="size-4" />
             Open GitHub Discussions
           </Button>

--- a/packages/web/src/screens/Home/Community.tsx
+++ b/packages/web/src/screens/Home/Community.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Map } from "lucide-react";
 
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { Button } from "@/components/ui/button";
+
+const VARIANT_CREATOR_URL = "https://variantcreator.diplicity.com";
 
 const DISCORD_URL = "https://discord.gg/2TkZbBRPW";
 
@@ -38,6 +40,10 @@ const GitHubIcon: React.FC<{ className?: string }> = ({ className }) => (
 );
 
 const Community: React.FC = () => {
+  const handleOpenVariantCreator = () => {
+    window.open(VARIANT_CREATOR_URL, "_blank", "noopener,noreferrer");
+  };
+
   const handleOpenDiscord = () => {
     window.open(DISCORD_URL, "_blank", "noopener,noreferrer");
   };
@@ -63,6 +69,27 @@ const Community: React.FC = () => {
           <Button onClick={handleOpenDiscord} className="w-full">
             <ExternalLink className="size-4" />
             Open Discord
+          </Button>
+        </ScreenCardContent>
+      </ScreenCard>
+
+      <ScreenCard>
+        <ScreenCardContent className="space-y-4">
+          <div className="flex items-center gap-3">
+            <Map className="size-5" />
+            <h2 className="text-lg font-semibold">Create your own variant</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Contribute by making your own custom variant. If you know how to
+            use an image editing app, you can make a variant using the Variant
+            Creator tool. This allows you to create private games on this
+            variant, and it might be added to the official variant pool! It is
+            strongly advised to join the Discord so you can get guidance and
+            help.
+          </p>
+          <Button onClick={handleOpenVariantCreator} className="w-full">
+            <ExternalLink className="size-4" />
+            Open Variant Creator
           </Button>
         </ScreenCardContent>
       </ScreenCard>

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -245,21 +245,25 @@ interface CreateStandardGameFormProps {
   onSubmit: (data: StandardGameFormValues) => Promise<void>;
   isSubmitting: boolean;
   variants: Variant[];
+  initialVariantId?: string;
+  initialPrivate?: boolean;
 }
 
 const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
   onSubmit,
   isSubmitting,
   variants,
+  initialVariantId,
+  initialPrivate,
 }) => {
   const form = useForm<StandardGameFormValues>({
     resolver: zodResolver(standardGameSchema),
     defaultValues: {
       name: randomGameName(),
-      variantId: variants[0].id,
+      variantId: initialVariantId ?? variants[0]?.id ?? "",
       mode: "standard",
       nationAssignment: "random" as NationAssignmentEnum,
-      private: false,
+      private: initialPrivate ?? false,
       deadlineMode: "fixed_time",
       movementPhaseDuration: "24 hours",
       retreatPhaseDuration: null,
@@ -599,7 +603,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
           <VariantSelector
             control={form.control}
             name="variantId"
-            disabled={isSubmitting}
+            disabled={isSubmitting || !!initialVariantId}
             variants={variants}
             selectedVariant={selectedVariant}
           />
@@ -729,10 +733,24 @@ const CreateGame: React.FC = () => {
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const { data: allVariants } = useVariantsListSuspense();
-  const variants = React.useMemo(
+  const publishedVariants = React.useMemo(
     () => allVariants.filter(v => v.status === "published"),
     [allVariants]
   );
+
+  const initialVariantId = searchParams.get("variantId") ?? undefined;
+  const initialPrivate = searchParams.get("private") === "true";
+
+  // Support draft variants linked from the variants page
+  const initialVariant = initialVariantId
+    ? allVariants.find(v => v.id === initialVariantId)
+    : undefined;
+  const variants = React.useMemo(() => {
+    if (initialVariant && !publishedVariants.find(v => v.id === initialVariant.id)) {
+      return [initialVariant, ...publishedVariants];
+    }
+    return publishedVariants;
+  }, [publishedVariants, initialVariant]);
   const createGameMutation = useGameCreate();
   const createSandboxGameMutation = useSandboxGameCreate();
   const checkNotificationPermission = useCheckNotificationPermission();
@@ -890,6 +908,8 @@ const CreateGame: React.FC = () => {
                 onSubmit={handleStandardGameSubmit}
                 isSubmitting={createGameMutation.isPending}
                 variants={variants}
+                initialVariantId={initialVariantId}
+                initialPrivate={initialPrivate}
               />
             </ScreenCardContent>
           </ScreenCard>

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -66,6 +66,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useCheckNotificationPermission } from "@/hooks/useCheckNotificationPermission";
+import { CREATE_GAME_PARAM } from "@/utils/routes";
 
 const standardGameSchema = z.object({
   name: z
@@ -277,6 +278,9 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
 
   const selectedVariant = variants?.find(v => v.id === form.watch("variantId"));
   const deadlineMode = form.watch("deadlineMode");
+  const isInitialVariantDraft =
+    initialVariantId !== undefined &&
+    variants.find(v => v.id === initialVariantId)?.status === "draft";
 
   return (
     <Form {...form}>
@@ -338,7 +342,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                   <Checkbox
                     checked={field.value}
                     onCheckedChange={field.onChange}
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || isInitialVariantDraft}
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">
@@ -603,7 +607,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
           <VariantSelector
             control={form.control}
             name="variantId"
-            disabled={isSubmitting || !!initialVariantId}
+            disabled={isSubmitting || isInitialVariantDraft}
             variants={variants}
             selectedVariant={selectedVariant}
           />
@@ -671,7 +675,7 @@ const CreateSandboxGameForm: React.FC<CreateSandboxGameFormProps> = ({
     defaultValues: {
       sandboxGame: {
         name: randomGameName(),
-        variantId: variants[0].id,
+        variantId: variants[0]?.id ?? "",
       },
     },
   });
@@ -738,15 +742,15 @@ const CreateGame: React.FC = () => {
     [allVariants]
   );
 
-  const initialVariantId = searchParams.get("variantId") ?? undefined;
-  const initialPrivate = searchParams.get("private") === "true";
+  const initialVariantId = searchParams.get(CREATE_GAME_PARAM.variantId) ?? undefined;
+  const initialPrivate = searchParams.get(CREATE_GAME_PARAM.private) === "true";
 
-  // Support draft variants linked from the variants page
-  const initialVariant = initialVariantId
-    ? allVariants.find(v => v.id === initialVariantId)
-    : undefined;
+  const initialVariant = React.useMemo(
+    () => (initialVariantId ? allVariants.find(v => v.id === initialVariantId) : undefined),
+    [allVariants, initialVariantId]
+  );
   const variants = React.useMemo(() => {
-    if (initialVariant && !publishedVariants.find(v => v.id === initialVariant.id)) {
+    if (initialVariant && !publishedVariants.some(v => v.id === initialVariant.id)) {
       return [initialVariant, ...publishedVariants];
     }
     return publishedVariants;

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from "react";
 import { Link, useNavigate } from "react-router";
-import { Download, FilePlus, Pencil, Play, Trash2 } from "lucide-react";
+import { Download, FilePlus, Monitor, Pencil, Trash2, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { ScreenContainer } from "@/components/ui/screen-container";
@@ -86,6 +86,7 @@ interface VariantRowProps {
   variant: Variant;
   onDelete: (variantId: string) => void;
   onCreateSandbox: (variant: Variant) => void;
+  onCreatePrivateGame: (variant: Variant) => void;
   isCreatingSandbox: boolean;
 }
 
@@ -93,12 +94,13 @@ const VariantRow: React.FC<VariantRowProps> = ({
   variant,
   onDelete,
   onCreateSandbox,
+  onCreatePrivateGame,
   isCreatingSandbox,
 }) => {
   const navigate = useNavigate();
   return (
     <div className="border rounded-lg overflow-hidden">
-      <div className="flex flex-col sm:flex-row sm:h-44">
+      <div className="flex flex-col sm:flex-row sm:h-56">
         {variant.svgUrl && (
           <div className="sm:w-44 flex-shrink-0 overflow-hidden">
             <MapPreview
@@ -125,47 +127,58 @@ const VariantRow: React.FC<VariantRowProps> = ({
               <p className="text-sm text-muted-foreground line-clamp-2">{variant.description}</p>
             )}
           </div>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => downloadDvar(variant.id)}
-            >
-              <Download className="size-4" /> DVAR
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => downloadDsvg(variant)}
-            >
-              <Download className="size-4" /> DSVG
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onCreateSandbox(variant)}
-              disabled={isCreatingSandbox}
-            >
-              <Play className="size-4" /> Sandbox
-            </Button>
-            {variant.canEdit && (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => navigate(`/variants/${variant.id}/edit`)}
-                >
-                  <Pencil className="size-4" /> Edit
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => onDelete(variant.id)}
-                >
-                  <Trash2 className="size-4" /> Delete
-                </Button>
-              </>
-            )}
+          <div className="space-y-2">
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => downloadDvar(variant.id)}
+              >
+                <Download className="size-4" /> DVAR
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => downloadDsvg(variant)}
+              >
+                <Download className="size-4" /> DSVG
+              </Button>
+              {variant.canEdit && (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => navigate(`/variants/${variant.id}/edit`)}
+                  >
+                    <Pencil className="size-4" /> Edit
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => onDelete(variant.id)}
+                  >
+                    <Trash2 className="size-4" /> Delete
+                  </Button>
+                </>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onCreateSandbox(variant)}
+                disabled={isCreatingSandbox}
+              >
+                <Monitor className="size-4" /> Sandbox
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onCreatePrivateGame(variant)}
+              >
+                <Users className="size-4" /> Private Game
+              </Button>
+            </div>
           </div>
         </div>
       </div>
@@ -213,6 +226,10 @@ const VariantsList: React.FC = () => {
     }
   };
 
+  const handleCreatePrivateGame = (variant: Variant) => {
+    navigate(`/create-game?variantId=${variant.id}&private=true`);
+  };
+
   const handleCreateSandbox = async (variant: Variant) => {
     try {
       const game = await sandboxMutation.mutateAsync({
@@ -248,6 +265,7 @@ const VariantsList: React.FC = () => {
           variant={variant}
           onDelete={setPendingDeleteId}
           onCreateSandbox={handleCreateSandbox}
+          onCreatePrivateGame={handleCreatePrivateGame}
           isCreatingSandbox={sandboxMutation.isPending}
         />
       ))}

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -172,13 +172,15 @@ const VariantRow: React.FC<VariantRowProps> = ({
               >
                 <Monitor className="size-4" /> Sandbox
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onCreatePrivateGame(variant)}
-              >
-                <Users className="size-4" /> Private Game
-              </Button>
+              {(variant.status !== "draft" || variant.canEdit) && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onCreatePrivateGame(variant)}
+                >
+                  <Users className="size-4" /> Private Game
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -30,6 +30,7 @@ import {
 import { MapPreview } from "@/components/MapPreview";
 import axiosInstance from "@/api/axiosInstance";
 import { useQueryClient } from "@tanstack/react-query";
+import { createGamePath } from "@/utils/routes";
 
 const statusLabel: Record<string, string> = {
   draft: "Draft",
@@ -227,7 +228,7 @@ const VariantsList: React.FC = () => {
   };
 
   const handleCreatePrivateGame = (variant: Variant) => {
-    navigate(`/create-game?variantId=${variant.id}&private=true`);
+    navigate(createGamePath({ variantId: variant.id, private: true }));
   };
 
   const handleCreateSandbox = async (variant: Variant) => {

--- a/packages/web/src/utils/routes.ts
+++ b/packages/web/src/utils/routes.ts
@@ -1,0 +1,8 @@
+export const CREATE_GAME_PARAM = {
+  variantId: "variantId",
+  private: "private",
+} as const;
+
+export function createGamePath(params: { variantId: string; private: boolean }): string {
+  return `/create-game?${CREATE_GAME_PARAM.variantId}=${params.variantId}&${CREATE_GAME_PARAM.private}=${params.private}`;
+}

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -279,7 +279,9 @@ class GameCreateSerializer(serializers.Serializer):
     )
 
     def validate_variant_id(self, value):
-        if not Variant.objects.filter(id=value, status=VariantStatus.PUBLISHED).exists():
+        if not Variant.objects.filter(
+            Q(status=VariantStatus.PUBLISHED) | Q(status=VariantStatus.DRAFT)
+        ).filter(id=value).exists():
             raise serializers.ValidationError("Variant with this ID does not exist.")
         return value
 
@@ -292,6 +294,18 @@ class GameCreateSerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs):
+        variant = Variant.objects.get(id=attrs["variant_id"])
+        if variant.status == VariantStatus.DRAFT:
+            request = self.context["request"]
+            if not attrs.get("private"):
+                raise serializers.ValidationError(
+                    {"variant_id": "Draft variants can only be used for private games."}
+                )
+            if variant.owner_id != request.user.id:
+                raise serializers.ValidationError(
+                    {"variant_id": "You can only create games with your own draft variants."}
+                )
+
         deadline_mode = attrs["deadline_mode"]
 
         if deadline_mode == DeadlineMode.FIXED_TIME:

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -279,9 +279,12 @@ class GameCreateSerializer(serializers.Serializer):
     )
 
     def validate_variant_id(self, value):
-        if not Variant.objects.filter(
-            Q(status=VariantStatus.PUBLISHED) | Q(status=VariantStatus.DRAFT)
-        ).filter(id=value).exists():
+        try:
+            self._validated_variant = Variant.objects.get(
+                id=value,
+                status__in=[VariantStatus.PUBLISHED, VariantStatus.DRAFT],
+            )
+        except Variant.DoesNotExist:
             raise serializers.ValidationError("Variant with this ID does not exist.")
         return value
 
@@ -294,14 +297,14 @@ class GameCreateSerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs):
-        variant = Variant.objects.get(id=attrs["variant_id"])
+        variant = self._validated_variant
         if variant.status == VariantStatus.DRAFT:
             request = self.context["request"]
             if not attrs.get("private"):
                 raise serializers.ValidationError(
                     {"variant_id": "Draft variants can only be used for private games."}
                 )
-            if variant.owner_id != request.user.id:
+            if variant.owner_id is None or variant.owner_id != request.user.id:
                 raise serializers.ValidationError(
                     {"variant_id": "You can only create games with your own draft variants."}
                 )

--- a/service/game/tests/test_game_create.py
+++ b/service/game/tests/test_game_create.py
@@ -3,6 +3,8 @@ from django.urls import reverse
 from rest_framework import status
 
 from game.models import Game
+from variant.models import Variant
+from common.constants import VariantStatus
 
 create_viewname = "game-create"
 
@@ -84,3 +86,44 @@ class TestGameCreateView:
         game = Game.objects.get(id=response.data["id"])
         assert game.fixed_deadline_time is None
         assert game.fixed_deadline_timezone is None
+
+
+class TestDraftVariantGameCreate:
+
+    @pytest.fixture
+    def draft_variant_owned_by_primary(self, db, primary_user):
+        return Variant.objects.create(
+            id="draft-owned-by-primary",
+            name="Draft Variant",
+            description="Test draft variant",
+            status=VariantStatus.DRAFT,
+            owner=primary_user,
+        )
+
+    @pytest.fixture
+    def draft_variant_owned_by_secondary(self, db, secondary_user):
+        return Variant.objects.create(
+            id="draft-owned-by-secondary",
+            name="Draft Variant (secondary)",
+            description="Test draft variant owned by secondary",
+            status=VariantStatus.DRAFT,
+            owner=secondary_user,
+        )
+
+    @pytest.mark.django_db
+    def test_non_owner_cannot_create_game_with_others_draft_variant(
+        self, authenticated_client, draft_variant_owned_by_secondary
+    ):
+        url = reverse(create_viewname)
+        payload = {**duration_payload(draft_variant_owned_by_secondary.id), "private": True}
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_owner_cannot_create_public_game_with_draft_variant(
+        self, authenticated_client, draft_variant_owned_by_primary
+    ):
+        url = reverse(create_viewname)
+        payload = {**duration_payload(draft_variant_owned_by_primary.id), "private": False}
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary

- **Backend**: `GameCreateSerializer` now accepts draft variants when the game is private and the requester is the variant owner; public games with draft variants are still rejected
- **Variants list**: Added a "Private Game" button to each variant card that navigates to `/create-game?variantId=<id>&private=true`
- **Create Game screen**: Reads `variantId` and `private` from URL params to pre-populate and lock the form; draft variants are injected into the selector when linked this way
- **Community screen**: Added a "Create your own variant" card with a link to the Variant Creator tool
- **HomeLayout**: Removed the "New" badge from the Community nav item
- **docker-compose**: `codegen` service now depends on `service` to ensure the API is up before schema generation

## Test plan

- [ ] As a variant owner with a draft variant, click "Private Game" on the Variants screen — confirm the Create Game form opens with the variant pre-selected and the private toggle on, and the variant selector is locked
- [ ] Submit the form — confirm the game is created successfully
- [ ] Attempt to create a public game with a draft variant via the API — confirm a 400 is returned
- [ ] Attempt to create a private game with another user's draft variant via the API — confirm a 400 is returned
- [ ] Confirm published variants still work as before (no regression)
- [ ] Check Community screen shows the new "Create your own variant" card

🤖 Generated with [Claude Code](https://claude.com/claude-code)