### PR TITLE
Add Railway authentication and access tier documentation

### DIFF
--- a/.claude/commands/debug-production.md
+++ b/.claude/commands/debug-production.md
@@ -2,7 +2,7 @@ Run a production health check by gathering data from multiple sources.
 
 ## Instructions
 
-0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production debugging is not available. The `RAILWAY_ACCOUNT_TOKEN` environment variable must be set in the claude.ai/code project settings."
+0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production debugging is not available. The `RAILWAY_API_TOKEN` environment variable must be set in the claude.ai/code project settings."
 
 1. **Check deployment status** by running `railway status` to see the current deployment state, uptime, and any recent deployment failures.
 

--- a/.claude/commands/debug-production.md
+++ b/.claude/commands/debug-production.md
@@ -2,6 +2,8 @@ Run a production health check by gathering data from multiple sources.
 
 ## Instructions
 
+0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production debugging is not available. The `RAILWAY_ACCOUNT_TOKEN` environment variable must be set in the claude.ai/code project settings."
+
 1. **Check deployment status** by running `railway status` to see the current deployment state, uptime, and any recent deployment failures.
 
 2. **Check recent logs** by running `railway logs --lines 50` and scanning for:

--- a/.claude/commands/prod-query.md
+++ b/.claude/commands/prod-query.md
@@ -11,6 +11,8 @@ Query: $ARGUMENTS
 
 ## Instructions
 
+0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production database queries are not available. The `RAILWAY_ACCOUNT_TOKEN` environment variable must be set in the claude.ai/code project settings."
+
 1. **Understand the request** and determine which Django models and fields are needed. If unsure about the schema, read the relevant model files under `service/` first. Available apps: `game`, `member`, `phase`, `order`, `unit`, `channel`, `draw_proposal`, `nation`, `province`, `supply_center`, `user_profile`, `variant`, `victory`.
 
 2. **Write a Python script** to the scratchpad directory that:

--- a/.claude/commands/prod-query.md
+++ b/.claude/commands/prod-query.md
@@ -11,7 +11,7 @@ Query: $ARGUMENTS
 
 ## Instructions
 
-0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production database queries are not available. The `RAILWAY_ACCOUNT_TOKEN` environment variable must be set in the claude.ai/code project settings."
+0. **Check Railway authentication** before proceeding. Run `railway status` and check the output. If it fails with an authentication error or "not logged in" message, stop immediately and tell the user: "Railway is not configured in this session — production database queries are not available. The `RAILWAY_API_TOKEN` environment variable must be set in the claude.ai/code project settings."
 
 1. **Understand the request** and determine which Django models and fields are needed. If unsure about the schema, read the relevant model files under `service/` first. Available apps: `game`, `member`, `phase`, `order`, `unit`, `channel`, `draw_proposal`, `nation`, `province`, `supply_center`, `user_profile`, `variant`, `victory`.
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,11 +5,9 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-if [ -z "${RAILWAY_ACCOUNT_TOKEN:-}" ]; then
-  echo "RAILWAY_ACCOUNT_TOKEN not set — Railway CLI will not be authenticated in this session." >&2
+if [ -z "${RAILWAY_API_TOKEN:-}" ]; then
+  echo "RAILWAY_API_TOKEN not set — Railway CLI will not be authenticated in this session." >&2
   exit 0
 fi
 
-mkdir -p ~/.railway
-printf '{"token":"%s"}' "${RAILWAY_ACCOUNT_TOKEN}" > ~/.railway/config.json
 echo "Railway CLI authenticated."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+if [ -z "${RAILWAY_ACCOUNT_TOKEN:-}" ]; then
