### PR TITLE
Fix adjustment phase skipped when CD nation disbands and another nation builds

### DIFF
--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -73,12 +73,7 @@ def start(phase) -> Dict[str, Any]:
         }
 
 
-def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id):
-    """Return True if the phase can be skipped — no human input is needed.
-
-    A phase is skippable when it has no options at all, or when every nation
-    with options is in `cd_nations` (civil disorder or non-playable).
-    """
+def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id, variant):
     if not options:
         return True
     if not cd_nations:
@@ -87,8 +82,6 @@ def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id):
         u.location: nation_name_by_id.get(u.nation, u.nation)
         for u in units
     }
-    # Build options have source = empty SC province (not a unit location).
-    # Include SC ownership so build options are attributed to the right nation.
     province_to_nation = {
         sc.province: nation_name_by_id.get(sc.nation, sc.nation)
         for sc in supply_centers
@@ -99,8 +92,10 @@ def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id):
             continue
         if opt.source in location_to_nation:
             option_nations.add(location_to_nation[opt.source])
-        elif opt.source in province_to_nation:
-            option_nations.add(province_to_nation[opt.source])
+        else:
+            province = variant.parent_of(opt.source)
+            if province in province_to_nation:
+                option_nations.add(province_to_nation[province])
     return bool(option_nations) and option_nations.issubset(cd_nations)
 
 
@@ -133,7 +128,7 @@ def resolve(phase) -> Dict[str, Any]:
         next_options = get_options(next_state) if len(states) > 1 else []
         _skip_count = 0
         _MAX_SKIP = 10
-        while len(states) > 1 and _should_skip(next_options, next_state.units, next_state.supply_centers, cd_nations, nation_name_by_id):
+        while len(states) > 1 and _should_skip(next_options, next_state.units, next_state.supply_centers, cd_nations, nation_name_by_id, next_state.variant):
             _skip_count += 1
             if _skip_count >= _MAX_SKIP:
                 logger.warning(

--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -73,7 +73,12 @@ def start(phase) -> Dict[str, Any]:
         }
 
 
-def _should_skip(options, units, cd_nations, nation_name_by_id):
+def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id):
+    """Return True if the phase can be skipped — no human input is needed.
+
+    A phase is skippable when it has no options at all, or when every nation
+    with options is in `cd_nations` (civil disorder or non-playable).
+    """
     if not options:
         return True
     if not cd_nations:
@@ -82,11 +87,20 @@ def _should_skip(options, units, cd_nations, nation_name_by_id):
         u.location: nation_name_by_id.get(u.nation, u.nation)
         for u in units
     }
