### PR TITLE
Make Firebase optional in Django settings and URL routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,25 @@ This starts all services:
 - Django API at http://localhost:8000
 - PostgreSQL database at http://localhost:5432
 
+### Minimal Backend Environment (Cloud / CI sessions)
+
+The Django service can start with only database credentials and `DJANGO_DEBUG`. Firebase (push notifications) and Google OAuth will be disabled but will not prevent the service from starting:
+
+```bash
+DATABASE_NAME=diplicity   # default: diplicity
+DATABASE_USER=postgres    # default: postgres
+DATABASE_PASSWORD=postgres # default: postgres
+DATABASE_HOST=localhost   # default: db
+DATABASE_PORT=5432        # default: 5432
+DJANGO_DEBUG=True
+```
+
+All database vars have defaults matching the local Docker Compose setup, so in practice `DJANGO_DEBUG=True` alone is sufficient when running against the default local database.
+
+Features that are disabled when credentials are absent:
+- **Firebase / push notifications**: requires `FIREBASE_PROJECT_ID` (and other `FIREBASE_*` vars). `fcm_django` is removed from `INSTALLED_APPS` and the `/devices/` endpoint is not registered.
+- **Google OAuth login**: requires `GOOGLE_CLIENT_ID`. Login attempts will fail with an authentication error but the service continues to run.
+
 ## Key Commands
 
 ### Frontend (React/TypeScript)

--- a/service/notification/utils.py
+++ b/service/notification/utils.py
@@ -1,6 +1,5 @@
 import logging
-from fcm_django.models import FCMDevice
-from firebase_admin.messaging import Message, Notification
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -8,6 +7,12 @@ logger = logging.getLogger(__name__)
 def send_notification_to_users(user_ids, title, body, notification_type, data=None):
     if not user_ids:
         return
+
+    if not getattr(settings, "FIREBASE_APP", None):
+        return
+
+    from fcm_django.models import FCMDevice
+    from firebase_admin.messaging import Message, Notification
 
     devices = FCMDevice.objects.filter(user_id__in=user_ids, active=True)
     if not devices.exists():

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -15,7 +15,6 @@ import os
 
 import dj_database_url
 from datetime import timedelta
-from firebase_admin import credentials, initialize_app
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -67,6 +66,8 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 
+_FIREBASE_PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID")
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -76,7 +77,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.postgres",
     "corsheaders",
-    "fcm_django",
     "rest_framework",
     "rest_framework_simplejwt",
     "rest_framework.authtoken",
@@ -103,6 +103,9 @@ INSTALLED_APPS = [
     "email_service",
     "drf_spectacular",
 ]
+
+if _FIREBASE_PROJECT_ID:
+    INSTALLED_APPS.append("fcm_django")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -269,20 +272,21 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=90),
 }
 
-firebase_credentials = {
-    "type": os.getenv("FIREBASE_TYPE"),
-    "project_id": os.getenv("FIREBASE_PROJECT_ID"),
-    "private_key_id": os.getenv("FIREBASE_PRIVATE_KEY_ID"),
-    "private_key": os.getenv("FIREBASE_PRIVATE_KEY", "").replace("\\n", "\n"),
-    "client_email": os.getenv("FIREBASE_CLIENT_EMAIL"),
-    "client_id": os.getenv("FIREBASE_CLIENT_ID"),
-    "auth_uri": os.getenv("FIREBASE_AUTH_URI"),
-    "token_uri": os.getenv("FIREBASE_TOKEN_URI"),
-    "auth_provider_x509_cert_url": os.getenv("FIREBASE_AUTH_PROVIDER_X509_CERT_URL"),
-    "client_x509_cert_url": os.getenv("FIREBASE_CLIENT_X509_CERT_URL"),
-}
+if _FIREBASE_PROJECT_ID:
+    from firebase_admin import credentials, initialize_app
 
-if os.getenv("FIREBASE_PROJECT_ID"):
+    firebase_credentials = {
+        "type": os.getenv("FIREBASE_TYPE"),
+        "project_id": _FIREBASE_PROJECT_ID,
+        "private_key_id": os.getenv("FIREBASE_PRIVATE_KEY_ID"),
+        "private_key": os.getenv("FIREBASE_PRIVATE_KEY", "").replace("\\n", "\n"),
+        "client_email": os.getenv("FIREBASE_CLIENT_EMAIL"),
+        "client_id": os.getenv("FIREBASE_CLIENT_ID"),
+        "auth_uri": os.getenv("FIREBASE_AUTH_URI"),
+        "token_uri": os.getenv("FIREBASE_TOKEN_URI"),
+        "auth_provider_x509_cert_url": os.getenv("FIREBASE_AUTH_PROVIDER_X509_CERT_URL"),
+        "client_x509_cert_url": os.getenv("FIREBASE_CLIENT_X509_CERT_URL"),
+    }
     FIREBASE_APP = initialize_app(credentials.Certificate(firebase_credentials))
 
 SPECTACULAR_SETTINGS = {

--- a/service/project/urls.py
+++ b/service/project/urls.py
@@ -18,19 +18,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
-from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet
 from rest_framework_simplejwt.views import TokenRefreshView
-from rest_framework.routers import DefaultRouter
 from project.views import test_sentry
 from project import settings
 
 
 urlpatterns = [
-    path(
-        "devices/",
-        FCMDeviceAuthorizedViewSet.as_view({"get": "list", "post": "create", "put": "update"}),
-        name="devices",
-    ),
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),
     path("", include("game.urls")),
@@ -52,6 +45,17 @@ urlpatterns = [
     ),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token-refresh"),
 ]
+
+if settings._FIREBASE_PROJECT_ID:
+    from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet
+
+    urlpatterns += [
+        path(
+            "devices/",
+            FCMDeviceAuthorizedViewSet.as_view({"get": "list", "post": "create", "put": "update"}),
+            name="devices",
+        ),
+    ]
 
 # Only enable in development
 if settings.DEBUG:


### PR DESCRIPTION
## Summary
Refactored Firebase initialization and FCM Django integration to be optional, allowing the Django service to start without Firebase credentials. This enables deployment in environments where push notifications are not required (e.g., CI/cloud deployments with minimal credentials).

## Key Changes
- **Settings**: Moved Firebase imports and initialization inside a conditional block that only executes when `FIREBASE_PROJECT_ID` environment variable is set
- **App Registration**: Made `fcm_django` app registration conditional on `FIREBASE_PROJECT_ID` presence
- **URL Routing**: Moved `/devices/` endpoint registration into a conditional block, only added when Firebase is configured
- **Notification Utils**: Added guard clause to skip Firebase operations when `FIREBASE_APP` is not initialized; moved Firebase imports inside the function to avoid import errors when Firebase is disabled
- **Documentation**: Updated CLAUDE.md with minimal backend environment setup instructions and list of features disabled without credentials

## Implementation Details
- Introduced `_FIREBASE_PROJECT_ID` variable at module level in settings to avoid repeated `os.getenv()` calls
- Firebase imports (`firebase_admin.credentials`, `initialize_app`) are now lazy-loaded only when needed
- The service gracefully degrades: Firebase/push notifications and Google OAuth are disabled but don't prevent startup
- All database configuration variables have sensible defaults matching the local Docker Compose setup

https://claude.ai/code/session_019vdAFbiGMkVLxmLNxo8jzE