### PR TITLE
Reject variant uploads with ambiguous phase transitions

### DIFF
--- a/service/variant/tests/test_dvar_validation.py
+++ b/service/variant/tests/test_dvar_validation.py
@@ -1,0 +1,76 @@
+from variant.utils import _validate_dvar_phase_progression
+
+
+CLASSICAL_PHASE_PROGRESSION = {
+    "seasons": ["Spring", "Fall"],
+    "transitions": [
+        {"from": {"type": "Movement", "season": "Spring"}, "to": {"type": "Retreat", "season": "Spring", "yearDelta": 0}},
+        {"from": {"type": "Retreat", "season": "Spring"}, "to": {"type": "Movement", "season": "Fall", "yearDelta": 0}},
+        {"from": {"type": "Movement", "season": "Fall"}, "to": {"type": "Retreat", "season": "Fall", "yearDelta": 0}},
+        {"from": {"type": "Retreat", "season": "Fall"}, "to": {"type": "Adjustment", "season": "Fall", "yearDelta": 0}},
+        {"from": {"type": "Adjustment", "season": "Fall"}, "to": {"type": "Movement", "season": "Spring", "yearDelta": 1}},
+    ],
+}
+
+
+def test_classical_progression_is_valid():
+    errors = _validate_dvar_phase_progression({"phaseProgression": CLASSICAL_PHASE_PROGRESSION})
+    assert errors == []
+
+
+def test_ambiguous_unconditional_transitions():
+    dvar = {
+        "phaseProgression": {
+            "seasons": ["Movement A", "Retreat", "Movement B", "Build"],
+            "transitions": [
+                {"from": {"type": "Movement", "season": "Movement A"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Movement", "season": "Movement B", "yearDelta": 0}},
+                {"from": {"type": "Movement", "season": "Movement B"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Adjustment", "season": "Build", "yearDelta": 0}},
+                {"from": {"type": "Adjustment", "season": "Build"}, "to": {"type": "Movement", "season": "Movement A", "yearDelta": 60}},
+            ],
+        }
+    }
+    errors = _validate_dvar_phase_progression(dvar)
+    assert len(errors) == 1
+    assert errors[0].code == "AMBIGUOUS_TRANSITION"
+    assert "1 and 3" in errors[0].message
+
+
+def test_conditional_transitions_with_same_from_are_valid():
+    dvar = {
+        "phaseProgression": {
+            "seasons": ["Movement A", "Retreat", "Movement B", "Build"],
+            "transitions": [
+                {"from": {"type": "Movement", "season": "Movement A"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Movement", "season": "Movement B", "yearDelta": 0}, "condition": {"yearMod": 100, "yearModValue": 20}},
+                {"from": {"type": "Movement", "season": "Movement B"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Adjustment", "season": "Build", "yearDelta": 0}, "condition": {"yearMod": 100, "yearModValue": 40}},
+                {"from": {"type": "Adjustment", "season": "Build"}, "to": {"type": "Movement", "season": "Movement A", "yearDelta": 60}},
+            ],
+        }
+    }
+    errors = _validate_dvar_phase_progression(dvar)
+    assert errors == []
+
+
+def test_one_conditional_one_unconditional_is_valid():
+    dvar = {
+        "phaseProgression": {
+            "seasons": ["Movement A", "Retreat", "Movement B", "Build"],
+            "transitions": [
+                {"from": {"type": "Movement", "season": "Movement A"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Movement", "season": "Movement B", "yearDelta": 0}},
+                {"from": {"type": "Movement", "season": "Movement B"}, "to": {"type": "Retreat", "season": "Retreat", "yearDelta": 20}},
+                {"from": {"type": "Retreat", "season": "Retreat"}, "to": {"type": "Adjustment", "season": "Build", "yearDelta": 0}, "condition": {"yearMod": 100, "yearModValue": 40}},
+                {"from": {"type": "Adjustment", "season": "Build"}, "to": {"type": "Movement", "season": "Movement A", "yearDelta": 60}},
+            ],
+        }
+    }
+    errors = _validate_dvar_phase_progression(dvar)
+    assert errors == []
+
+
+def test_missing_phase_progression():
+    errors = _validate_dvar_phase_progression({})
+    assert errors == []

--- a/service/variant/utils.py
+++ b/service/variant/utils.py
@@ -53,6 +53,7 @@ def validate_dvar(dvar):
 
     errors.extend(_validate_dvar_references(dvar))
     errors.extend(_validate_dvar_adjacencies(dvar))
+    errors.extend(_validate_dvar_phase_progression(dvar))
     return errors
 
 
@@ -165,6 +166,37 @@ def _validate_dvar_adjacencies(dvar):
                     f"adjacencies.{source}",
                 )
             )
+
+    return errors
+
+
+def _validate_dvar_phase_progression(dvar):
+    errors = []
+    pp = dvar.get("phaseProgression")
+    if not pp:
+        return errors
+
+    transitions = pp.get("transitions", [])
+    unconditional_froms = {}
+    for i, t in enumerate(transitions):
+        if "condition" in t and t["condition"]:
+            continue
+        key = (t["from"]["type"], t["from"]["season"])
+        if key in unconditional_froms:
+            prev_i = unconditional_froms[key]
+            errors.append(
+                DvarValidationError(
+                    "AMBIGUOUS_TRANSITION",
+                    f"Transitions {prev_i} and {i} both match "
+                    f"from ({key[0]}, {key[1]}) with no condition — "
+                    f"transition {i} will never fire. "
+                    f"Give the phases distinct season names or add a "
+                    f"yearMod condition to disambiguate.",
+                    f"phaseProgression.transitions.{i}",
+                )
+            )
+        else:
+            unconditional_froms[key] = i
 
     return errors
 


### PR DESCRIPTION
## Summary

- Adds upload-time validation that rejects phase progressions where two unconditional transitions share the same `(from_type, from_season)`. The second transition would be unreachable at runtime since `next_phase()` picks the first match.
- This caused the Battle of Tsushima variant's Build phase to be skipped — two Retreat phases shared the season name `"Retreat"`, so the `Retreat → Build` transition was shadowed by `Retreat → Movement B`.
- The error message tells variant creators how to fix it: use distinct season names or add `yearMod` conditions.