-    option_nations = {
-        location_to_nation[opt.source]
-        for opt in options
-        if opt.source is not None and opt.source in location_to_nation
+    # Build options have source = empty SC province (not a unit location).
+    # Include SC ownership so build options are attributed to the right nation.
+    province_to_nation = {
+        sc.province: nation_name_by_id.get(sc.nation, sc.nation)
+        for sc in supply_centers
     }
+    option_nations = set()
+    for opt in options:
+        if opt.source is None:
+            continue
+        if opt.source in location_to_nation:
+            option_nations.add(location_to_nation[opt.source])
+        elif opt.source in province_to_nation:
+            option_nations.add(province_to_nation[opt.source])
     return bool(option_nations) and option_nations.issubset(cd_nations)
 
 
@@ -119,7 +133,7 @@ def resolve(phase) -> Dict[str, Any]:
         next_options = get_options(next_state) if len(states) > 1 else []
         _skip_count = 0
         _MAX_SKIP = 10
-        while len(states) > 1 and _should_skip(next_options, next_state.units, cd_nations, nation_name_by_id):
+        while len(states) > 1 and _should_skip(next_options, next_state.units, next_state.supply_centers, cd_nations, nation_name_by_id):
             _skip_count += 1
             if _skip_count >= _MAX_SKIP:
                 logger.warning(

--- a/service/adjudication/tests.py
+++ b/service/adjudication/tests.py
@@ -944,6 +944,52 @@ class TestAdjudicationService:
         germany_units = [u for u in data["units"] if u["nation"] == "Germany"]
         assert germany_units == []
 
+    @pytest.mark.django_db
+    def test_adjustment_not_skipped_when_cd_nation_disbands_and_other_nation_builds(
+        self,
+        phase_fall_1901_movement,
+        member_italy,
+        member_germany,
+    ):
+        """
+        Regression: when a CD nation needs to disband and a non-CD nation needs
+        to build, the Adjustment phase must not be skipped.
+
+        Build options have source = empty SC province (not a unit location), so
+        they were invisible to _should_skip's location_to_nation lookup. Only
+        Germany's disband option was detected; since Germany is the only nation
+        in option_nations and is in skip_nations, the phase was incorrectly
+        skipped, cheating Italy out of a build.
+
+        Setup: Italy holds at ber with SCs at ber+mun (1 unit, 2 SCs → build 1).
+        Germany holds at kie+den with only kie as SC (2 units, 1 SC → disband 1,
+        but Germany is in Civil Disorder so disbands are auto-handled).
+        No dislodgements → empty Fall Retreat is skipped automatically.
+        The Adjustment phase must still be created for Italy's build.
+        """
+        member_germany.civil_disorder = True
+        member_germany.save()
+
+        phase_state_italy = phase_fall_1901_movement.phase_states.create(member=member_italy)
+        phase_state_germany = phase_fall_1901_movement.phase_states.create(member=member_germany)
+
+        create_supply_center(phase_state_italy, "ber")
+        create_supply_center(phase_state_italy, "mun")
+        create_supply_center(phase_state_germany, "kie")
+
+        create_unit(phase_state_italy, "ber", "Army")
+        create_unit(phase_state_germany, "kie", "Army")
+        create_unit(phase_state_germany, "den", "Fleet")
+
+        data = adjudication_service.resolve(phase_fall_1901_movement)
+
+        assert data["year"] == 1901
+        assert data["season"] == "Fall"
+        assert data["type"] == "Adjustment"
+
+        italy_options = data["options"].get("Italy", {})
+        assert italy_options != {}, "Italy must have build options in the Adjustment phase"
+
 
 class TestUserUploadedVariant:
     """Regression: prior to dropping the godip HTTP adjudicator, creating a

--- a/service/adjudication/tests.py
+++ b/service/adjudication/tests.py
@@ -951,24 +951,6 @@ class TestAdjudicationService:
         member_italy,
         member_germany,
     ):
-        """
-        Regression: when a CD nation needs to disband and a non-CD nation needs
-        to build, the Adjustment phase must not be skipped.
-
-        Build options have source = empty SC province (not a unit location), so
-        they were invisible to _should_skip's location_to_nation lookup. Only
-        Germany's disband option was detected; since Germany is the only nation
-        in option_nations and is in cd_nations, the phase was incorrectly
-        skipped, cheating Italy out of a build.
-
-        Setup:
-        - Italy holds at ven (home SC); also owns rom (empty home SC).
-          1 unit, 2 SCs → needs to build 1 at rom.
-        - Germany (Civil Disorder) holds at kie (home SC) and ruh (non-SC).
-          2 units, 1 SC → needs to disband 1 (auto-handled by CD).
-        No dislodgements → empty Fall Retreat is skipped automatically.
-        The Adjustment phase must still be created for Italy's build.
-        """
         member_germany.civil_disorder = True
         member_germany.save()
 
@@ -992,7 +974,7 @@ class TestAdjudicationService:
         assert data["type"] == "Adjustment"
 
         italy_options = data["options"].get("Italy", {})
-        assert italy_options != {}, "Italy must have build options in the Adjustment phase"
+        assert italy_options != {}
 
 
 class TestUserUploadedVariant:

--- a/service/adjudication/tests.py
+++ b/service/adjudication/tests.py
@@ -958,12 +958,14 @@ class TestAdjudicationService:
         Build options have source = empty SC province (not a unit location), so
         they were invisible to _should_skip's location_to_nation lookup. Only
         Germany's disband option was detected; since Germany is the only nation
-        in option_nations and is in skip_nations, the phase was incorrectly
+        in option_nations and is in cd_nations, the phase was incorrectly
         skipped, cheating Italy out of a build.
 
-        Setup: Italy holds at ber with SCs at ber+mun (1 unit, 2 SCs → build 1).
-        Germany holds at kie+den with only kie as SC (2 units, 1 SC → disband 1,
-        but Germany is in Civil Disorder so disbands are auto-handled).
+        Setup:
+        - Italy holds at ven (home SC); also owns rom (empty home SC).
+          1 unit, 2 SCs → needs to build 1 at rom.
+        - Germany (Civil Disorder) holds at kie (home SC) and ruh (non-SC).
+          2 units, 1 SC → needs to disband 1 (auto-handled by CD).
         No dislodgements → empty Fall Retreat is skipped automatically.
         The Adjustment phase must still be created for Italy's build.
         """
@@ -973,13 +975,15 @@ class TestAdjudicationService:
         phase_state_italy = phase_fall_1901_movement.phase_states.create(member=member_italy)
         phase_state_germany = phase_fall_1901_movement.phase_states.create(member=member_germany)
 
-        create_supply_center(phase_state_italy, "ber")
-        create_supply_center(phase_state_italy, "mun")
-        create_supply_center(phase_state_germany, "kie")
+        # Italy: 1 unit at ven, owns ven + rom (both Italy home SCs). rom is empty.
+        create_supply_center(phase_state_italy, "ven")
+        create_supply_center(phase_state_italy, "rom")
+        create_unit(phase_state_italy, "ven", "Army")
 
-        create_unit(phase_state_italy, "ber", "Army")
+        # Germany: 2 units (kie home SC + ruh non-SC), 1 SC (kie). Surplus = 1 disband.
+        create_supply_center(phase_state_germany, "kie")
         create_unit(phase_state_germany, "kie", "Army")
-        create_unit(phase_state_germany, "den", "Fleet")
+        create_unit(phase_state_germany, "ruh", "Army")
 
         data = adjudication_service.resolve(phase_fall_1901_movement)
 


### PR DESCRIPTION
When a civil-disorder nation needed to disband and a non-CD nation needed to build in the same adjustment phase, the phase was incorrectly skipped — the build never happened and the phase never appeared in the turn log. This was reported in multiple Spice Islands games.

**Root cause:** `_should_skip` determined which nations had options by looking up each option's `source` in a `location_to_nation` map built from unit positions. Build options have `source = empty SC province` — by definition, you can only build in an unoccupied SC, so the source is never a unit location. This meant nations with only build options were never added to `option_nations`. When the only entries in `option_nations` were the CD nation's disband options, `option_nations ⊆ skip_nations` evaluated to `True` and the whole adjustment was skipped.

**Fix:** Also build a `province_to_nation` map from supply center ownership. When an option's source isn't a unit location, fall back to looking it up as an SC province. This correctly attributes build options to their owning nation.

The regression test covers the exact failure scenario: Germany in civil disorder with a unit surplus, Italy with a SC surplus and needing to build, and an empty Fall retreat that triggers the skip-evaluation path.