### PR TITLE
Add civil disorder recovery endpoint

### DIFF
--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -156,3 +156,15 @@ class IsGameMaster(BasePermission):
             self.message = "Only the Game Master can perform this action."
             return False
         return True
+
+
+class IsInCivilDisorder(BasePermission):
+    message = "Player is not in civil disorder."
+
+    def has_permission(self, request, view):
+        game = resolve_game(request, view.kwargs.get("game_id"))
+        member = game.members.filter(user=request.user).first()
+        if not member:
+            self.message = "User is not a member of the game."
+            return False
+        return member.civil_disorder

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -5,12 +5,13 @@ from rest_framework import status
 from game.models import Game
 from phase.models import Phase
 from user_profile.models import UserProfile
-from common.constants import GameStatus, NationAssignment
+from common.constants import GameStatus, NationAssignment, PhaseStatus
 
 User = get_user_model()
 
 join_viewname = "game-join"
 retrieve_viewname = "game-retrieve"
+recovery_viewname = "civil-disorder-recovery"
 
 
 class TestCivilDisorderSerialization:
@@ -328,3 +329,151 @@ def test_game_start_phase_not_immediately_resolvable(classical_variant, primary_
     assert phase.status == "active"
     assert phase.phase_states.exists()
     assert phase not in Phase.objects.filter_due_phases()
+
+
+class TestCivilDisorderRecovery:
+
+    @pytest.mark.django_db
+    def test_recover_from_civil_disorder(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_france_nation,
+        secondary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game = Game.objects.create(
+            name="CD Recovery Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        member = game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            civil_disorder=True,
+        )
+        game.members.create(user=secondary_user, nation=classical_france_nation)
+
+        phase = game.phases.create(
+            variant=classical_variant,
+            season="Spring",
+            year=1901,
+            type="Movement",
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        phase.phase_states.create(member=member, orders_confirmed=True)
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["civil_disorder"] is False
+
+        member.refresh_from_db()
+        assert member.civil_disorder is False
+
+        phase_state = phase.phase_states.get(member=member)
+        assert phase_state.orders_confirmed is False
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args[1]
+        assert call_kwargs["notification_type"] == "civil_disorder_recovery"
+        assert secondary_user.id in call_kwargs["user_ids"]
+        assert primary_user.id not in call_kwargs["user_ids"]
+        assert "England" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_recover_fails_if_not_in_civil_disorder(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+    ):
+        game = Game.objects.create(
+            name="Not CD Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            civil_disorder=False,
+        )
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_recover_fails_if_not_game_member(
+        self,
+        authenticated_client,
+        classical_variant,
+        secondary_user,
+        classical_england_nation,
+    ):
+        game = Game.objects.create(
+            name="No Member Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(
+            user=secondary_user,
+            nation=classical_england_nation,
+            civil_disorder=True,
+        )
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_recover_fails_if_game_not_active(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+    ):
+        game = Game.objects.create(
+            name="Completed Game",
+            variant=classical_variant,
+            status=GameStatus.COMPLETED,
+        )
+        game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            civil_disorder=True,
+        )
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_recover_fails_if_unauthenticated(
+        self,
+        unauthenticated_client,
+        classical_variant,
+        classical_england_nation,
+        primary_user,
+    ):
+        game = Game.objects.create(
+            name="Unauth Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            civil_disorder=True,
+        )
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = unauthenticated_client.post(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/service/member/urls.py
+++ b/service/member/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path("game/<str:game_id>/join/", views.MemberCreateView.as_view(), name="game-join"),
     path("game/<str:game_id>/leave/", views.MemberDeleteView.as_view(), name="game-leave"),
+    path("game/<str:game_id>/recover-from-civil-disorder/", views.CivilDisorderRecoveryView.as_view(), name="civil-disorder-recovery"),
 ]

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -1,4 +1,5 @@
-from rest_framework import permissions, generics
+from rest_framework import permissions, generics, status
+from rest_framework.response import Response
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
@@ -6,8 +7,9 @@ from drf_spectacular.utils import extend_schema
 from .models import Member
 from .serializers import MemberSerializer
 from common.serializers import EmptySerializer
-from common.permissions import IsPendingGame, IsNotGameMember, IsSpaceAvailable, IsGameMember
+from common.permissions import IsActiveGame, IsGameMember, IsInCivilDisorder, IsPendingGame, IsNotGameMember, IsSpaceAvailable
 from common.views import SelectedGameMixin
+import notification.utils as notification_utils
 
 
 class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
@@ -37,3 +39,49 @@ class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):
         with transaction.atomic():
             super().perform_destroy(instance)
             game.delete_if_empty_pending()
+
+
+class CivilDisorderRecoveryView(SelectedGameMixin, generics.GenericAPIView):
+    serializer_class = EmptySerializer
+    permission_classes = [
+        permissions.IsAuthenticated,
+        IsActiveGame,
+        IsGameMember,
+        IsInCivilDisorder,
+    ]
+
+    @extend_schema(request=EmptySerializer, responses={200: MemberSerializer})
+    def post(self, request, *args, **kwargs):
+        game = self.get_game()
+        member = get_object_or_404(Member, game=game, user=request.user)
+
+        with transaction.atomic():
+            member.civil_disorder = False
+            member.save(update_fields=["civil_disorder"])
+
+            current_phase = game.current_phase
+            if current_phase:
+                current_phase.phase_states.filter(member=member).update(
+                    orders_confirmed=False
+                )
+
+            user_ids = list(
+                game.members.exclude(user=request.user)
+                .filter(user__isnull=False)
+                .values_list("user_id", flat=True)
+            )
+            nation_name = member.nation.name if member.nation else "A player"
+
+            def send_notifications():
+                notification_utils.send_notification_to_users(
+                    user_ids=user_ids,
+                    title="Player Returned",
+                    body=f"{nation_name} has returned from civil disorder.",
+                    notification_type="civil_disorder_recovery",
+                    data={"game_id": str(game.id)},
+                )
+
+            transaction.on_commit(send_notifications)
+
+        serializer = MemberSerializer(member, context=self.get_serializer_context())
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Players in civil disorder can POST to `/game/{id}/recover-from-civil-disorder/` to clear their CD status. The endpoint clears the `civil_disorder` flag, resets the current phase state's `orders_confirmed` to `false` so the player can submit orders again, and sends a push notification to all other players in the game.

Permission checks enforce that the request comes from an authenticated member of an active game who is currently in civil disorder.

Closes #586

<sub>Generated with Claude Code</sub>