### PR TITLE
Mark phase as completed when game ends via draw

### DIFF
--- a/service/draw_proposal/models.py
+++ b/service/draw_proposal/models.py
@@ -1,7 +1,7 @@
 from django.db import models, transaction
 from django.utils import timezone
 from common.models import BaseModel
-from common.constants import GameStatus
+from common.constants import GameStatus, PhaseStatus
 from draw_proposal.constants import DrawProposalStatus
 from victory.models import Victory
 
@@ -140,6 +140,10 @@ class DrawProposal(BaseModel):
             self.game.status = GameStatus.COMPLETED
             self.game.finished_at = timezone.now()
             self.game.save()
+
+            self.phase.status = PhaseStatus.COMPLETED
+            self.phase.scheduled_resolution = None
+            self.phase.save()
 
             return victory
 

--- a/service/draw_proposal/tests.py
+++ b/service/draw_proposal/tests.py
@@ -1,6 +1,7 @@
 import pytest
+from django.utils import timezone
 from rest_framework import status
-from common.constants import GameStatus
+from common.constants import GameStatus, PhaseStatus
 from draw_proposal.models import DrawProposal, DrawVote
 from draw_proposal.constants import DrawProposalStatus
 from victory.models import Victory
@@ -201,7 +202,8 @@ class TestDrawProposalProcessAcceptance:
         self, game_factory, phase_factory, member_factory, supply_center_factory, draw_proposal_factory
     ):
         game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game)
+        future = timezone.now() + timezone.timedelta(hours=20)
+        phase = phase_factory(game=game, scheduled_resolution=future)
         m1 = member_factory(game=game)
         m2 = member_factory(game=game)
         m3 = member_factory(game=game)
@@ -238,6 +240,10 @@ class TestDrawProposalProcessAcceptance:
 
         game.refresh_from_db()
         assert game.status == GameStatus.COMPLETED
+
+        phase.refresh_from_db()
+        assert phase.status == PhaseStatus.COMPLETED
+        assert phase.scheduled_resolution is None
 
     def test_cd_member_not_in_victory(
         self, game_factory, phase_factory, member_factory


### PR DESCRIPTION
The draw proposal acceptance path (`DrawProposal.process_acceptance`) set `game.status` to `completed` but left the current phase as `active` with a future `scheduled_resolution`. The frontend timer checks `phase.status === "active"`, so it kept ticking on finished games.

Adds `phase.status = COMPLETED` and `phase.scheduled_resolution = None` to the draw completion path, matching what `PhaseManager.resolve()` already does for solo victories and abandonments.

Closes #623