### PR TITLE
Fix options computation timeout for large variants

### DIFF
--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -198,6 +198,14 @@ def _fleet_target_is_bare_multi_coast(view: StateView, order: MoveOrder) -> bool
     return bool(variant.coasts_of(order.target))
 
 
+def _reachable_provinces(variant, source_loc: str, unit_type: str) -> set:
+    result = set()
+    for adj in variant.adjacencies_of(source_loc):
+        if adj.allows(unit_type):
+            result.add(variant.parent_of(adj.to))
+    return result
+
+
 def _support_options(
     view: StateView,
     supporter: Unit,
@@ -229,14 +237,12 @@ def _support_options(
                     named_coast=None,
                 )
             )
+    supporter_targets = _reachable_provinces(variant, source_loc, supporter.type)
+    supporter_targets.discard(source_parent)
     for mover_loc, mover in standing_items:
         if variant.parent_of(mover_loc) == source_parent:
             continue
-        # A support is given to a province, never a named coast — enumerate
-        # bare provinces only so a multi-coast target yields a single option.
-        for target in variant.provinces:
-            if target == source_parent:
-                continue
+        for target in supporter_targets:
             order = SupportMoveOrder(
                 nation=supporter.nation,
                 source=source_loc,


### PR DESCRIPTION
### Why?

`get_options()` times out for large variants like cold-war-1961 (110 units, 364 provinces). The support-move inner loop iterates every province for every (supporter, mover) pair — roughly 4.4M iterations — exceeding the 30s gunicorn timeout.

### How?

Pre-compute the set of provinces each supporter can reach via adjacency, then iterate only those (~6-15) instead of every province in the variant. Reduces the support-move loop from O(N² × P) to O(N² × D).

- Closes #583

<sub>Generated with Claude Code</sub>