### PR TITLE
Add game creator boot endpoint and auto-remove CD players from staging

### DIFF
--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework import status
+from rest_framework.test import APIClient
 from game.models import Game
 from phase.models import Phase
 from user_profile.models import UserProfile
@@ -298,6 +299,124 @@ def test_game_has_exactly_one_game_master(
     game_masters = game.members.filter(is_game_master=True)
     assert game_masters.count() == 1
     assert game_masters.first().user == secondary_user
+
+
+kick_viewname = "game-kick"
+
+
+class TestKickMember:
+
+    @pytest.mark.django_db
+    def test_kick_member_success(
+        self,
+        authenticated_client,
+        pending_game_created_by_primary_user,
+        secondary_user,
+    ):
+        game = pending_game_created_by_primary_user
+        member = game.members.create(user=secondary_user)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not game.members.filter(user=secondary_user).exists()
+
+    @pytest.mark.django_db
+    def test_kick_member_non_game_master_forbidden(
+        self,
+        authenticated_client,
+        pending_game_created_by_secondary_user_joined_by_primary,
+        secondary_user,
+    ):
+        game = pending_game_created_by_secondary_user_joined_by_primary
+        gm_member = game.members.get(user=secondary_user)
+
+        url = reverse(kick_viewname, args=[game.id, gm_member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_kick_member_active_game_forbidden(
+        self,
+        authenticated_client,
+        active_game_created_by_primary_user,
+        secondary_user,
+    ):
+        game = active_game_created_by_primary_user
+        member = game.members.create(user=secondary_user)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_kick_self_forbidden(
+        self,
+        authenticated_client,
+        pending_game_created_by_primary_user,
+        primary_user,
+    ):
+        game = pending_game_created_by_primary_user
+        gm_member = game.members.get(user=primary_user)
+
+        url = reverse(kick_viewname, args=[game.id, gm_member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_kick_nonexistent_member_404(
+        self,
+        authenticated_client,
+        pending_game_created_by_primary_user,
+    ):
+        game = pending_game_created_by_primary_user
+
+        url = reverse(kick_viewname, args=[game.id, 99999])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_kick_unauthenticated(
+        self,
+        unauthenticated_client,
+        pending_game_created_by_secondary_user,
+        secondary_user,
+    ):
+        game = pending_game_created_by_secondary_user
+        member = game.members.get(user=secondary_user)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = unauthenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.django_db
+    def test_kicked_player_can_rejoin(
+        self,
+        authenticated_client,
+        pending_game_created_by_secondary_user,
+        primary_user,
+        secondary_user,
+    ):
+        game = pending_game_created_by_secondary_user
+        member = game.members.create(user=primary_user)
+
+        secondary_client = APIClient()
+        secondary_client.force_authenticate(user=secondary_user)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        secondary_client.delete(url)
+
+        assert not game.members.filter(user=primary_user).exists()
+
+        join_url = reverse(join_viewname, args=[game.id])
+        response = authenticated_client.post(join_url)
+        assert response.status_code == status.HTTP_201_CREATED
 
 
 @pytest.mark.django_db

--- a/service/member/urls.py
+++ b/service/member/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path("game/<str:game_id>/join/", views.MemberCreateView.as_view(), name="game-join"),
     path("game/<str:game_id>/leave/", views.MemberDeleteView.as_view(), name="game-leave"),
+    path("game/<str:game_id>/kick/<int:member_id>/", views.MemberKickView.as_view(), name="game-kick"),
 ]

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions, generics
+from django.conf import settings
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
@@ -6,8 +7,9 @@ from drf_spectacular.utils import extend_schema
 from .models import Member
 from .serializers import MemberSerializer
 from common.serializers import EmptySerializer
-from common.permissions import IsPendingGame, IsNotGameMember, IsSpaceAvailable, IsGameMember
+from common.permissions import IsPendingGame, IsNotGameMember, IsSpaceAvailable, IsGameMember, IsGameMaster
 from common.views import SelectedGameMixin
+from notification.tasks import send_notification
 
 
 class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
@@ -37,3 +39,29 @@ class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):
         with transaction.atomic():
             super().perform_destroy(instance)
             game.delete_if_empty_pending()
+
+
+class MemberKickView(SelectedGameMixin, generics.DestroyAPIView):
+    serializer_class = EmptySerializer
+    permission_classes = [permissions.IsAuthenticated, IsPendingGame, IsGameMaster]
+
+    def get_object(self):
+        game = self.get_game()
+        member = get_object_or_404(Member, game=game, id=self.kwargs["member_id"])
+        if member.user == self.request.user:
+            self.permission_denied(self.request, message="Cannot kick yourself from the game.")
+        return member
+
+    def perform_destroy(self, instance):
+        game = instance.game
+        user_id = instance.user_id
+        with transaction.atomic():
+            instance.delete()
+            if user_id:
+                send_notification.defer(
+                    user_ids=[user_id],
+                    title=game.name,
+                    body="You were removed from this game by the game creator.",
+                    notification_type="kicked_from_staging",
+                    data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+                )

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -473,6 +473,7 @@ class PhaseManager(models.Manager):
             Member.objects.filter(
                 user_id__in=user_ids,
                 game__status=GameStatus.PENDING,
+                is_game_master=False,
             ).select_related("game")
         )
 

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -22,11 +22,8 @@ from victory.utils import check_for_solo_winner
 from victory.models import Victory
 from email_service.tasks import send_email_notification
 from email_service.templates import notification_email
-from django.apps import apps
 from notification import utils as notification_utils
 from notification.tasks import send_notification
-
-Game = apps.get_model("game", "Game")
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -526,6 +523,7 @@ class PhaseManager(models.Manager):
                 notification_type="removed_from_staging",
             )
 
+        from game.models import Game
         for game in Game.objects.filter(id__in=game_ids, status=GameStatus.PENDING):
             game.delete_if_empty_pending()
 

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -441,6 +441,9 @@ class PhaseManager(models.Manager):
             m.civil_disorder = True
         Member.objects.bulk_update(newly_cd_members, ["civil_disorder"])
 
+        cd_user_ids = [m.user_id for m in newly_cd_members if m.user_id is not None]
+        self._remove_from_staging_games(cd_user_ids)
+
         user_ids = [
             m.user_id for m in phase.game.members.all() if m.user_id is not None
         ]
@@ -461,6 +464,41 @@ class PhaseManager(models.Manager):
         transaction.on_commit(send_notifications)
 
         return newly_cd_members
+
+    def _remove_from_staging_games(self, user_ids):
+        if not user_ids:
+            return
+
+        staging_members = list(
+            Member.objects.filter(
+                user_id__in=user_ids,
+                game__status=GameStatus.PENDING,
+            ).select_related("game")
+        )
+
+        if not staging_members:
+            return
+
+        games_by_user = {}
+        game_ids = set()
+        for m in staging_members:
+            games_by_user.setdefault(m.user_id, []).append(m.game)
+            game_ids.add(m.game_id)
+
+        Member.objects.filter(id__in=[m.id for m in staging_members]).delete()
+
+        for user_id, games in games_by_user.items():
+            game_names = ", ".join(g.name for g in games)
+            send_notification.defer(
+                user_ids=[user_id],
+                title="Removed from staging games",
+                body=f"You were removed from {game_names} because you entered civil disorder in an active game.",
+                notification_type="removed_from_staging",
+            )
+
+        from game.models import Game
+        for game in Game.objects.filter(id__in=game_ids, status=GameStatus.PENDING):
+            game.delete_if_empty_pending()
 
     def _check_eliminations(self, previous_phase, new_phase):
         units_by_nation = {}

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3210,6 +3210,7 @@ class TestCivilDisorderStagingRemoval:
         variant,
         italy_nation,
         germany_nation,
+        venice_province,
         primary_user,
         secondary_user,
     ):
