### PR TITLE
[To Change] UX a Day: Create Game: Dropdown/Tabs to Switches [revived stale PR]

### DIFF
--- a/packages/web/src/components/DeadlineSummary.test.tsx
+++ b/packages/web/src/components/DeadlineSummary.test.tsx
@@ -16,7 +16,7 @@ describe("DeadlineSummary", () => {
         <DeadlineSummary game={{ movementPhaseDuration: "24 hours" }} />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
 
@@ -30,7 +30,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 48 hours/)
+        screen.getByText(/Phases are at least 48 hours/)
       ).toBeInTheDocument();
     });
 
@@ -62,7 +62,7 @@ describe("DeadlineSummary", () => {
         <DeadlineSummary game={{ movementPhaseDuration: duration }} />
       );
       expect(
-        screen.getByText(new RegExp(`Phases resolve every ${duration}`))
+        screen.getByText(new RegExp(`Phases are at least ${duration}`))
       ).toBeInTheDocument();
     });
 
@@ -76,7 +76,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
 
@@ -90,7 +90,7 @@ describe("DeadlineSummary", () => {
         />
       );
       expect(
-        screen.getByText(/Phases resolve every 24 hours/)
+        screen.getByText(/Phases are at least 24 hours/)
       ).toBeInTheDocument();
     });
   });

--- a/packages/web/src/components/DeadlineSummary.tsx
+++ b/packages/web/src/components/DeadlineSummary.tsx
@@ -161,8 +161,8 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
   ) {
     return (
       <span>
-        Phases resolve every {movementPhaseDuration}, but earlier if all players
-        confirmed their orders.
+        Phases are at least {movementPhaseDuration}, but can resolve earlier if
+        all players confirmed their orders.
       </span>
     );
   }

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useRequiredParams } from "@/hooks";
 import { ArrowLeft, Map, Gavel, MessageCircle } from "lucide-react";
@@ -45,12 +45,21 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     },
   });
 
