### PR TITLE
UX a day: Add keyboard shortcuts for order type menu on desktop

### DIFF
--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -50,10 +50,10 @@ function useBanner(duration = 3000) {
 }
 
 const ORDER_TYPE_KEYS: Record<string, string> = {
-  Hold: "h",
-  Move: "m",
-  Support: "s",
-  Convoy: "c",
+  Hold: "H",
+  Move: "M",
+  Support: "S",
+  Convoy: "C",
 };
 
 const GameMap: React.FC = () => {
@@ -230,7 +230,7 @@ const GameMap: React.FC = () => {
     );
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      const orderTypeId = keyToOrderType[event.key.toLowerCase()];
+      const orderTypeId = keyToOrderType[event.key.toUpperCase()];
       if (!orderTypeId) return;
       const match = wizard.choices.find((c) => c.id === orderTypeId);
       if (match) {

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -57,6 +57,8 @@ const ORDER_TYPE_KEYS: Record<string, string> = {
   MoveViaConvoy: "V",
   Army: "A",
   Fleet: "F",
+  Disband: "D",
+  Build: "B",
 };
 
 const GameMap: React.FC = () => {

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -54,6 +54,7 @@ const ORDER_TYPE_KEYS: Record<string, string> = {
   Move: "M",
   Support: "S",
   Convoy: "C",
+  MoveViaConvoy: "V",
 };
 
 const GameMap: React.FC = () => {

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -293,7 +293,7 @@ const GameMap: React.FC = () => {
                 onClick={() => handleSelectOrderOption(c.id)}
               >
                 {isDesktopWeb && ORDER_TYPE_KEYS[c.id] && (
-                  <kbd className="inline-flex items-center justify-center size-5 rounded border border-border bg-muted text-muted-foreground font-mono text-xs shrink-0 pl-px pt-px">
+                  <kbd className="inline-flex items-center justify-center size-5 rounded border border-border bg-muted text-muted-foreground font-mono text-xs shrink-0 pl-px pt-0.5">
                     {ORDER_TYPE_KEYS[c.id]}
                   </kbd>
                 )}

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -55,6 +55,8 @@ const ORDER_TYPE_KEYS: Record<string, string> = {
   Support: "S",
   Convoy: "C",
   MoveViaConvoy: "V",
+  Army: "A",
+  Fleet: "F",
 };
 
 const GameMap: React.FC = () => {

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -1,5 +1,6 @@
 import { useRequiredParams } from "../hooks";
 import { useRef, useMemo, useEffect, useState, useCallback } from "react";
+import { useIsDesktopWeb } from "@/hooks/use-platform";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { determineRenderableProvinces } from "../utils/provinces";
@@ -48,6 +49,13 @@ function useBanner(duration = 3000) {
   return { message, show };
 }
 
+const ORDER_TYPE_KEYS: Record<string, string> = {
+  Hold: "h",
+  Move: "m",
+  Support: "s",
+  Convoy: "c",
+};
+
 const GameMap: React.FC = () => {
   const { gameId, phaseId } = useRequiredParams<{
     gameId: string;
@@ -63,6 +71,7 @@ const GameMap: React.FC = () => {
   const { data: orders } = useGameOrdersList(gameId, selectedPhase);
   const { data: optionsData } = useGameOptionsRetrieve(gameId);
 
+  const isDesktopWeb = useIsDesktopWeb();
   const containerRef = useRef<HTMLDivElement>(null);
   const [menuPosition, setMenuPosition] = useState<{
     x: number;
@@ -213,6 +222,26 @@ const GameMap: React.FC = () => {
       wizard.nextField === "namedCoast") &&
     menuPosition !== null;
 
+  useEffect(() => {
+    if (!showMenu || !isDesktopWeb) return;
+
+    const keyToOrderType = Object.fromEntries(
+      Object.entries(ORDER_TYPE_KEYS).map(([id, key]) => [key, id])
+    );
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const orderTypeId = keyToOrderType[event.key.toLowerCase()];
+      if (!orderTypeId) return;
+      const match = wizard.choices.find((c) => c.id === orderTypeId);
+      if (match) {
+        wizard.select(match.id);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showMenu, isDesktopWeb, wizard]);
+
   const displayOrders = pendingOrder
     ? [
         ...(orders ?? []).filter(
@@ -263,6 +292,11 @@ const GameMap: React.FC = () => {
                 key={c.id}
                 onClick={() => handleSelectOrderOption(c.id)}
               >
+                {isDesktopWeb && ORDER_TYPE_KEYS[c.id] && (
+                  <kbd className="inline-flex items-center justify-center size-5 rounded border border-border bg-muted text-muted-foreground font-mono text-xs shrink-0 pl-px pt-px">
+                    {ORDER_TYPE_KEYS[c.id]}
+                  </kbd>
+                )}
                 {c.label}
               </FloatingMenuItem>
             ))}

--- a/packages/web/src/hooks/use-platform.ts
+++ b/packages/web/src/hooks/use-platform.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+import { Capacitor } from "@capacitor/core";
+
+export function useIsDesktopWeb(): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (Capacitor.isNativePlatform()) return false;
+    return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+  });
+
+  useEffect(() => {
+    if (Capacitor.isNativePlatform()) return;
+    const mql = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const onChange = () => setMatches(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return matches;
+}


### PR DESCRIPTION
Some very logical feedback why Backstabbr is still preferred over Dip: on desktop, adding orders is super easy because of keyboard shortcuts.

For desktop (any width), I added a listener for the keyboard and a small 'key' icon with the correct key. 
- Hover still works the same
- Press the key and move immediately to the next step.
- Works on all desktop widths. 

Mobile is unchanged.

Super tiny change, **major** UX improvement. It does feel **much** more fluent and easy, and it doesn't interfere.

Pictures:
<img width="309" height="302" alt="image" src="https://github.com/user-attachments/assets/392d0a09-389f-474f-9c29-25aa12388af3" />
<img width="240" height="301" alt="image" src="https://github.com/user-attachments/assets/495a9906-857a-4dde-a17f-d27c5581bc5f" />
<img width="287" height="161" alt="image" src="https://github.com/user-attachments/assets/569566e0-e09a-44c5-bc8b-35c1ba673e9a" />




## Summary

- Pressing a keyboard shortcut while the order type menu is open instantly selects that option and closes the menu
- A `<kbd>` badge showing the shortcut key is displayed before each menu item label on desktop
- Desktop-only: detection uses `(hover: hover) and (pointer: fine)` media query + `Capacitor.isNativePlatform()` rather than viewport width, so shortcuts work at any browser size and are correctly hidden on Android, iOS, and mobile web

### Shortcuts

| Key | Order |
|-----|-------|
| H | Hold |
| M | Move |
| S | Support |
| C | Convoy |
| V | Move Via Convoy |
| A | Army (build phase) |
| F | Fleet (build phase) |
| D | Disband |
| B | Build |

## Test plan

- [ ] Open game map on desktop — click a unit, verify shortcut badges appear in the menu
- [ ] Press the shortcut key while menu is open — verify the corresponding order is selected
- [ ] Press an unmapped key (e.g. `z`) — verify nothing happens
- [ ] Resize browser to a narrow width — verify shortcuts still work (not gated on viewport)
- [ ] Open DevTools → toggle device emulation (touch device) — verify badges disappear and shortcuts stop firing
- [ ] On Android / iOS builds — verify no badges and no keyboard shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)