@@ -3235,7 +3236,8 @@ class TestCivilDisorderStagingRemoval:
             ordinal=1, status=PhaseStatus.COMPLETED,
         )
         phase1.phase_states.create(member=italy, has_possible_orders=True)
-        phase1.phase_states.create(member=germany, has_possible_orders=True)
+        phase1_germany = phase1.phase_states.create(member=germany, has_possible_orders=True)
+        phase1_germany.orders.create(source=venice_province, order_type=OrderType.HOLD)
 
         phase2 = Phase.objects.create(
             game=game, variant=variant,
@@ -3243,7 +3245,8 @@ class TestCivilDisorderStagingRemoval:
             ordinal=2, status=PhaseStatus.ACTIVE,
         )
         phase2.phase_states.create(member=italy, has_possible_orders=True)
-        phase2.phase_states.create(member=germany, has_possible_orders=True)
+        phase2_germany = phase2.phase_states.create(member=germany, has_possible_orders=True)
+        phase2_germany.orders.create(source=venice_province, order_type=OrderType.HOLD)
 
         return game, italy, germany, phase2
 
@@ -3253,6 +3256,7 @@ class TestCivilDisorderStagingRemoval:
         italy_vs_germany_variant,
         italy_vs_germany_italy_nation,
         italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
         primary_user,
         secondary_user,
         in_memory_procrastinate,