+  echo "RAILWAY_ACCOUNT_TOKEN not set — Railway CLI will not be authenticated in this session." >&2
+  exit 0
+fi
+
+mkdir -p ~/.railway
+printf '{"token":"%s"}' "${RAILWAY_ACCOUNT_TOKEN}" > ~/.railway/config.json
+echo "Railway CLI authenticated."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,16 @@
     "defaultMode": "acceptEdits"
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,9 +648,11 @@ The application is deployed on **Railway** (project: `devoted-rejoicing`, servic
 
 ## Railway CLI
 
-The Railway CLI authenticates via the login token stored in `~/.railway/config.json` (set by `railway login`). Do **not** set a `RAILWAY_TOKEN` env var — project tokens conflict with CLI commands and cause "Project Token not found" errors.
+The Railway CLI authenticates via the `RAILWAY_API_TOKEN` environment variable. This is an **account-scoped** token, not a project token.
 
-In cloud sessions, the session-start hook writes `~/.railway/config.json` automatically if the `RAILWAY_ACCOUNT_TOKEN` environment variable is set in the project settings.
+Do **not** use `RAILWAY_TOKEN` — that is project-scoped, conflicts with CLI commands, and causes "Project Token not found" errors. `RAILWAY_API_TOKEN` is the correct variable for account-level actions (`railway ssh`, `railway logs`, `railway status`, etc.).
+
+In cloud sessions, the session-start hook checks for `RAILWAY_API_TOKEN` at startup and logs whether Railway is available. The Railway CLI reads this env var directly — no config file write is needed.
 
 ## Railway Access Tiers
 
@@ -662,9 +664,9 @@ Not all sessions have Railway access:
 
 ### When Railway is not configured
 
-If `~/.railway/config.json` does not exist, or any `railway` command fails with an authentication or "not logged in" error, **stop immediately** — this is an expected missing-credential situation, not a bug to diagnose. Tell the user:
+If any `railway` command fails with an authentication or "not logged in" error, **stop immediately** — this is an expected missing-credential situation, not a bug to diagnose. Tell the user:
 
-> "Railway is not configured in this session. Production debugging requires the `RAILWAY_ACCOUNT_TOKEN` environment variable to be set in the claude.ai/code project settings."
+> "Railway is not configured in this session. Production debugging requires the `RAILWAY_API_TOKEN` environment variable to be set in the claude.ai/code project settings."
 
 Do not retry Railway commands, do not attempt workarounds, and do not use `/prod-query` or `/debug-production`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -650,6 +650,34 @@ The application is deployed on **Railway** (project: `devoted-rejoicing`, servic
 
 The Railway CLI authenticates via the login token stored in `~/.railway/config.json` (set by `railway login`). Do **not** set a `RAILWAY_TOKEN` env var — project tokens conflict with CLI commands and cause "Project Token not found" errors.
 
+In cloud sessions, the session-start hook writes `~/.railway/config.json` automatically if the `RAILWAY_ACCOUNT_TOKEN` environment variable is set in the project settings.
+
+## Railway Access Tiers
+
+Not all sessions have Railway access:
+
+- **Owner sessions**: Full Railway account token configured — all commands available including `railway ssh`
+- **Trusted contributor sessions**: Full Railway account token configured — all commands available; write safety rules apply (see below)
+- **Casual contributor sessions**: No Railway token — Railway commands unavailable
+
+### When Railway is not configured
+
+If `~/.railway/config.json` does not exist, or any `railway` command fails with an authentication or "not logged in" error, **stop immediately** — this is an expected missing-credential situation, not a bug to diagnose. Tell the user:
+
+> "Railway is not configured in this session. Production debugging requires the `RAILWAY_ACCOUNT_TOKEN` environment variable to be set in the claude.ai/code project settings."
+
+Do not retry Railway commands, do not attempt workarounds, and do not use `/prod-query` or `/debug-production`.
+
+### Write safety
+
+`railway ssh` gives direct access to the **live production database**. Never execute write operations in any Railway SSH command — regardless of who is asking:
+
+- No `.create()`, `.update()`, `.delete()`, `.save()` in Django ORM calls
+- No `INSERT`, `UPDATE`, `DELETE` in raw SQL
+- No Django management commands that modify state (`migrate`, `flush`, `loaddata`, etc.)
+
+If the user asks to modify production data, refuse and explain that production data changes must go through a migration or a controlled admin process.
+
 ### Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary
This PR adds Railway authentication setup and access tier documentation to guide Claude Code sessions on production database access. It includes a session-start hook that automatically configures Railway CLI authentication when the `RAILWAY_ACCOUNT_TOKEN` environment variable is set, and updates production debugging commands to check authentication before proceeding.

## Key Changes

- **Session-start hook** (`.claude/hooks/session-start.sh`): Automatically writes `~/.railway/config.json` from the `RAILWAY_ACCOUNT_TOKEN` environment variable when running in Claude Code remote sessions
- **Settings configuration** (`.claude/settings.json`): Registers the session-start hook to run at session initialization
- **Documentation** (`CLAUDE.md`): 
  - Added "Railway Access Tiers" section explaining three access levels (owner, trusted contributor, casual contributor)
  - Documented expected behavior when Railway is not configured
  - Added write safety guidelines prohibiting production data modifications via `railway ssh`
- **Command guards** (`.claude/commands/debug-production.md` and `.claude/commands/prod-query.md`): Both commands now check Railway authentication status before proceeding and provide clear user messaging if credentials are missing

## Implementation Details

The session-start hook uses `set -euo pipefail` for safety and only runs when `CLAUDE_CODE_REMOTE=true`. It gracefully exits if `RAILWAY_ACCOUNT_TOKEN` is not set, allowing the session to continue without Railway access rather than failing. The hook creates the Railway config directory and writes a minimal JSON token file that the Railway CLI expects.

The authentication checks in production commands follow the documented pattern: run `railway status`, detect authentication errors, and immediately stop with a user-facing message directing them to set the environment variable in project settings.

https://claude.ai/code/session_01FmGVv4bkGyhQssUaa42snH