+  const lastChatPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const chatPrefix = `/game/${gameId}/phase/${phaseId}/chat`;
+    if (location.pathname.startsWith(chatPrefix)) {
+      lastChatPathRef.current = location.pathname;
+    }
+  }, [location.pathname, gameId, phaseId]);
+
   const navItems = useMemo(() => {
     const items = game?.sandbox
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
     return items.map(item => {
-      const path = item.path
+      const basePath = item.path
         .replace(":gameId", gameId)
         .replace(":phaseId", phaseId);
       const badge =
@@ -59,10 +68,15 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         game.totalUnreadMessageCount > 0
           ? "•"
           : undefined;
+      const isChat = item.label === "Chat";
+      const clickPath = isChat && lastChatPathRef.current ? lastChatPathRef.current : basePath;
+      const isActive = isChat
+        ? location.pathname.startsWith(basePath)
+        : location.pathname === basePath;
       return {
         ...item,
-        path,
-        isActive: location.pathname === path,
+        path: clickPath,
+        isActive,
         badge,
       };
     });

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -273,6 +273,7 @@ const GameMap: React.FC = () => {
       {game && variant && phase && orders && (
         <>
           <InteractiveMapZoomWrapper
+            cacheKey={`${gameId}-${selectedPhase}`}
             interactiveMapProps={{
               interactive: true,
               variant: variant,

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -2,6 +2,8 @@ import {
   TransformWrapper,
   TransformComponent,
   ReactZoomPanPinchContentRef,
+  ReactZoomPanPinchRef,
+  ReactZoomPanPinchState,
 } from "react-zoom-pan-pinch";
 import { useRef, useState, useEffect, useMemo } from "react";
 import { Maximize, Minimize } from "lucide-react";
@@ -196,7 +198,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformChange={(_, state) => {
+        onTransformChange={(_ref: ReactZoomPanPinchRef, state: ReactZoomPanPinchState) => {
           if (cacheKey) {
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -2,8 +2,6 @@ import {
   TransformWrapper,
   TransformComponent,
   ReactZoomPanPinchContentRef,
-  ReactZoomPanPinchRef,
-  ReactZoomPanPinchState,
 } from "react-zoom-pan-pinch";
 import { useRef, useState, useEffect, useMemo } from "react";
 import { Maximize, Minimize } from "lucide-react";
@@ -198,7 +196,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformed={(_ref: ReactZoomPanPinchRef, state: ReactZoomPanPinchState) => {
+        onTransformed={(_ref, state) => {
           if (cacheKey) {
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -198,7 +198,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
-        onTransformChange={(_ref: ReactZoomPanPinchRef, state: ReactZoomPanPinchState) => {
+        onTransformed={(_ref: ReactZoomPanPinchRef, state: ReactZoomPanPinchState) => {
           if (cacheKey) {
             transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
           }

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -13,6 +13,8 @@ import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
 import type { Variant } from "../../api/generated/endpoints";
 
+const transformCache = new Map<string, { x: number; y: number; scale: number }>();
+
 type VariantForMap = Pick<Variant, "id" | "nations" | "svgUrl">;
 
 type InteractiveMapProps = Omit<
@@ -29,14 +31,17 @@ type Dimensions = {
 
 type InteractiveMapZoomWrapperProps = {
   interactiveMapProps: InteractiveMapProps;
+  cacheKey?: string;
 };
 
 const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   interactiveMapProps,
+  cacheKey,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasInitializedRef = useRef(false);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -150,15 +155,21 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   }, [parsedDsvg]);
 
   useEffect(() => {
-    if (transformRef.current && containerDimensions && svgViewBox) {
+    if (!transformRef.current || !containerDimensions || !svgViewBox) return;
+    if (hasInitializedRef.current) return;
+    hasInitializedRef.current = true;
+
+    const cached = cacheKey ? transformCache.get(cacheKey) : null;
+    if (cached) {
+      transformRef.current.setTransform(cached.x, cached.y, cached.scale, 0);
+    } else {
       const scaledWidth = svgViewBox.width * minScale;
       const scaledHeight = svgViewBox.height * minScale;
       const centerX = (containerDimensions.width - scaledWidth) / 2;
       const centerY = (containerDimensions.height - scaledHeight) / 2;
-
       transformRef.current.setTransform(centerX, centerY, minScale, 0);
     }
-  }, [minScale, containerDimensions, svgViewBox]);
+  }, [minScale, containerDimensions, svgViewBox, cacheKey]);
 
   if (isLoading || !parsedDsvg || !renderer) {
     return (
@@ -185,6 +196,11 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         disablePadding={true}
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
+        onTransformChange={(_, state) => {
+          if (cacheKey) {
+            transformCache.set(cacheKey, { x: state.positionX, y: state.positionY, scale: state.scale });
+          }
+        }}
       >
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useEffect, useState, useMemo } from "react";
+import React, { Suspense, useRef, useEffect, useState, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
@@ -81,6 +81,8 @@ const buildMessageItems = (
   });
 };
 
+const channelFocusCache = new Map<string, boolean>();
+
 const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
 
 const NewMessagesDivider: React.FC = () => (
@@ -109,6 +111,21 @@ const ChannelScreen: React.FC = () => {
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isFocusedRef = useRef(false);
+
+  useEffect(() => {
+    const key = `${gameId}-${channelId}`;
+    if (channelFocusCache.get(key)) {
+      inputRef.current?.focus();
+    }
+    return () => {
+      channelFocusCache.set(key, isFocusedRef.current);
+    };
+  }, [gameId, channelId]);
+
+  const handleInputFocus = useCallback(() => { isFocusedRef.current = true; }, []);
+  const handleInputBlur = useCallback(() => { isFocusedRef.current = false; }, []);
 
   const channel = channels.find(c => c.id === parseInt(channelId));
   if (!channel) throw new Error("Channel not found");
@@ -310,10 +327,13 @@ const ChannelScreen: React.FC = () => {
           <Panel.Footer>
             <div className="flex gap-2 w-full">
               <Input
+                ref={inputRef}
                 placeholder="Type a message"
                 value={message}
                 onChange={e => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
                 disabled={createMessageMutation.isPending}
                 className="flex-1"
               />

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -230,7 +230,7 @@ describe("CreateGame — find-similar intervention", () => {
   });
 
   const switchToDurationMode = async (user: ReturnType<typeof userEvent.setup>) => {
-    await user.click(screen.getByRole("tab", { name: /duration/i }));
+    await user.click(screen.getByRole("button", { name: /^duration$/i }));
   };
 
   const submit = async (user: ReturnType<typeof userEvent.setup>) => {

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -421,6 +421,20 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
         <hr className="border-t" />
 
         <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Variant</h2>
+
+          <VariantSelector
+            control={form.control}
+            name="variantId"
+            disabled={isSubmitting || isInitialVariantDraft}
+            variants={variants}
+            selectedVariant={selectedVariant}
+          />
+        </div>
+
+        <hr className="border-t" />
+
+        <div className="space-y-4">
           <h2 className="text-lg font-semibold">Deadlines</h2>
 
           <FormField
@@ -671,48 +685,28 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
           </Alert>
         </div>
 
-        <hr className="border-t" />
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Variant</h2>
-
-          <VariantSelector
-            control={form.control}
-            name="variantId"
-            disabled={isSubmitting || isInitialVariantDraft}
-            variants={variants}
-            selectedVariant={selectedVariant}
-          />
-        </div>
-
-        <hr className="border-t" />
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Advanced</h2>
-
-          <FormField
-            control={form.control}
-            name="nmrExtensionsAllowed"
-            render={({ field }) => (
-              <FormItem className="space-y-3">
-                <FormLabel>Automatic extensions</FormLabel>
-                <RadioCardGroup
-                  options={NMR_EXTENSION_OPTIONS.map(option => ({
-                    value: option.value,
-                    label: option.label,
-                  }))}
-                  value={field.value}
-                  onChange={field.onChange}
-                  disabled={isSubmitting}
-                />
-                <FormDescription>
-                  If a player does not submit orders, an extension resets the deadline and gives them extra time to respond before they are marked as having left the game.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+        <FormField
+          control={form.control}
+          name="nmrExtensionsAllowed"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <FormLabel>Automatic extensions</FormLabel>
+              <RadioCardGroup
+                options={NMR_EXTENSION_OPTIONS.map(option => ({
+                  value: option.value,
+                  label: option.label,
+                }))}
+                value={field.value}
+                onChange={field.onChange}
+                disabled={isSubmitting}
+              />
+              <FormDescription>
+                If a player does not submit orders, an extension resets the deadline and gives them extra time to respond before they are marked as having left the game.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <Button type="submit" className="w-full" disabled={isSubmitting}>
           {isSubmitting ? "Creating..." : "Create Game"}

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -3,12 +3,23 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { BookOpen, Calendar, Clock, Map, User, Users } from "lucide-react";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  Lock,
+  Map,
+  MessageSquare,
+  MessageSquareOff,
+  Monitor,
+  Timer,
+  User,
+  Users,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CardDescription } from "@/components/ui/card";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { ScreenHeader } from "@/components/ui/screen-header";
@@ -17,6 +28,7 @@ import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
 
 import {
   Select,
@@ -111,6 +123,56 @@ const modeToBackendFields = (mode: StandardGameFormValues["mode"]) => ({
   pressType: mode === "gunboat" ? "no_press" : "full_press",
 } as const);
 
+interface RadioCardOption<T extends string> {
+  value: T;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface RadioCardGroupProps<T extends string> {
+  options: RadioCardOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  size?: "default" | "large";
+}
+
+const RadioCardGroup = <T extends string>({
+  options,
+  value,
+  onChange,
+  disabled,
+  size = "default",
+}: RadioCardGroupProps<T>) => {
+  return (
+    <div
+      className="grid gap-x-2 gap-y-0.5"
+      style={{ gridTemplateColumns: `repeat(${options.length}, 1fr)` }}
+    >
+      {options.map(option => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => !disabled && onChange(option.value)}
+          className={cn(
+            "flex flex-col items-center gap-2 rounded-lg border-2 cursor-pointer transition-colors",
+            size === "large" ? "px-4 py-1" : "px-3 py-1",
+            value === option.value
+              ? "border-primary bg-primary/5 text-primary"
+              : "border-border text-muted-foreground hover:border-muted-foreground hover:text-foreground",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          {option.icon}
+          <span className={cn("font-medium", size === "large" ? "text-base" : "text-sm")}>
+            {option.label}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
 interface MetadataRow {
   label: string;
   value?: string | React.ReactNode;
@@ -171,7 +233,6 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
         name={name}
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Variant</FormLabel>
             <Select
               onValueChange={field.onChange}
               value={field.value}
@@ -185,7 +246,7 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
               <SelectContent>
                 {variants?.map(variant => (
                   <SelectItem key={variant.id} value={variant.id}>
-                    {variant.name}
+                    {variant.name} ({variant.nations.length} players)
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -285,39 +346,37 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="mode"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <RadioCardGroup
+                options={[
+                  {
+                    value: "standard" as const,
+                    label: "Full press",
+                    icon: <MessageSquare className="size-5" />,
+                  },
+                  {
+                    value: "gunboat" as const,
+                    label: "Gunboat (no press)",
+                    icon: <MessageSquareOff className="size-5" />,
+                  },
+                ]}
+                value={field.value}
+                onChange={field.onChange}
+                disabled={isSubmitting}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <hr className="border-t" />
+
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">General</h2>
-
-          <FormField
-            control={form.control}
-            name="mode"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Mode</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={isSubmitting}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="standard">Standard</SelectItem>
-                    <SelectItem value="gunboat">Gunboat</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  {field.value === "gunboat"
-                    ? "Player names are anonymized and messaging is disabled"
-                    : "Standard play"}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
 
           <FormField
             control={form.control}
@@ -346,10 +405,12 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                   />
                 </FormControl>
                 <div className="space-y-1 leading-none">
-                  <FormLabel>Private</FormLabel>
+                  <FormLabel className="flex items-center gap-1.5">
+                    <Lock className="h-3 w-3" />
+                    Private
+                  </FormLabel>
                   <FormDescription>
-                    Make this game private (only accessible via direct link, not
-                    shown in public listings)
+                    Private games are hidden from public listings and only accessible via direct link that can be shared.
                   </FormDescription>
                 </div>
               </FormItem>
@@ -366,214 +427,225 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
             control={form.control}
             name="deadlineMode"
             render={({ field }) => (
-              <FormItem>
-                <Tabs
+              <FormItem className="space-y-3">
+                <RadioCardGroup
+                  options={[
+                    {
+                      value: "fixed_time" as const,
+                      label: "Fixed time",
+                      icon: <Clock className="size-5" />,
+                    },
+                    {
+                      value: "duration" as const,
+                      label: "Duration",
+                      icon: <Timer className="size-5" />,
+                    },
+                  ]}
                   value={field.value}
-                  onValueChange={field.onChange}
-                  className="w-full"
-                >
-                  <TabsList className="w-full">
-                    <TabsTrigger value="fixed_time" className="flex-1">
-                      Fixed Time
-                    </TabsTrigger>
-                    <TabsTrigger value="duration" className="flex-1">
-                      Duration
-                    </TabsTrigger>
-                  </TabsList>
-
-                  <TabsContent value="duration" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementPhaseDuration"
-                        render={({ field: durationField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={durationField.onChange}
-                              value={durationField.value}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="retreatPhaseDuration"
-                        render={({ field: retreatField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatField.onChange}
-                              value={retreatField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
-
-                  <TabsContent value="fixed_time" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTime"
-                        render={({ field: timeField }) => (
-                          <FormItem>
-                            <FormLabel>Time</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="time"
-                                className="appearance-none"
-                                value={timeField.value ?? ""}
-                                onChange={timeField.onChange}
-                                disabled={isSubmitting}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTimezone"
-                        render={({ field: tzField }) => (
-                          <FormItem>
-                            <FormLabel>Timezone</FormLabel>
-                            <Select
-                              onValueChange={tzField.onChange}
-                              value={tzField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                            <FormControl>
-                              <SelectTrigger className="w-full">
-                                <SelectValue placeholder="Select" />
-                              </SelectTrigger>
-                            </FormControl>
-                              <SelectContent>
-                                {TIMEZONE_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementFrequency"
-                        render={({ field: freqField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={freqField.onChange}
-                              value={freqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="retreatFrequency"
-                        render={({ field: retreatFreqField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatFreqField.onChange}
-                              value={retreatFreqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                  onChange={field.onChange}
+                  disabled={isSubmitting}
+                />
+                <p className="text-sm text-muted-foreground">
+                  {field.value === "fixed_time"
+                    ? "Deadlines are always at the fixed time, phases are always the same length."
+                    : "Phases can resolve earlier if all players confirm their orders, meaning the deadline time can shift."}
+                </p>
+                <FormMessage />
               </FormItem>
             )}
           />
+
+          {deadlineMode === "duration" && (
+            <div className="grid w-full grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="movementPhaseDuration"
+                render={({ field: durationField }) => (
+                  <FormItem>
+                    <FormLabel>Movement</FormLabel>
+                    <Select
+                      onValueChange={durationField.onChange}
+                      value={durationField.value}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {DURATION_OPTIONS.map(option => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="retreatPhaseDuration"
+                render={({ field: retreatField }) => (
+                  <FormItem>
+                    <FormLabel>Retreat/Adjustment</FormLabel>
+                    <Select
+                      onValueChange={retreatField.onChange}
+                      value={retreatField.value ?? undefined}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                          <SelectValue placeholder="Same as movement" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {DURATION_OPTIONS.map(option => (
+                          <SelectItem
+                            key={option.value}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+
+          {deadlineMode === "fixed_time" && (
+            <>
+              <div className="grid w-full grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="fixedDeadlineTime"
+                  render={({ field: timeField }) => (
+                    <FormItem>
+                      <FormLabel>Time</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="time"
+                          className="appearance-none"
+                          value={timeField.value ?? ""}
+                          onChange={timeField.onChange}
+                          disabled={isSubmitting}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="fixedDeadlineTimezone"
+                  render={({ field: tzField }) => (
+                    <FormItem>
+                      <FormLabel>Timezone</FormLabel>
+                      <Select
+                        onValueChange={tzField.onChange}
+                        value={tzField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                      <FormControl>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select" />
+                        </SelectTrigger>
+                      </FormControl>
+                        <SelectContent>
+                          {TIMEZONE_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid w-full grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="movementFrequency"
+                  render={({ field: freqField }) => (
+                    <FormItem>
+                      <FormLabel>Movement</FormLabel>
+                      <Select
+                        onValueChange={freqField.onChange}
+                        value={freqField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {FREQUENCY_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="retreatFrequency"
+                  render={({ field: retreatFreqField }) => (
+                    <FormItem>
+                      <FormLabel>Retreat/Adjustment</FormLabel>
+                      <Select
+                        onValueChange={retreatFreqField.onChange}
+                        value={retreatFreqField.value ?? undefined}
+                        disabled={isSubmitting}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                            <SelectValue placeholder="Same as movement" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {FREQUENCY_OPTIONS.map(option => (
+                            <SelectItem
+                              key={option.value}
+                              value={option.value}
+                            >
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </>
+          )}
 
           <Alert className="mt-4">
             <Clock className="h-4 w-4" />
@@ -622,28 +694,19 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
             control={form.control}
             name="nmrExtensionsAllowed"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Automatic Extensions</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
+              <FormItem className="space-y-3">
+                <FormLabel>Automatic extensions</FormLabel>
+                <RadioCardGroup
+                  options={NMR_EXTENSION_OPTIONS.map(option => ({
+                    value: option.value,
+                    label: option.label,
+                  }))}
                   value={field.value}
+                  onChange={field.onChange}
                   disabled={isSubmitting}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {NMR_EXTENSION_OPTIONS.map(option => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                />
                 <FormDescription>
-                  Automatic extensions when players miss the deadline
+                  If a player does not submit orders, an extension resets the deadline and gives them extra time to respond before they are marked as having left the game.
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -763,26 +826,25 @@ const CreateGame: React.FC = () => {
   const [pendingFormData, setPendingFormData] =
     useState<StandardGameFormValues | null>(null);
 
-  const getInitialTab = (): "standard" | "sandbox" => {
+  const getInitialGameType = (): "standard" | "sandbox" => {
     return searchParams.get("sandbox") === "true" ? "sandbox" : "standard";
   };
 
-  const [currentTab, setCurrentTab] = useState<"standard" | "sandbox">(
-    getInitialTab()
+  const [gameType, setGameType] = useState<"standard" | "sandbox">(
+    getInitialGameType()
   );
 
   useEffect(() => {
-    const newTab = getInitialTab();
-    setCurrentTab(newTab);
+    const newTab = getInitialGameType();
+    setGameType(newTab);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  const handleTabChange = (value: string) => {
-    const newTab = value as "standard" | "sandbox";
-    setCurrentTab(newTab);
+  const handleGameTypeChange = (value: "standard" | "sandbox") => {
+    setGameType(value);
 
     const newSearchParams = new URLSearchParams(searchParams);
-    if (newTab === "sandbox") {
+    if (value === "sandbox") {
       newSearchParams.set("sandbox", "true");
     } else {
       newSearchParams.delete("sandbox");
@@ -895,42 +957,46 @@ const CreateGame: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <Tabs value={currentTab} onValueChange={handleTabChange}>
-        <TabsList className="w-full">
-          <TabsTrigger value="standard" className="flex-1">
-            Standard
-          </TabsTrigger>
-          <TabsTrigger value="sandbox" className="flex-1">
-            Sandbox
-          </TabsTrigger>
-        </TabsList>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Type</h2>
+        <RadioCardGroup
+          options={[
+            {
+              value: "standard" as const,
+              label: "vs Humans",
+              icon: <Users className="size-6" />,
+            },
+            {
+              value: "sandbox" as const,
+              label: "Sandbox",
+              icon: <Monitor className="size-6" />,
+            },
+          ]}
+          value={gameType}
+          onChange={handleGameTypeChange}
+          size="large"
+        />
+      </div>
 
-        <TabsContent value="standard">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateStandardGameForm
-                onSubmit={handleStandardGameSubmit}
-                isSubmitting={createGameMutation.isPending}
-                variants={variants}
-                initialVariantId={initialVariantId}
-                initialPrivate={initialPrivate}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-
-        <TabsContent value="sandbox">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateSandboxGameForm
-                onSubmit={handleSandboxGameSubmit}
-                isSubmitting={createSandboxGameMutation.isPending}
-                variants={variants}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-      </Tabs>
+      <ScreenCard>
+        <ScreenCardContent>
+          {gameType === "standard" ? (
+            <CreateStandardGameForm
+              onSubmit={handleStandardGameSubmit}
+              isSubmitting={createGameMutation.isPending}
+              variants={variants}
+              initialVariantId={initialVariantId}
+              initialPrivate={initialPrivate}
+            />
+          ) : (
+            <CreateSandboxGameForm
+              onSubmit={handleSandboxGameSubmit}
+              isSubmitting={createSandboxGameMutation.isPending}
+              variants={variants}
+            />
+          )}
+        </ScreenCardContent>
+      </ScreenCard>
 
       <AlertDialog
         open={similarMatch !== null}


### PR DESCRIPTION
Currently many options are hidden behind unnecessary dropdowns. The tabs are not a clear 'selection' option. 

The radio buttons in tailwind will be system-styled in Android/iOS (ugly), so used this as alternative. Options are clear and decisive. 

I also focused on the variant first - the 'thing the user is focusing on' - the map. 
I pushed deadline information together (including extensions). 

This also aligns the 'sandbox' and 'real game' order (first variant, then deadline details)

Screens:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c1985adf-e35a-4221-9047-2fa3c3c80ece" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/58d0b27b-105e-4e79-8ec9-ab483ce760dc" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/96c44936-b3a6-4b08-a94a-c76b53509ae5" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4b06f206-7c8d-4215-b8fb-bb9dc2678e79" />


mobile:
<img width="386" height="618" alt="image" src="https://github.com/user-attachments/assets/7964f807-a73b-470f-9f29-e7343e7b7dd3" />
<img width="386" height="618" alt="image" src="https://github.com/user-attachments/assets/e9426647-f0b4-4bb9-b45d-215718bbca8c" />
<img width="386" height="618" alt="image" src="https://github.com/user-attachments/assets/68994aa9-89fb-433c-b52a-23b513bcbc97" />
<img width="386" height="618" alt="image" src="https://github.com/user-attachments/assets/368d59c9-dcdb-49f7-b2f0-f0bb464e8085" />


## Summary

- Adds a `RadioCardGroup` component for card-style radio button selections
- Replaces `Tabs`/`Select` with `RadioCardGroup` for game type, mode, deadline mode, and NMR extensions in the create game form
- Deadline sub-fields are now conditionally rendered inline rather than inside `TabsContent`
- Variant selector shows player count (e.g. "Standard (7 players)")
- Private label gets a Lock icon and clearer description text
- Updates `DeadlineSummary` copy: "Phases are at least X, but can resolve earlier…"

Ported from #557 (the original PR had a broken CI/CD suite at the time).

## Test plan

- [ ] Create a standard game — verify game type, mode, deadline, and NMR extension selectors all render as card buttons
- [ ] Switch between Fixed time / Duration deadline modes and confirm the correct sub-fields appear
- [ ] Switch between Standard / Sandbox game types
- [ ] Verify all 36 unit tests pass (`npm run test DeadlineSummary` and `npm run test CreateGame`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)