### PR TITLE
UX a day: Preserve navigation state when switching between map, orders, and chat

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useRef, useEffect } from "react";
-import { useLocation, useNavigate } from "react-router";
+import React, { useMemo } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -45,14 +45,13 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     },
   });
 
-  const lastChatPathRef = useRef<string | null>(null);
+  const [searchParams] = useSearchParams();
   const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
 
-  useEffect(() => {
-    if (location.pathname.startsWith(chatPrefix)) {
-      lastChatPathRef.current = location.pathname;
-    }
-  }, [location.pathname, chatPrefix]);
+  const lastChatChannelId =
+    location.pathname.startsWith(chatPrefix + "/")
+      ? location.pathname.slice(chatPrefix.length + 1)
+      : searchParams.get("chatChannel");
 
   const navItems = useMemo(() => {
     const items = game?.sandbox
@@ -69,9 +68,9 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           ? "•"
           : undefined;
       const isChat = item.label === "Chat";
-      const lastChatPath = lastChatPathRef.current;
-      const validChatPath = lastChatPath?.startsWith(chatPrefix) ? lastChatPath : null;
-      const clickPath = isChat && validChatPath ? validChatPath : basePath;
+      const clickPath = isChat
+        ? lastChatChannelId ? `${chatPrefix}/${lastChatChannelId}` : basePath
+        : lastChatChannelId ? `${basePath}?chatChannel=${lastChatChannelId}` : basePath;
       const isActive = isChat
         ? location.pathname === basePath || location.pathname.startsWith(basePath + "/")
         : location.pathname === basePath;
@@ -82,7 +81,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, chatPrefix, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
+  }, [gameId, phaseId, chatPrefix, lastChatChannelId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -46,16 +46,15 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
   });
 
   const lastChatPathRef = useRef<string | null>(null);
+  const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
 
   useEffect(() => {
-    const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
     if (location.pathname.startsWith(chatPrefix)) {
       lastChatPathRef.current = location.pathname;
     }
-  }, [location.pathname, gameId, phaseId]);
+  }, [location.pathname, chatPrefix]);
 
   const navItems = useMemo(() => {
-    const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
     const items = game?.sandbox
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
@@ -83,7 +82,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
+  }, [gameId, phaseId, chatPrefix, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
@@ -45,12 +45,21 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     },
   });
 
+  const lastChatPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
+    if (location.pathname.startsWith(chatPrefix)) {
+      lastChatPathRef.current = location.pathname;
+    }
+  }, [location.pathname, gameId, phaseId]);
+
   const navItems = useMemo(() => {
     const items = game?.sandbox
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
     return items.map(item => {
-      const path = item.path
+      const basePath = item.path
         .replace(":gameId", gameId)
         .replace(":phaseId", phaseId);
       const badge =
@@ -59,10 +68,15 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         game.totalUnreadMessageCount > 0
           ? "•"
           : undefined;
+      const isChat = item.label === "Chat";
+      const clickPath = isChat && lastChatPathRef.current ? lastChatPathRef.current : basePath;
+      const isActive = isChat
+        ? location.pathname.startsWith(basePath)
+        : location.pathname === basePath;
       return {
         ...item,
-        path,
-        isActive: location.pathname === path,
+        path: clickPath,
+        isActive,
         badge,
       };
     });

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
@@ -45,16 +45,17 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     },
   });
 
-  const [lastChatPath, setLastChatPath] = useState<string | null>(null);
+  const lastChatPathRef = useRef<string | null>(null);
 
   useEffect(() => {
     const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
     if (location.pathname.startsWith(chatPrefix)) {
-      setLastChatPath(location.pathname);
+      lastChatPathRef.current = location.pathname;
     }
   }, [location.pathname, gameId, phaseId]);
 
   const navItems = useMemo(() => {
+    const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
     const items = game?.sandbox
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
@@ -69,9 +70,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           ? "•"
           : undefined;
       const isChat = item.label === "Chat";
-      // Only use lastChatPath if it still belongs to the current phase — guards against
-      // stale paths surviving a phase advance.
-      const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
+      const lastChatPath = lastChatPathRef.current;
       const validChatPath = lastChatPath?.startsWith(chatPrefix) ? lastChatPath : null;
       const clickPath = isChat && validChatPath ? validChatPath : basePath;
       const isActive = isChat
@@ -84,7 +83,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox, lastChatPath]);
+  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -46,17 +46,12 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
   });
 
   const [searchParams] = useSearchParams();
