### PR TITLE
Revert will-change: transform on map transform layer

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -248,10 +248,7 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         onZoomStart={handleGestureStart}
         onZoomStop={handleGestureStop}
       >
-        <TransformComponent
-          wrapperStyle={{ width: "100%", height: "100%" }}
-          contentStyle={{ willChange: "transform" }}
-        >
+        <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
           <InteractiveMap
             ref={svgRef}
             {...interactiveMapProps}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Reverts the `will-change: transform` added to `TransformComponent`'s `contentStyle` in #634. This change promoted the SVG to a GPU compositing layer which caused rendering bugs on some devices.

The pointer-events suppression during gestures (also from #634) is retained.

## Test plan

- [ ] Pan and zoom the map — no rendering bugs
- [ ] Verify the map renders correctly on mobile
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1kUDNVFBzb49LpFeHk1mC)_