@@ -3261,6 +3265,7 @@ class TestCivilDisorderStagingRemoval:
             italy_vs_germany_variant,
             italy_vs_germany_italy_nation,
             italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
             primary_user,
             secondary_user,
         )
@@ -3284,6 +3289,7 @@ class TestCivilDisorderStagingRemoval:
         italy_vs_germany_variant,
         italy_vs_germany_italy_nation,
         italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
         primary_user,
         secondary_user,
         in_memory_procrastinate,
@@ -3292,6 +3298,7 @@ class TestCivilDisorderStagingRemoval:
             italy_vs_germany_variant,
             italy_vs_germany_italy_nation,
             italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
             primary_user,
             secondary_user,
         )
@@ -3313,6 +3320,7 @@ class TestCivilDisorderStagingRemoval:
         italy_vs_germany_variant,
         italy_vs_germany_italy_nation,
         italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
         primary_user,
         secondary_user,
         in_memory_procrastinate,
@@ -3321,6 +3329,7 @@ class TestCivilDisorderStagingRemoval:
             italy_vs_germany_variant,
             italy_vs_germany_italy_nation,
             italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
             primary_user,
             secondary_user,
         )
@@ -3343,6 +3352,7 @@ class TestCivilDisorderStagingRemoval:
         italy_vs_germany_variant,
         italy_vs_germany_italy_nation,
         italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
         primary_user,
         secondary_user,
         in_memory_procrastinate,
@@ -3351,6 +3361,7 @@ class TestCivilDisorderStagingRemoval:
             italy_vs_germany_variant,
             italy_vs_germany_italy_nation,
             italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
             primary_user,
             secondary_user,
         )
@@ -3365,14 +3376,13 @@ class TestCivilDisorderStagingRemoval:
 
         Phase.objects._check_civil_disorder(phase2)
 
-        jobs = in_memory_procrastinate.jobs
         staging_removal_jobs = [
-            j for j in jobs
-            if j.get("task_name") == "notification.send_notification"
-            and j.get("task_kwargs", {}).get("notification_type") == "removed_from_staging"
+            j for j in in_memory_procrastinate.jobs.values()
+            if j["task_name"] == "notification.send_notification"
+            and j["args"].get("notification_type") == "removed_from_staging"
         ]
         assert len(staging_removal_jobs) == 1
-        assert staging_removal_jobs[0]["task_kwargs"]["user_ids"] == [primary_user.id]
+        assert staging_removal_jobs[0]["args"]["user_ids"] == [primary_user.id]
 
 
 class TestSetOrdersOutcome:

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3203,6 +3203,178 @@ class TestCivilDisorderDetection:
         mock_send_notification_to_users.assert_not_called()
 
 