-  const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
-
-  const lastChatChannelId =
-    location.pathname.startsWith(chatPrefix + "/")
-      ? location.pathname.slice(chatPrefix.length + 1)
-      : searchParams.get("chatChannel");
 
   const navItems = useMemo(() => {
     const items = game?.sandbox
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
+    const searchParamsStr = searchParams.toString();
     return items.map(item => {
       const basePath = item.path
         .replace(":gameId", gameId)
@@ -67,21 +62,19 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         game.totalUnreadMessageCount > 0
           ? "•"
           : undefined;
-      const isChat = item.label === "Chat";
-      const clickPath = isChat
-        ? lastChatChannelId ? `${chatPrefix}/${lastChatChannelId}` : basePath
-        : lastChatChannelId ? `${basePath}?chatChannel=${lastChatChannelId}` : basePath;
-      const isActive = isChat
-        ? location.pathname === basePath || location.pathname.startsWith(basePath + "/")
+      const path = searchParamsStr ? `${basePath}?${searchParamsStr}` : basePath;
+      const chatBasePath = `/game/${gameId}/phase/${phaseId}/chat`;
+      const isActive = item.label === "Chat"
+        ? location.pathname === chatBasePath || location.pathname.startsWith(chatBasePath + "/")
         : location.pathname === basePath;
       return {
         ...item,
-        path: clickPath,
+        path,
         isActive,
         badge,
       };
     });
-  }, [gameId, phaseId, chatPrefix, lastChatChannelId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
+  }, [gameId, phaseId, searchParams, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
@@ -45,12 +45,12 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     },
   });
 
-  const lastChatPathRef = useRef<string | null>(null);
+  const [lastChatPath, setLastChatPath] = useState<string | null>(null);
 
   useEffect(() => {
     const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
     if (location.pathname.startsWith(chatPrefix)) {
-      lastChatPathRef.current = location.pathname;
+      setLastChatPath(location.pathname);
     }
   }, [location.pathname, gameId, phaseId]);
 
@@ -69,9 +69,13 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           ? "•"
           : undefined;
       const isChat = item.label === "Chat";
-      const clickPath = isChat && lastChatPathRef.current ? lastChatPathRef.current : basePath;
+      // Only use lastChatPath if it still belongs to the current phase — guards against
+      // stale paths surviving a phase advance.
+      const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
+      const validChatPath = lastChatPath?.startsWith(chatPrefix) ? lastChatPath : null;
+      const clickPath = isChat && validChatPath ? validChatPath : basePath;
       const isActive = isChat
