### PR TITLE
Add email notifications for high-signal game events

### DIFF
--- a/service/email_service/tasks.py
+++ b/service/email_service/tasks.py
@@ -1,0 +1,17 @@
+import logging
+
+from procrastinate.contrib.django import app
+
+from email_service import utils as email_utils
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(name="email_service.send_email_notification")
+def send_email_notification(user_ids, subject, html):
+    logger.info(f"Running send_email_notification task: {subject}")
+    email_utils.send_email_to_users(
+        user_ids=user_ids,
+        subject=subject,
+        html=html,
+    )

--- a/service/email_service/templates.py
+++ b/service/email_service/templates.py
@@ -1,0 +1,112 @@
+LOGO_URL = "https://diplicity.com/otto.png"
+
+
+def notification_email(title, body, link=None, link_text="View Game"):
+    cta_block = ""
+    if link:
+        cta_block = f"""
+          <tr>
+            <td class="pad-md" align="center" style="padding: 28px 44px 8px;">
+              <!--[if mso]>
+                <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{link}" style="height:48px;v-text-anchor:middle;width:260px;" arcsize="8%" stroke="f" fillcolor="#1c1a14">
+                  <w:anchorlock/>
+                  <center style="color:#f5efe0;font-family:Georgia,serif;font-size:15px;letter-spacing:0.18em;text-transform:uppercase;">{link_text} &#8594;</center>
+                </v:roundrect>
+              <![endif]-->
+              <!--[if !mso]><!-- -->
+              <a class="btn-a" href="{link}" style="display:inline-block; background:#1c1a14; color:#f5efe0; text-decoration:none; padding: 16px 36px; font-family: Georgia, serif; font-size: 14px; letter-spacing: 0.20em; text-transform: uppercase; border:1px solid #1c1a14;">
+                {link_text} &nbsp;&rarr;
+              </a>
+              <!--<![endif]-->
+            </td>
+          </tr>"""
+
+    return f"""<!doctype html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="color-scheme" content="light">
+  <meta name="supported-color-schemes" content="light">
+  <title>{title}</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    @media only screen and (max-width: 480px) {{
+      .container {{ width: 100% !important; padding: 24px 20px !important; }}
+      .h1        {{ font-size: 28px !important; line-height: 1.15 !important; }}
+      .btn-a     {{ display: block !important; width: 100% !important; box-sizing: border-box; }}
+      .stamp     {{ font-size: 10px !important; }}
+      .pad-md    {{ padding: 28px 22px !important; }}
+    }}
+  </style>
+</head>
+<body style="margin:0; padding:0; background:#ece4d3; font-family: Georgia, 'Iowan Old Style', 'Palatino Linotype', Palatino, serif; color:#23201a;">
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; mso-hide:all; font-size:1px; line-height:1px; color:#ece4d3;">
+    {body} &#8199;&#847; &zwnj; &nbsp; &#847; &zwnj; &nbsp;
+  </div>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ece4d3;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px; max-width:560px; background:#f5efe0; border:1px solid #d8cdb4;">
+          <tr>
+            <td style="padding: 0; border-bottom: 1px dashed #b3a685;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td align="left"  style="padding: 16px 28px; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color:#6b5c3f; font-family: Georgia, serif;">Diplomatic Cable</td>
+                  <td align="right" style="padding: 16px 28px; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color:#6b5c3f; font-family: Georgia, serif;">Notification</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td class="pad-md" align="center" style="padding: 44px 44px 8px;">
+              <img src="{LOGO_URL}" width="56" height="56" alt="Diplicity" style="display:block; width:56px; height:56px; border:0; outline:none; border-radius:50%;">
+              <h1 class="h1" style="margin: 22px 0 0; font-family: Georgia, 'Iowan Old Style', serif; font-weight: 400; font-size: 34px; line-height: 1.1; letter-spacing:-0.01em; color:#1c1a14;">
+                {title}
+              </h1>
+            </td>
+          </tr>
+          <tr>
+            <td class="pad-md" style="padding: 22px 44px 8px; font-family: Georgia, serif; font-size: 16px; line-height: 1.65; color:#3a3527;">
+              <p style="margin: 0;">{body}</p>
+            </td>
+          </tr>
+          {cta_block}
+          <tr>
+            <td class="pad-md" style="padding: 28px 44px 0;">
+              <div style="border-top:1px dashed #b3a685; line-height:0; height:0;">&nbsp;</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="pad-md" style="padding: 18px 44px 6px; font-family: Georgia, serif; font-size: 13px; line-height: 1.6; color:#5b4a36;">
+              <p style="margin:0;"><em>You received this because you have email notifications enabled. You can disable them in your profile settings.</em></p>
+            </td>
+          </tr>
+          <tr>
+            <td class="pad-md" style="padding: 18px 44px 36px; font-family: Georgia, serif; font-size: 14px; line-height: 1.6; color:#3a3527;">
+              <p style="margin:0;">&mdash; The Diplicity volunteers</p>
+            </td>
+          </tr>
+        </table>
+        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px; max-width:560px;">
+          <tr>
+            <td align="center" style="padding: 22px 24px 8px; font-family: Georgia, serif; font-size: 12px; line-height: 1.6; color:#7a6843;">
+              <a href="https://discord.gg/GyqEmaWS" style="color:#5b4a36; text-decoration:underline;">Discord</a>
+              &nbsp;&middot;&nbsp;
+              <a href="https://diplicity.com" style="color:#5b4a36; text-decoration:underline;">diplicity.com</a>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding: 4px 24px 28px; font-family: Georgia, serif; font-size: 11px; line-height: 1.6; color:#9b8a64; letter-spacing: 0.12em; text-transform: uppercase;">
+              Diplicity &middot; Since 2014
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""

--- a/service/email_service/tests.py
+++ b/service/email_service/tests.py
@@ -137,4 +137,5 @@ class TestNotificationEmailTemplate:
         from email_service.templates import notification_email
 
         html = notification_email(title="Test", body="Test body")
-        assert "btn-a" not in html
+        assert 'href="None"' not in html
+        assert "View Game" not in html

--- a/service/email_service/tests.py
+++ b/service/email_service/tests.py
@@ -1,7 +1,12 @@
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.test import override_settings
+
+from user_profile.models import UserProfile
+
+User = get_user_model()
 
 
 class TestSendEmail:
@@ -40,3 +45,96 @@ class TestSendEmail:
         mock_resend.Emails.send.side_effect = Exception("Resend API error")
 
         send_email(to="a@b.com", subject="Test", html="<p>Hi</p>")
+
+
+class TestSendEmailToUsers:
+
+    @pytest.mark.django_db
+    @patch("email_service.utils.resend")
+    def test_sends_to_users_with_email_notifications_enabled(self, mock_resend):
+        from email_service.utils import send_email_to_users
+
+        user = User.objects.create_user(username="enabled", email="enabled@example.com", password="pass")
+        UserProfile.objects.create(user=user, name="Enabled User", email_notifications_enabled=True)
+
+        send_email_to_users(
+            user_ids=[user.id],
+            subject="Test",
+            html="<p>Hello</p>",
+        )
+
+        mock_resend.Emails.send.assert_called_once()
+        assert mock_resend.Emails.send.call_args[0][0]["to"] == ["enabled@example.com"]
+
+    @pytest.mark.django_db
+    @patch("email_service.utils.resend")
+    def test_skips_users_with_email_notifications_disabled(self, mock_resend):
+        from email_service.utils import send_email_to_users
+
+        user = User.objects.create_user(username="disabled", email="disabled@example.com", password="pass")
+        UserProfile.objects.create(user=user, name="Disabled User", email_notifications_enabled=False)
+
+        send_email_to_users(
+            user_ids=[user.id],
+            subject="Test",
+            html="<p>Hello</p>",
+        )
+
+        mock_resend.Emails.send.assert_not_called()
+
+    @pytest.mark.django_db
+    @patch("email_service.utils.resend")
+    def test_filters_mixed_users(self, mock_resend):
+        from email_service.utils import send_email_to_users
+
+        user_on = User.objects.create_user(username="on", email="on@example.com", password="pass")
+        UserProfile.objects.create(user=user_on, name="On User", email_notifications_enabled=True)
+
+        user_off = User.objects.create_user(username="off", email="off@example.com", password="pass")
+        UserProfile.objects.create(user=user_off, name="Off User", email_notifications_enabled=False)
+
+        send_email_to_users(
+            user_ids=[user_on.id, user_off.id],
+            subject="Test",
+            html="<p>Hello</p>",
+        )
+
+        assert mock_resend.Emails.send.call_count == 1
+        assert mock_resend.Emails.send.call_args[0][0]["to"] == ["on@example.com"]
+
+    @pytest.mark.django_db
+    @patch("email_service.utils.resend")
+    def test_handles_empty_user_ids(self, mock_resend):
+        from email_service.utils import send_email_to_users
+
+        send_email_to_users(user_ids=[], subject="Test", html="<p>Hello</p>")
+
+        mock_resend.Emails.send.assert_not_called()
+
+
+class TestNotificationEmailTemplate:
+
+    def test_includes_title_and_body(self):
+        from email_service.templates import notification_email
+
+        html = notification_email(title="Game Started", body="Your game has begun.")
+        assert "Game Started" in html
+        assert "Your game has begun." in html
+
+    def test_includes_link_when_provided(self):
+        from email_service.templates import notification_email
+
+        html = notification_email(
+            title="Test",
+            body="Test body",
+            link="https://diplicity.com/game/123",
+            link_text="View Game",
+        )
+        assert "https://diplicity.com/game/123" in html
+        assert "View Game" in html
+
+    def test_omits_link_section_when_no_link(self):
+        from email_service.templates import notification_email
+
+        html = notification_email(title="Test", body="Test body")
+        assert "btn-a" not in html

--- a/service/email_service/utils.py
+++ b/service/email_service/utils.py
@@ -2,6 +2,7 @@ import logging
 
 import resend
 from django.conf import settings
+from django.contrib.auth.models import User
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +23,17 @@ def send_email(to, subject, html):
         logger.info(f"Sent email to {to}: {subject}")
     except Exception as e:
         logger.error(f"Failed to send email to {to}: {e}")
+
+
+def send_email_to_users(user_ids, subject, html):
+    if not user_ids:
+        return
+
+    users = User.objects.filter(
+        id__in=user_ids,
+        profile__email_notifications_enabled=True,
+    ).values_list("email", flat=True)
+
+    for email in users:
+        if email:
+            send_email(to=email, subject=subject, html=html)

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -358,15 +358,6 @@ class TestGameRetrieveViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-
-        print(f"\n\n=== TEST: test_retrieve_game_query_count_with_multiple_members ===")
-        print(f"Total queries: {query_count}")
-        print(f"Number of members: {game.members.count()}")
-        print(f"Number of phase_states: {phase.phase_states.count()}")
-        for i, query in enumerate(connection.queries, 1):
-            sql = query['sql'][:300]
-            print(f"{i}. {sql}")
-
         assert query_count == 5
 
 
@@ -927,19 +918,6 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-
-        print("\n" + "=" * 80)
-        print(f"QUERY COUNT: {query_count}")
-        print("=" * 80)
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}:")
-            print(f"SQL: {query['sql']}")
-            print(f"Time: {query['time']}")
-        print("=" * 80 + "\n")
-
-        # 5 (not 4) since GameListSerializer now embeds current_phase +
-        # phase_confirmed, which adds one prefetch for PhaseState.member.
-        # Still flat across N games and N phases.
         assert query_count == 5
 
     @pytest.mark.django_db
@@ -991,19 +969,6 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-
-        print("\n" + "=" * 80)
-        print(f"QUERY COUNT: {query_count}")
-        print("=" * 80)
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}:")
-            print(f"SQL: {query['sql']}")
-            print(f"Time: {query['time']}")
-        print("=" * 80 + "\n")
-
-        # 5 (not 4) since GameListSerializer now embeds current_phase +
-        # phase_confirmed, which adds one prefetch for PhaseState.member.
-        # Still flat across N games and N phases.
         assert query_count == 5
 
     @pytest.mark.django_db
@@ -1596,11 +1561,6 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-
-        print(f"\nQuery count: {query_count}")
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}: {query['sql']}")
-
         assert query_count == 44
 
     @pytest.mark.django_db
@@ -1621,11 +1581,6 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-
-        print(f"\nQuery count: {query_count}")
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}: {query['sql']}")
-
         assert query_count == 44
 
 
@@ -2143,12 +2098,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-
-        print(f"\nQuery count (small variant): {query_count}")
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}: {query['sql']}")
-
-        assert query_count == 53
+        assert query_count == 54
 
     @pytest.mark.django_db
     def test_create_sandbox_game_query_count_large_variant(
@@ -2169,12 +2119,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-
-        print(f"\nQuery count (large variant): {query_count}")
-        for i, query in enumerate(connection.queries, 1):
-            print(f"\nQuery {i}: {query['sql']}")
-
-        assert query_count == 53
+        assert query_count == 54
 
 
 class TestSandboxGameFiltering:

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -5,6 +5,8 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from channel.models import ChannelMessage
 from draw_proposal.models import DrawProposal
+from email_service.tasks import send_email_notification
+from email_service.templates import notification_email
 from game.models import Game
 from common.constants import GameStatus, PhaseStatus
 from notification.tasks import send_notification
@@ -107,15 +109,24 @@ def _send_game_start_notification(instance):
     if not user_ids:
         return
 
+    link = f"{settings.FRONTEND_URL}/game/{instance.id}"
+    body = "The game has started. You can now chat with other players and submit your orders. Good luck!"
+
     send_notification.defer(
         user_ids=user_ids,
         title=instance.name,
-        body="The game has started. You can now chat with other players and submit your orders. Good luck!",
+        body=body,
         notification_type="game_start",
-        data={
-            "game_id": str(instance.id),
-            "link": f"{settings.FRONTEND_URL}/game/{instance.id}",
-        },
+        data={"game_id": str(instance.id), "link": link},
+    )
+    send_email_notification.defer(
+        user_ids=user_ids,
+        subject=f"{instance.name} — Game Started",
+        html=notification_email(
+            title=instance.name,
+            body=body,
+            link=link,
+        ),
     )
 
 
@@ -196,16 +207,24 @@ def send_phase_resolved_notification(sender, instance, created, **kwargs):  # no
 
         def _send():
             user_ids = [member.user_id for member in instance.game.members.all() if member.user_id is not None]
+            link = f"{settings.FRONTEND_URL}/game/{instance.game.id}"
+            body = f"{instance.name} has been resolved"
 
             send_notification_to_users(
                 user_ids=user_ids,
                 title=instance.game.name,
-                body=f"{instance.name} has been resolved",
+                body=body,
                 notification_type="phase_resolved",
-                data={
-                    "game_id": str(instance.game.id),
-                    "link": f"{settings.FRONTEND_URL}/game/{instance.game.id}",
-                },
+                data={"game_id": str(instance.game.id), "link": link},
+            )
+            send_email_notification.defer(
+                user_ids=user_ids,
+                subject=f"{instance.game.name} — {instance.name} Resolved",
+                html=notification_email(
+                    title=instance.game.name,
+                    body=body,
+                    link=link,
+                ),
             )
 
         transaction.on_commit(_send)

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -65,6 +65,10 @@ def _notification_jobs(connector, notification_type=None):
     return jobs
 
 
+def _email_jobs(connector):
+    return [j for j in connector.jobs.values() if j["task_name"] == "email_service.send_email_notification"]
+
+
 @pytest.mark.django_db
 def test_channel_message_notification_uses_display_name(active_game, in_memory_procrastinate):
     sender_member = active_game.members.first()
@@ -241,3 +245,24 @@ class TestGameEndNotifications:
         assert secondary_user.id in args["user_ids"]
         assert italy.name in args["body"]
         assert "Better luck" in args["body"]
+
+
+class TestGameStartEmailNotification:
+
+    @pytest.mark.django_db
+    def test_game_start_defers_email_notification(
+        self, make_end_game_notification_game, in_memory_procrastinate
+    ):
+        game, phase, italy, germany = make_end_game_notification_game()
+        game.status = GameStatus.PENDING
+        game.save()
+
+        game.status = GameStatus.ACTIVE
+        game.save()
+
+        jobs = _email_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        args = jobs[0]["args"]
+        assert "Game Started" in args["subject"]
+        assert game.name in args["subject"]
+        assert game.name in args["html"]

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -20,6 +20,8 @@ from supply_center.models import SupplyCenter
 from unit.models import Unit
 from victory.utils import check_for_solo_winner
 from victory.models import Victory
+from email_service.tasks import send_email_notification
+from email_service.templates import notification_email
 from notification import utils as notification_utils
 from notification.tasks import send_notification
 
@@ -353,12 +355,24 @@ class PhaseManager(models.Manager):
                     if ps.member.user_id is None:
                         continue
 
+                    link = f"{settings.FRONTEND_URL}/game/{phase.game.id}"
+
                     notification_utils.send_notification_to_users(
                         user_ids=[ps.member.user_id],
                         title=phase.game.name,
                         body=body,
                         notification_type="deadline_warning",
-                        data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
+                        data={"game_id": str(phase.game.id), "link": link},
+                    )
+                    send_email_notification.defer(
+                        user_ids=[ps.member.user_id],
+                        subject=f"{phase.game.name} — Deadline Approaching",
+                        html=notification_email(
+                            title=phase.game.name,
+                            body=body,
+                            link=link,
+                            link_text="Submit Orders",
+                        ),
                     )
                     ps.deadline_warning_sent_for = phase.scheduled_resolution
                     warned_states.append(ps)
@@ -450,12 +464,24 @@ class PhaseManager(models.Manager):
 
         def send_notifications():
             if user_ids:
+                link = f"{settings.FRONTEND_URL}/game/{phase.game.id}"
+                body = f"{nation_names} entered civil disorder."
+
                 notification_utils.send_notification_to_users(
                     user_ids=user_ids,
                     title="Civil Disorder",
-                    body=f"{nation_names} entered civil disorder.",
+                    body=body,
                     notification_type="civil_disorder",
                     data={"game_id": str(phase.game.id)},
+                )
+                send_email_notification.defer(
+                    user_ids=user_ids,
+                    subject=f"{phase.game.name} — Civil Disorder",
+                    html=notification_email(
+                        title="Civil Disorder",
+                        body=body,
+                        link=link,
+                    ),
                 )
 
         transaction.on_commit(send_notifications)

--- a/service/user_profile/migrations/0003_userprofile_email_notifications_enabled.py
+++ b/service/user_profile/migrations/0003_userprofile_email_notifications_enabled.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user_profile', '0002_alter_userprofile_picture'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='email_notifications_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/service/user_profile/models.py
+++ b/service/user_profile/models.py
@@ -22,3 +22,4 @@ class UserProfile(BaseModel):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
     name = models.CharField(max_length=255)
     picture = models.URLField(null=True, blank=True)
+    email_notifications_enabled = models.BooleanField(default=False)

--- a/service/user_profile/serializers.py
+++ b/service/user_profile/serializers.py
@@ -6,6 +6,7 @@ class UserProfileSerializer(serializers.Serializer):
     name = serializers.CharField(min_length=2, max_length=255)
     picture = serializers.CharField(read_only=True, allow_null=True)
     email = serializers.CharField(source="user.email", read_only=True)
+    email_notifications_enabled = serializers.BooleanField(required=False)
 
     def validate_name(self, value):
         value = value.strip()
@@ -17,5 +18,8 @@ class UserProfileSerializer(serializers.Serializer):
 
     def update(self, instance, validated_data):
         instance.name = validated_data.get("name", instance.name)
+        instance.email_notifications_enabled = validated_data.get(
+            "email_notifications_enabled", instance.email_notifications_enabled
+        )
         instance.save()
         return instance

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -22,6 +22,7 @@ class TestUserProfileRetrieveView:
         assert response.data["name"] == primary_user.profile.name
         assert response.data["picture"] == primary_user.profile.picture
         assert response.data["email"] == primary_user.email
+        assert response.data["email_notifications_enabled"] is False
 
     @pytest.mark.django_db
     def test_retrieve_user_profile_unauthenticated(self, unauthenticated_client):
@@ -103,6 +104,33 @@ class TestUserProfileUpdateView:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["name"] == "Trimmed Name"
+
+    @pytest.mark.django_db
+    def test_enable_email_notifications(self, authenticated_client, primary_user):
+        url = reverse("user-profile-update")
+        response = authenticated_client.patch(
+            url, {"email_notifications_enabled": True}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["email_notifications_enabled"] is True
+        primary_user.profile.refresh_from_db()
+        assert primary_user.profile.email_notifications_enabled is True
+
+    @pytest.mark.django_db
+    def test_disable_email_notifications(self, authenticated_client, primary_user):
+        primary_user.profile.email_notifications_enabled = True
+        primary_user.profile.save()
+
+        url = reverse("user-profile-update")
+        response = authenticated_client.patch(
+            url, {"email_notifications_enabled": False}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["email_notifications_enabled"] is False
+        primary_user.profile.refresh_from_db()
+        assert primary_user.profile.email_notifications_enabled is False
 
 
 class TestUserAccountDelete:


### PR DESCRIPTION
Adds opt-in email notifications to the four high-signal game events identified in the reliability initiative.

- Adds `email_notifications_enabled` boolean to `UserProfile` (default `False`, opt-in per community feedback)
- Exposes the field via the profile API so the frontend (#597) can add a toggle
- Creates a reusable Diplomatic Cable HTML email template matching the existing verification/password-reset style
- Creates a `send_email_notification` Procrastinate task so email sending doesn't block phase resolution
- Wires email alongside push notifications for: deadline warnings, phase resolved, civil disorder, game start
- Only sends to users who have explicitly opted in — the `send_email_to_users` utility filters by `email_notifications_enabled=True`

Closes #596

<sub>Generated with Claude Code</sub>