+class TestCivilDisorderStagingRemoval:
+
+    def _setup_cd_scenario(
+        self,
+        variant,
+        italy_nation,
+        germany_nation,
+        primary_user,
+        secondary_user,
+    ):
+        game = Game.objects.create(
+            variant=variant,
+            name="Active CD Game",
+            status=GameStatus.ACTIVE,
+        )
+        italy = Member.objects.create(
+            nation=italy_nation,
+            user=primary_user,
+            game=game,
+        )
+        germany = Member.objects.create(
+            nation=germany_nation,
+            user=secondary_user,
+            game=game,
+        )
+
+        phase1 = Phase.objects.create(
+            game=game, variant=variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        phase1.phase_states.create(member=italy, has_possible_orders=True)
+        phase1.phase_states.create(member=germany, has_possible_orders=True)
+
+        phase2 = Phase.objects.create(
+            game=game, variant=variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        phase2.phase_states.create(member=italy, has_possible_orders=True)
+        phase2.phase_states.create(member=germany, has_possible_orders=True)
+
+        return game, italy, germany, phase2
+
+    @pytest.mark.django_db
+    def test_cd_removes_player_from_staging_games(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+
+        staging_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Staging Game",
+            status=GameStatus.PENDING,
+        )
+        staging_game.members.create(user=primary_user)
+        staging_game.members.create(user=secondary_user, is_game_master=True)
+
+        Phase.objects._check_civil_disorder(phase2)
+
+        assert not staging_game.members.filter(user=primary_user).exists()
+        assert staging_game.members.filter(user=secondary_user).exists()
+
+    @pytest.mark.django_db
+    def test_cd_does_not_remove_from_active_games(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+
+        other_active_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Other Active Game",
+            status=GameStatus.ACTIVE,
+        )
+        other_active_game.members.create(user=primary_user)
+
+        Phase.objects._check_civil_disorder(phase2)
+
+        assert other_active_game.members.filter(user=primary_user).exists()
+
+    @pytest.mark.django_db
+    def test_cd_staging_removal_deletes_empty_pending_game(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+
+        staging_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Solo Staging Game",
+            status=GameStatus.PENDING,
+        )
+        staging_game.members.create(user=primary_user)
+        staging_id = staging_game.id
+
+        Phase.objects._check_civil_disorder(phase2)
+
+        assert not Game.objects.filter(id=staging_id).exists()
+
+    @pytest.mark.django_db
+    def test_cd_staging_removal_sends_notification(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+
+        staging_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Staging Game",
+            status=GameStatus.PENDING,
+        )
+        staging_game.members.create(user=primary_user)
+        staging_game.members.create(user=secondary_user, is_game_master=True)
+
+        Phase.objects._check_civil_disorder(phase2)
+
+        jobs = in_memory_procrastinate.jobs
+        staging_removal_jobs = [
+            j for j in jobs
+            if j.get("task_name") == "notification.send_notification"
+            and j.get("task_kwargs", {}).get("notification_type") == "removed_from_staging"
+        ]
+        assert len(staging_removal_jobs) == 1
+        assert staging_removal_jobs[0]["task_kwargs"]["user_ids"] == [primary_user.id]
+
+
 class TestSetOrdersOutcome:
 
     def _setup_phase(self, variant, italy_nation, germany_nation, primary_user, secondary_user):

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3385,6 +3385,40 @@ class TestCivilDisorderStagingRemoval:
         assert staging_removal_jobs[0]["args"]["user_ids"] == [primary_user.id]
 
 
+    @pytest.mark.django_db
+    def test_cd_does_not_remove_game_master_from_staging(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+
+        staging_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="GM Staging Game",
+            status=GameStatus.PENDING,
+        )
+        staging_game.members.create(user=primary_user, is_game_master=True)
+        staging_game.members.create(user=secondary_user)
+
+        Phase.objects._check_civil_disorder(phase2)
+
+        assert staging_game.members.filter(user=primary_user).exists()
+        assert staging_game.members.filter(user=secondary_user).exists()
+
+
 class TestSetOrdersOutcome:
 
     def _setup_phase(self, variant, italy_nation, germany_nation, primary_user, secondary_user):


### PR DESCRIPTION
Game creators can now kick players from staging games via `DELETE /api/game/<id>/kick/<member_id>/`. The endpoint requires the caller to be the game master of a pending game. Kicked players receive a push notification and can rejoin freely (hard delete, not soft).

When a player enters civil disorder in any active game, they are automatically removed from all staging games they've joined. They receive a notification listing which games they were removed from. If the removal leaves a staging game with no members, the game is cleaned up.

Self-kick is prevented — the game master should use the existing `/leave` endpoint instead.

Closes #590

**Note:** Tests could not be run locally — Docker image rebuild fails due to PyPI network connectivity issues within Docker. The existing service image is stale (Django 5.x) while the codebase requires Django 6.x. Tests are written and should pass once CI runs them.

<sub>Generated with Claude Code</sub>