-        ? location.pathname.startsWith(basePath)
+        ? location.pathname === basePath || location.pathname.startsWith(basePath + "/")
         : location.pathname === basePath;
       return {
         ...item,
@@ -80,7 +84,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
+  }, [gameId, phaseId, location.pathname, game?.totalUnreadMessageCount, game?.sandbox, lastChatPath]);
 
   // Filter out Map for desktop sidebar since map is already visible in right panel
   const sidebarNavItems = useMemo(

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -273,7 +273,6 @@ const GameMap: React.FC = () => {
       {game && variant && phase && orders && (
         <>
           <InteractiveMapZoomWrapper
-            cacheKey={`${gameId}-${selectedPhase}`}
             interactiveMapProps={{
               interactive: true,
               variant: variant,

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -273,6 +273,7 @@ const GameMap: React.FC = () => {
       {game && variant && phase && orders && (
         <>
           <InteractiveMapZoomWrapper
+            cacheKey={`${gameId}-${selectedPhase}`}
             interactiveMapProps={{
               interactive: true,
               variant: variant,

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -2,6 +2,7 @@ import {
   TransformWrapper,
   TransformComponent,
   ReactZoomPanPinchContentRef,
+  ReactZoomPanPinchRef,
 } from "react-zoom-pan-pinch";
 import { useRef, useState, useEffect, useMemo } from "react";
 import { Maximize, Minimize } from "lucide-react";
@@ -13,6 +14,7 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
+const TRANSFORM_CACHE_MAX = 50;
 const transformCache = new Map<string, { x: number; y: number; scale: number }>();
 
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;
@@ -155,6 +157,10 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   }, [parsedDsvg]);
 
   useEffect(() => {
+    hasInitializedRef.current = false;
+  }, [cacheKey]);
+
+  useEffect(() => {
     if (!transformRef.current || !containerDimensions || !svgViewBox) return;
     if (hasInitializedRef.current) return;
     hasInitializedRef.current = true;
@@ -196,8 +202,12 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformChange={(_, state) => {
+        onTransformed={(_ref: ReactZoomPanPinchRef, state) => {
           if (cacheKey) {
+            if (transformCache.size >= TRANSFORM_CACHE_MAX) {
+              const oldest = transformCache.keys().next().value;
+              if (oldest !== undefined) transformCache.delete(oldest);
+            }
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }
         }}

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -38,6 +38,13 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // --- Diagnostic ---
+  const renderCountRef = useRef(0);
+  const prevZoomPropsRef = useRef<typeof interactiveMapProps | null>(null);
+  const lastTransformTimeRef = useRef<number | null>(null);
+  const transformFrameTimesRef = useRef<number[]>([]);
+  const fpsFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
   const parsedDsvg = useMemo(() => (dsvg ? parseDsvg(dsvg) : null), [dsvg]);
@@ -123,6 +130,39 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
     });
   };
 
+  const handleGestureStart = () => {
+    if (svgRef.current) {
+      svgRef.current.style.pointerEvents = "none";
+    }
+  };
+
+  const handleGestureStop = () => {
+    if (svgRef.current) {
+      svgRef.current.style.pointerEvents = "";
+    }
+  };
+
+  const handleTransformed = () => {
+    const now = performance.now();
+    if (lastTransformTimeRef.current !== null) {
+      transformFrameTimesRef.current.push(now - lastTransformTimeRef.current);
+    }
+    lastTransformTimeRef.current = now;
+
+    if (fpsFlushTimerRef.current) clearTimeout(fpsFlushTimerRef.current);
+    fpsFlushTimerRef.current = setTimeout(() => {
+      const times = transformFrameTimesRef.current;
+      if (times.length > 1) {
+        const avg = times.reduce((a, b) => a + b, 0) / times.length;
+        console.log(
+          `[InteractiveMapZoom] gesture: ${times.length} updates, avg ${avg.toFixed(1)}ms between transforms (~${(1000 / avg).toFixed(0)} fps)`
+        );
+      }
+      transformFrameTimesRef.current = [];
+      lastTransformTimeRef.current = null;
+    }, 500);
+  };
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -159,6 +199,21 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
     }
   }, [minScale, containerDimensions, svgViewBox]);
 
+  // --- Diagnostic logging ---
+  renderCountRef.current += 1;
+  if (prevZoomPropsRef.current) {
+    const changed = (
+      Object.keys(interactiveMapProps) as Array<keyof typeof interactiveMapProps>
+    ).filter((k) => interactiveMapProps[k] !== prevZoomPropsRef.current![k]);
+    console.log(
+      `[InteractiveMapZoom] render #${renderCountRef.current}`,
+      changed.length > 0 ? { changedProps: changed } : "(internal state change)"
+    );
+  } else {
+    console.log(`[InteractiveMapZoom] render #${renderCountRef.current} (initial)`);
+  }
+  prevZoomPropsRef.current = interactiveMapProps;
+
   if (isLoading || !parsedDsvg || !renderer) {
     return (
       <div
@@ -184,6 +239,13 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
+        onTransformed={handleTransformed}
+        onPanningStart={handleGestureStart}
+        onPanningStop={handleGestureStop}
+        onPinchingStart={handleGestureStart}
+        onPinchingStop={handleGestureStop}
+        onZoomStart={handleGestureStart}
+        onZoomStop={handleGestureStop}
       >
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -2,7 +2,6 @@ import {
   TransformWrapper,
   TransformComponent,
   ReactZoomPanPinchContentRef,
-  ReactZoomPanPinchRef,
 } from "react-zoom-pan-pinch";
 import { useRef, useState, useEffect, useMemo } from "react";
 import { Maximize, Minimize } from "lucide-react";
@@ -14,7 +13,6 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
-const TRANSFORM_CACHE_MAX = 5;
 const transformCache = new Map<string, { x: number; y: number; scale: number }>();
 
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;
@@ -43,7 +41,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const initializedCacheKeyRef = useRef<string | undefined | null>(null);
+  const hasInitializedRef = useRef(false);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -158,8 +156,8 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
 
   useEffect(() => {
     if (!transformRef.current || !containerDimensions || !svgViewBox) return;
-    if (initializedCacheKeyRef.current === cacheKey) return;
-    initializedCacheKeyRef.current = cacheKey;
+    if (hasInitializedRef.current) return;
+    hasInitializedRef.current = true;
 
     const cached = cacheKey ? transformCache.get(cacheKey) : null;
     if (cached) {
@@ -198,12 +196,8 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformed={(_ref: ReactZoomPanPinchRef, state) => {
+        onTransformChange={(_, state) => {
           if (cacheKey) {
-            if (transformCache.size >= TRANSFORM_CACHE_MAX && !transformCache.has(cacheKey)) {
-              const oldest = transformCache.keys().next().value;
-              if (oldest !== undefined) transformCache.delete(oldest);
-            }
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }
         }}

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -43,7 +43,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   const svgRef = useRef<SVGSVGElement>(null);
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const hasInitializedRef = useRef(false);
+  const initializedCacheKeyRef = useRef<string | undefined | null>(null);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -157,13 +157,9 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   }, [parsedDsvg]);
 
   useEffect(() => {
-    hasInitializedRef.current = false;
-  }, [cacheKey]);
-
-  useEffect(() => {
     if (!transformRef.current || !containerDimensions || !svgViewBox) return;
-    if (hasInitializedRef.current) return;
-    hasInitializedRef.current = true;
+    if (initializedCacheKeyRef.current === cacheKey) return;
+    initializedCacheKeyRef.current = cacheKey;
 
     const cached = cacheKey ? transformCache.get(cacheKey) : null;
     if (cached) {

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -13,8 +13,6 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
-const transformCache = new Map<string, { x: number; y: number; scale: number }>();
-
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;
 
 type InteractiveMapProps = Omit<
@@ -31,17 +29,14 @@ type Dimensions = {
 
 type InteractiveMapZoomWrapperProps = {
   interactiveMapProps: InteractiveMapProps;
-  cacheKey?: string;
 };
 
 const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   interactiveMapProps,
-  cacheKey,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const hasInitializedRef = useRef(false);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -155,21 +150,14 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   }, [parsedDsvg]);
 
   useEffect(() => {
-    if (!transformRef.current || !containerDimensions || !svgViewBox) return;
-    if (hasInitializedRef.current) return;
-    hasInitializedRef.current = true;
-
-    const cached = cacheKey ? transformCache.get(cacheKey) : null;
-    if (cached) {
-      transformRef.current.setTransform(cached.x, cached.y, cached.scale, 0);
-    } else {
+    if (transformRef.current && containerDimensions && svgViewBox) {
       const scaledWidth = svgViewBox.width * minScale;
       const scaledHeight = svgViewBox.height * minScale;
       const centerX = (containerDimensions.width - scaledWidth) / 2;
       const centerY = (containerDimensions.height - scaledHeight) / 2;
       transformRef.current.setTransform(centerX, centerY, minScale, 0);
     }
-  }, [minScale, containerDimensions, svgViewBox, cacheKey]);
+  }, [minScale, containerDimensions, svgViewBox]);
 
   if (isLoading || !parsedDsvg || !renderer) {
     return (
@@ -196,11 +184,6 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformed={(_ref, state) => {
-          if (cacheKey) {
-            transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
-          }
-        }}
       >
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -196,7 +196,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformChange={(_, state) => {
+        onTransformed={(_ref, state) => {
           if (cacheKey) {
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -204,7 +204,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         velocityAnimation={{ disabled: true }}
         onTransformed={(_ref: ReactZoomPanPinchRef, state) => {
           if (cacheKey) {
-            if (transformCache.size >= TRANSFORM_CACHE_MAX) {
+            if (transformCache.size >= TRANSFORM_CACHE_MAX && !transformCache.has(cacheKey)) {
               const oldest = transformCache.keys().next().value;
               if (oldest !== undefined) transformCache.delete(oldest);
             }

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -14,7 +14,7 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
-const TRANSFORM_CACHE_MAX = 50;
+const TRANSFORM_CACHE_MAX = 5;
 const transformCache = new Map<string, { x: number; y: number; scale: number }>();
 
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -13,6 +13,8 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
+const transformCache = new Map<string, { x: number; y: number; scale: number }>();
+
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;
 
 type InteractiveMapProps = Omit<
@@ -29,14 +31,17 @@ type Dimensions = {
 
 type InteractiveMapZoomWrapperProps = {
   interactiveMapProps: InteractiveMapProps;
+  cacheKey?: string;
 };
 
 const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   interactiveMapProps,
+  cacheKey,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasInitializedRef = useRef(false);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -150,15 +155,21 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   }, [parsedDsvg]);
 
   useEffect(() => {
-    if (transformRef.current && containerDimensions && svgViewBox) {
+    if (!transformRef.current || !containerDimensions || !svgViewBox) return;
+    if (hasInitializedRef.current) return;
+    hasInitializedRef.current = true;
+
+    const cached = cacheKey ? transformCache.get(cacheKey) : null;
+    if (cached) {
+      transformRef.current.setTransform(cached.x, cached.y, cached.scale, 0);
+    } else {
       const scaledWidth = svgViewBox.width * minScale;
       const scaledHeight = svgViewBox.height * minScale;
       const centerX = (containerDimensions.width - scaledWidth) / 2;
       const centerY = (containerDimensions.height - scaledHeight) / 2;
-
       transformRef.current.setTransform(centerX, centerY, minScale, 0);
     }
-  }, [minScale, containerDimensions, svgViewBox]);
+  }, [minScale, containerDimensions, svgViewBox, cacheKey]);
 
   if (isLoading || !parsedDsvg || !renderer) {
     return (
@@ -185,6 +196,11 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
+        onTransformChange={(_, state) => {
+          if (cacheKey) {
+            transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
+          }
+        }}
       >
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap

--- a/packages/web/src/components/ui/message.tsx
+++ b/packages/web/src/components/ui/message.tsx
@@ -45,7 +45,7 @@ const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "rounded-lg p-2 text-foreground bg-secondary break-words whitespace-normal",
+      "rounded-lg p-2 text-foreground bg-secondary break-words whitespace-pre-wrap",
       className
     )}
     {...props}

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { Link } from "react-router";
+import { Link, Navigate, useSearchParams } from "react-router";
 import { UserPlus, MessageSquare, MessageSquareOff } from "lucide-react";
 import { useRequiredParams } from "@/hooks";
 
@@ -144,12 +144,22 @@ const ChannelListScreen: React.FC = () => {
   );
 };
 
-const ChannelListScreenSuspense: React.FC = () => (
-  <QueryErrorBoundary>
-    <Suspense fallback={<div></div>}>
-      <ChannelListScreen />
-    </Suspense>
-  </QueryErrorBoundary>
-);
+const ChannelListScreenSuspense: React.FC = () => {
+  const { gameId, phaseId } = useRequiredParams<{ gameId: string; phaseId: string }>();
+  const [searchParams] = useSearchParams();
+  const channelId = searchParams.get("channelId");
+
+  if (channelId) {
+    return <Navigate to={`/game/${gameId}/phase/${phaseId}/chat/channel/${channelId}`} replace />;
+  }
+
+  return (
+    <QueryErrorBoundary>
+      <Suspense fallback={<div></div>}>
+        <ChannelListScreen />
+      </Suspense>
+    </QueryErrorBoundary>
+  );
+};
 
 export { ChannelListScreenSuspense as ChannelListScreen };

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useEffect, useState, useMemo } from "react";
+import React, { Suspense, useRef, useEffect, useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
@@ -81,6 +81,8 @@ const buildMessageItems = (
   });
 };
 
+const channelFocusCache = new Map<string, boolean>();
+
 const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
 
 const NewMessagesDivider: React.FC = () => (
@@ -109,6 +111,21 @@ const ChannelScreen: React.FC = () => {
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isFocusedRef = useRef(false);
+
+  useEffect(() => {
+    const key = `${gameId}-${channelId}`;
+    if (channelFocusCache.get(key)) {
+      inputRef.current?.focus();
+    }
+    return () => {
+      channelFocusCache.set(key, isFocusedRef.current);
+    };
+  }, [gameId, channelId]);
+
+  const handleInputFocus = useCallback(() => { isFocusedRef.current = true; }, []);
+  const handleInputBlur = useCallback(() => { isFocusedRef.current = false; }, []);
 
   const channel = channels.find(c => c.id === parseInt(channelId));
   if (!channel) throw new Error("Channel not found");
@@ -310,10 +327,13 @@ const ChannelScreen: React.FC = () => {
           <Panel.Footer>
             <div className="flex gap-2 w-full">
               <Input
+                ref={inputRef}
                 placeholder="Type a message"
                 value={message}
                 onChange={e => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
                 disabled={createMessageMutation.isPending}
                 className="flex-1"
               />

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -81,6 +81,7 @@ const buildMessageItems = (
   });
 };
 
+const FOCUS_CACHE_MAX = 100;
 const channelFocusCache = new Map<string, boolean>();
 
 const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
@@ -120,6 +121,12 @@ const ChannelScreen: React.FC = () => {
       inputRef.current?.focus();
     }
     return () => {
+      if (channelFocusCache.size >= FOCUS_CACHE_MAX && !channelFocusCache.has(key)) {
+        const oldest = channelFocusCache.keys().next().value;
+        if (oldest !== undefined) channelFocusCache.delete(oldest);
+      }
+      // isFocusedRef.current is only true when onFocus fired, so no-press games
+      // (which never render the Input) will naturally store false here.
       channelFocusCache.set(key, isFocusedRef.current);
     };
   }, [gameId, channelId]);

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -119,7 +119,12 @@ const ChannelScreen: React.FC = () => {
   useEffect(() => {
     const key = `${gameId}-${channelId}`;
     if (channelFocusCache.get(key)) {
-      inputRef.current?.focus();
+      const el = inputRef.current;
+      if (el) {
+        el.focus();
+        const len = el.value.length;
+        el.setSelectionRange(len, len);
+      }
     }
     return () => {
       if (channelFocusCache.size >= FOCUS_CACHE_MAX && !channelFocusCache.has(key)) {

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, useRef, useEffect, useState, useMemo, useCallback } from "react";
-import { useNavigate } from "react-router";
+import React, { Suspense, useRef, useEffect, useState, useMemo } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
 import { useDraft, useRequiredParams } from "@/hooks";
@@ -81,8 +81,6 @@ const buildMessageItems = (
   });
 };
 
-const channelFocusCache = new Map<string, boolean>();
-
 const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
 
 const NewMessagesDivider: React.FC = () => (
@@ -103,6 +101,7 @@ const ChannelScreen: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [message, setMessage] = useDraft(gameId, channelId);
+  const [, setSearchParams] = useSearchParams();
 
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: channels } = useGamesChannelsListSuspense(gameId);
@@ -111,21 +110,14 @@ const ChannelScreen: React.FC = () => {
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const isFocusedRef = useRef(false);
 
   useEffect(() => {
-    const key = `${gameId}-${channelId}`;
-    if (channelFocusCache.get(key)) {
-      inputRef.current?.focus();
-    }
-    return () => {
-      channelFocusCache.set(key, isFocusedRef.current);
-    };
-  }, [gameId, channelId]);
-
-  const handleInputFocus = useCallback(() => { isFocusedRef.current = true; }, []);
-  const handleInputBlur = useCallback(() => { isFocusedRef.current = false; }, []);
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      next.set("channelId", channelId);
+      return next;
+    }, { replace: true });
+  }, [channelId, setSearchParams]);
 
   const channel = channels.find(c => c.id === parseInt(channelId));
   if (!channel) throw new Error("Channel not found");
@@ -327,14 +319,11 @@ const ChannelScreen: React.FC = () => {
           <Panel.Footer>
             <div className="flex gap-2 w-full">
               <Textarea
-                ref={inputRef}
                 placeholder="Type a message"
                 value={message}
                 rows={1}
                 onChange={e => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
                 disabled={createMessageMutation.isPending}
                 className="flex-1 min-h-0 max-h-32 resize-none py-2"
               />

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -81,7 +81,6 @@ const buildMessageItems = (
   });
 };
 
-const FOCUS_CACHE_MAX = 100;
 const channelFocusCache = new Map<string, boolean>();
 
 const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
@@ -111,7 +110,6 @@ const ChannelScreen: React.FC = () => {
   const createMessageMutation = useGamesChannelsMessagesCreateCreate();
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
-  const isMobileDevice = useMemo(() => window.matchMedia("(pointer: coarse)").matches, []);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isFocusedRef = useRef(false);
@@ -119,20 +117,9 @@ const ChannelScreen: React.FC = () => {
   useEffect(() => {
     const key = `${gameId}-${channelId}`;
     if (channelFocusCache.get(key)) {
-      const el = inputRef.current;
-      if (el) {
-        el.focus();
-        const len = el.value.length;
-        el.setSelectionRange(len, len);
-      }
+      inputRef.current?.focus();
     }
     return () => {
-      if (channelFocusCache.size >= FOCUS_CACHE_MAX && !channelFocusCache.has(key)) {
-        const oldest = channelFocusCache.keys().next().value;
-        if (oldest !== undefined) channelFocusCache.delete(oldest);
-      }
-      // isFocusedRef.current is only true when onFocus fired, so no-press games
-      // (which never render the Input) will naturally store false here.
       channelFocusCache.set(key, isFocusedRef.current);
     };
   }, [gameId, channelId]);
@@ -211,22 +198,9 @@ const ChannelScreen: React.FC = () => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (isMobileDevice) return;
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
-      if (e.altKey) {
-        const textarea = e.currentTarget;
-        const start = textarea.selectionStart;
-        const end = textarea.selectionEnd;
-        const newValue = message.slice(0, start) + "\n" + message.slice(end);
-        setMessage(newValue);
-        requestAnimationFrame(() => {
-          textarea.selectionStart = start + 1;
-          textarea.selectionEnd = start + 1;
-        });
-      } else {
-        handleSubmit();
-      }
+      handleSubmit();
     }
   };
 
@@ -351,34 +325,26 @@ const ChannelScreen: React.FC = () => {
           </Panel.Content>
           <Separator />
           <Panel.Footer>
-            <div className="flex flex-col gap-1 w-full">
-              <div className="flex gap-2">
-                <Textarea
-                  ref={inputRef}
-                  placeholder="Type a message"
-                  value={message}
-                  rows={1}
-                  onChange={e => setMessage(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onFocus={handleInputFocus}
-                  onBlur={handleInputBlur}
-                  disabled={createMessageMutation.isPending}
-                  enterKeyHint={isMobileDevice ? "enter" : "send"}
-                  className="flex-1 min-h-0 max-h-32 resize-none py-2"
-                />
-                <Button
-                  onClick={handleSubmit}
-                  disabled={!message.trim() || createMessageMutation.isPending}
-                  size="icon"
-                >
-                  <Send className="size-4" />
-                </Button>
-              </div>
-              {!isMobileDevice && (
-                <p className="text-[10px] text-muted-foreground/60 leading-none">
-                  Alt+Enter to add a new line
-                </p>
-              )}
+            <div className="flex gap-2 w-full">
+              <Textarea
+                ref={inputRef}
+                placeholder="Type a message"
+                value={message}
+                rows={1}
+                onChange={e => setMessage(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
+                disabled={createMessageMutation.isPending}
+                className="flex-1 min-h-0 max-h-32 resize-none py-2"
+              />
+              <Button
+                onClick={handleSubmit}
+                disabled={!message.trim() || createMessageMutation.isPending}
+                size="icon"
+              >
+                <Send className="size-4" />
+              </Button>
             </div>
           </Panel.Footer>
         </Panel>

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import {
   Message,
@@ -111,8 +111,9 @@ const ChannelScreen: React.FC = () => {
   const createMessageMutation = useGamesChannelsMessagesCreateCreate();
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
+  const isMobileDevice = useMemo(() => window.matchMedia("(pointer: coarse)").matches, []);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const isFocusedRef = useRef(false);
 
   useEffect(() => {
@@ -204,10 +205,23 @@ const ChannelScreen: React.FC = () => {
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isMobileDevice) return;
+    if (e.key === "Enter") {
       e.preventDefault();
-      handleSubmit();
+      if (e.altKey) {
+        const textarea = e.currentTarget;
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const newValue = message.slice(0, start) + "\n" + message.slice(end);
+        setMessage(newValue);
+        requestAnimationFrame(() => {
+          textarea.selectionStart = start + 1;
+          textarea.selectionEnd = start + 1;
+        });
+      } else {
+        handleSubmit();
+      }
     }
   };
 
@@ -332,25 +346,34 @@ const ChannelScreen: React.FC = () => {
           </Panel.Content>
           <Separator />
           <Panel.Footer>
-            <div className="flex gap-2 w-full">
-              <Input
-                ref={inputRef}
-                placeholder="Type a message"
-                value={message}
-                onChange={e => setMessage(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-                disabled={createMessageMutation.isPending}
-                className="flex-1"
-              />
-              <Button
-                onClick={handleSubmit}
-                disabled={!message.trim() || createMessageMutation.isPending}
-                size="icon"
-              >
-                <Send className="size-4" />
-              </Button>
+            <div className="flex flex-col gap-1 w-full">
+              <div className="flex gap-2">
+                <Textarea
+                  ref={inputRef}
+                  placeholder="Type a message"
+                  value={message}
+                  rows={1}
+                  onChange={e => setMessage(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  onFocus={handleInputFocus}
+                  onBlur={handleInputBlur}
+                  disabled={createMessageMutation.isPending}
+                  enterKeyHint={isMobileDevice ? "enter" : "send"}
+                  className="flex-1 min-h-0 max-h-32 resize-none py-2"
+                />
+                <Button
+                  onClick={handleSubmit}
+                  disabled={!message.trim() || createMessageMutation.isPending}
+                  size="icon"
+                >
+                  <Send className="size-4" />
+                </Button>
+              </div>
+              {!isMobileDevice && (
+                <p className="text-[10px] text-muted-foreground/60 leading-none">
+                  Alt+Enter to add a new line
+                </p>
+              )}
             </div>
           </Panel.Footer>
         </Panel>


### PR DESCRIPTION
I implemented this because it's a very good desktop improvement - we had this in the old Dip (based on user feedback), it makes logical sense, and I just got it re-affirmed/reminded by this beta tester. Sounded like a good 'UX a day' small improvement:
https://github.com/johnpooch/diplicity-react/discussions/614

This feature makes switching back and forth between the map while being in a conversation much easier — you can quickly jump to the map to check a position and return to exactly where you were in chat without losing your place.

## Changes

** Allow multi-line messages
- On mobile, enter now adds a newline. Pressing the 'send' button sends it. 
- On desktop, alt+enter now adds a newline. Pressing 'enter' sends it. 
<img width="450" height="577" alt="image" src="https://github.com/user-attachments/assets/761bc3f7-c8e2-4714-b58c-7a319f8fdc27" />
<img width="450" height="577" alt="image" src="https://github.com/user-attachments/assets/e4797627-b691-4f5c-b5bf-fa44ae13f85a" />


**Chat tab remembers your position**
- The Chat tab now returns you to the last channel you were viewing (e.g. the Italy chat), not always the channel list root
- The Chat tab highlights correctly when you're inside a channel (previously it appeared inactive on sub-routes)

**Map preserves zoom and pan (mobile only)**
- When you switch away from the Map tab and return, your zoom level and pan position are restored
- The cache is keyed per game + phase, so switching games or phases always starts centered

**Chat input focus is restored**
- If the text input had focus (keyboard open on Android) when you left the channel, focus is returned when you come back (note - the keyboard will not open on iOS, it will just focus on the field but iOS does not allow keyboard restore)
- If it didn't have focus, it stays unfocused — no unwanted keyboard pop-ups

**Draft messages unit location**
- When focus is restored on a draft message, the unit cursor is placed at the end instead of at the start.

## Test plan
- [ ] Open a channel, scroll to a specific message, switch to Map, switch back to Chat — confirm you land in the same channel
- [ ] Pan and zoom the map, switch to Chat/Orders, switch back to Map — confirm position is preserved
- [ ] Focus the chat input, switch to Map, switch back — confirm keyboard reappears (Android)
- [ ] Do not focus the chat input, switch away and back — confirm keyboard does not appear
- [ ] Switch between two different games — confirm map position resets correctly for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)