### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
Bumps `packages/web/package.json` version from `1.4.0` to `1.5.0` for the next iOS release.

Changes since 1.4.0 include Sign in with Apple on the web, Draw proposals UX, auto-advance UI to the newest phase, gunboat icon on game cards, map preview on variant cards, Civil Disorder retreat fix, and several smaller bug fixes.

<sub>Generated with [Claude Code](https://claude.com/claude-code)</sub>