### PR TITLE
Fix map colour distortion in Android dark mode

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap"
     rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
   <title>Diplicity</title>
 
   <!-- PWA Manifest -->


### PR DESCRIPTION
## Problem

On Xiaomi/Redmi devices with system dark mode enabled, map colours appear distorted. Switching the system to light mode restores correct colours.

<img width="1080" height="1807" alt="image" src="https://github.com/user-attachments/assets/28fae411-9f97-48dc-b437-cd71355fbd3f" />


**Root cause**: The Android theme `AppTheme.NoActionBar` uses `Theme.AppCompat.DayNight.NoActionBar`, which tells Android the app participates in system dark/light switching. On Android 10+ — and especially on MIUI/HyperOS, which is aggressive about this — the Android WebView applies an **algorithmic forced dark mode** on top of whatever colours the web content already has.

The app already handles dark mode via CSS. So in system dark mode:
1. CSS dark mode transforms colours correctly ✓
2. Android WebView forced dark applies a *second* colour transformation on top ✗

The result is doubly-transformed, wrong colours.

## Fix (attempt 1 — CSS)

Add `<meta name="color-scheme" content="light dark">` to `index.html`. This is the W3C-standard signal that the page manages its own dark mode, which should prevent the WebView's forced dark algorithm from running.

## If this doesn't work — nuclear option (Java)

If MIUI ignores the meta tag (it can be stubborn), the definitive fix is to explicitly disable forced dark mode on the WebView in `MainActivity.java`:

```java
import android.os.Bundle;
import androidx.webkit.WebSettingsCompat;
import androidx.webkit.WebViewFeature;
import com.getcapacitor.BridgeActivity;

public class MainActivity extends BridgeActivity {
    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        // Disable Android WebView forced dark mode — the app manages dark mode via CSS.
        // Without this, DayNight theme causes WebView to apply a second colour transform
        // on top of our CSS dark mode, producing wrong colours on MIUI devices.
        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
            WebSettingsCompat.setAlgorithmicDarkeningAllowed(
                getBridge().getWebView().getSettings(), false);
        } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
            WebSettingsCompat.setForceDark(
                getBridge().getWebView().getSettings(), WebSettingsCompat.FORCE_DARK_OFF);
        }
    }
}
```

`ALGORITHMIC_DARKENING` is the API 33+ replacement for the deprecated `FORCE_DARK` — the `else if` covers older Android versions.

## Test plan

- [ ] Verify map colours are correct on a Xiaomi/Redmi device with system dark mode enabled
- [ ] Verify map colours are correct with system light mode (regression check)
- [ ] Verify the app's own dark/light mode toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)