### PR TITLE
Fix variant upload error handling for non-object server responses

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/packages/web/src/screens/Variants/VariantCreate.tsx
+++ b/packages/web/src/screens/Variants/VariantCreate.tsx
@@ -118,9 +118,11 @@ const VariantUploadForm: React.FC<VariantUploadFormProps> = ({
       await onSubmit({ dvar, dsvg });
     } catch (error) {
       const axiosError = error as AxiosError<ServerError>;
-      const data = axiosError.response?.data ?? {
-        detail: axiosError.message ?? "Unknown error",
-      };
+      const raw = axiosError.response?.data;
+      const data: ServerError =
+        raw !== null && raw !== undefined && typeof raw === "object"
+          ? (raw as ServerError)
+          : { detail: axiosError.message ?? "Unknown error" };
       setErrors(data);
     }
   };


### PR DESCRIPTION

<img width="684" height="774" alt="image" src="https://github.com/user-attachments/assets/bdb7596f-0254-447d-85a1-ccdc31785e7e" />

Doctype: html error :D:D:D:D

Note there is a bump in there that I don't know why - it might be legacy, or claude might have added it - it made this change from the variant-creator repo into this one, because it realised the issue was there.

## Summary

- Guards against non-object server error bodies in `VariantUploadForm` — previously a raw string or empty body from the server could cause `Object.entries` to throw or produce garbage in the error display
- Bumps version to 1.5.1

## Test plan

- [ ] Upload a variant with an invalid file to trigger a server error — verify the error alert renders correctly
- [ ] All 362 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)