### PR TITLE
Provision native dev environment in Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,22 +1,147 @@
 #!/bin/bash
 set -euo pipefail
 
+# SessionStart hook for Claude Code on the web.
+#
+# Prepares the container so the full local (non-Docker) dev workflow is ready
+# the moment a session starts:
+#   - Python 3.12 virtualenv + backend dependencies (service/.venv)
+#   - Native PostgreSQL cluster started, with the `diplicity` database created
+#     and migrated (SQLite is NOT viable — some migrations use Postgres-only
+#     raw SQL such as `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`)
+#   - Frontend npm dependencies (packages/web)
+#   - Railway CLI installed (production access additionally requires the Railway
+#     API host to be in the network egress allowlist — see notes below)
+#   - Session env vars (venv on PATH + local DB config) via $CLAUDE_ENV_FILE
+
+# Only run in the remote (Claude Code on the web) environment.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-if [ -z "${RAILWAY_API_TOKEN:-}" ]; then
-  echo "RAILWAY_API_TOKEN not set — Railway CLI will not be authenticated in this session." >&2
-  exit 0
-fi
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+VENV_DIR="$PROJECT_DIR/service/.venv"
 
-echo "Railway CLI authenticated."
+log() { echo "[session-start] $*"; }
 
-if [ -z "${RAILWAY_TOKEN:-}" ]; then
-  echo "RAILWAY_TOKEN not set — 'railway run' (prod-query) will not be available in this session." >&2
+###############################################################################
+# 1. Python backend: virtualenv (Python 3.12) + dependencies
+#    Django 6 requires Python 3.12+, but the system default `python3` is 3.11.
+###############################################################################
+if ! command -v python3.12 >/dev/null 2>&1; then
+  log "WARNING: python3.12 not found — backend cannot run (Django 6 needs 3.12+)."
 else
-  echo "Installing service Python dependencies for railway run..."
-  pip install -q -r "$(git rev-parse --show-toplevel)/service/requirements.txt" && \
-    echo "Service dependencies installed." || \
-    echo "Warning: failed to install service dependencies — prod-query may not work." >&2
+  if [ ! -x "$VENV_DIR/bin/python" ]; then
+    log "Creating Python 3.12 virtualenv at service/.venv"
+    python3.12 -m venv "$VENV_DIR"
+  fi
+  log "Installing backend dependencies"
+  "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+  "$VENV_DIR/bin/pip" install --quiet \
+    -r "$PROJECT_DIR/service/requirements.txt" \
+    -r "$PROJECT_DIR/service/dev_requirements.txt"
 fi
+
+###############################################################################
+# 2. PostgreSQL: start the native cluster and ensure role + database exist.
+###############################################################################
+PG_READY=false
+if command -v pg_ctlcluster >/dev/null 2>&1; then
+  PG_VER=$(pg_lsclusters -h | awk 'NR==1{print $1}')
+  PG_CLUSTER=$(pg_lsclusters -h | awk 'NR==1{print $2}')
+  if ! pg_lsclusters -h | awk 'NR==1{print $4}' | grep -q online; then
+    log "Starting PostgreSQL cluster $PG_VER/$PG_CLUSTER"
+    pg_ctlcluster "$PG_VER" "$PG_CLUSTER" start || true
+  fi
+  for _ in $(seq 1 15); do
+    if su postgres -c "pg_isready -q" >/dev/null 2>&1; then
+      PG_READY=true
+      break
+    fi
+    sleep 1
+  done
+  if [ "$PG_READY" = true ]; then
+    su postgres -c "psql -tAc \"ALTER USER postgres WITH PASSWORD 'postgres';\"" >/dev/null 2>&1 || true
+    if ! su postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='diplicity'\"" 2>/dev/null | grep -q 1; then
+      log "Creating 'diplicity' database"
+      su postgres -c "createdb -O postgres diplicity" || true
+    fi
+  else
+    log "WARNING: PostgreSQL did not become ready — backend tests will not run."
+  fi
+else
+  log "WARNING: PostgreSQL not found — backend tests will not run."
+fi
+
+###############################################################################
+# 3. Apply migrations to the local dev database (so `runserver` works too).
+###############################################################################
+if [ "$PG_READY" = true ] && [ -x "$VENV_DIR/bin/python" ]; then
+  log "Applying database migrations"
+  if ! ( cd "$PROJECT_DIR/service" && \
+         DATABASE_HOST=127.0.0.1 DATABASE_PORT=5432 DATABASE_NAME=diplicity \
+         DATABASE_USER=postgres DATABASE_PASSWORD=postgres \
+         "$VENV_DIR/bin/python" manage.py migrate --noinput ) >/tmp/diplicity-migrate.log 2>&1; then
+    log "WARNING: migrate failed (see /tmp/diplicity-migrate.log)"
+  fi
+fi
+
+###############################################################################
+# 4. Frontend: npm dependencies.
+###############################################################################
+if [ -f "$PROJECT_DIR/packages/web/package.json" ]; then
+  log "Installing frontend dependencies"
+  ( cd "$PROJECT_DIR/packages/web" && npm install --no-audit --no-fund --silent )
+fi
+
+###############################################################################
+# 5. Railway CLI for production access.
+#    The CLI authenticates from $RAILWAY_API_TOKEN, but every railway command
+#    reaches production via Railway's hosts (e.g. backboard.railway.com), which
+#    must be in the environment's network egress allowlist, otherwise commands
+#    fail with "Host not in allowlist".
+###############################################################################
+if [ -n "${RAILWAY_API_TOKEN:-}" ]; then
+  if ! command -v railway >/dev/null 2>&1; then
+    log "Installing Railway CLI"
+    npm install -g --silent @railway/cli || log "WARNING: Railway CLI install failed"
+  fi
+  if command -v railway >/dev/null 2>&1; then
+    # `railway whoami` exercises the real API + token. The egress block returns a
+    # 403 "Host not in allowlist" page (not JSON), so the CLI exits non-zero —
+    # this distinguishes a genuinely reachable API from an allowlist block.
+    if railway whoami >/dev/null 2>&1; then
+      log "Railway CLI ready (authenticated, API reachable)."
+    else
+      log "Railway CLI installed, but the Railway API is NOT reachable — add backboard.railway.com to the network egress allowlist to enable production commands."
+    fi
+  fi
+else
+  log "RAILWAY_API_TOKEN not set — Railway production access unavailable."
+fi
+
+# RAILWAY_TOKEN (project-scoped) powers `railway run` for /prod-query and
+# /debug-production. The backend deps it needs are already in service/.venv
+# (installed above and put on PATH below), so no extra install is needed here.
+if [ -n "${RAILWAY_TOKEN:-}" ]; then
+  log "RAILWAY_TOKEN set — 'railway run' (prod-query) available."
+else
+  log "RAILWAY_TOKEN not set — 'railway run' (prod-query) unavailable."
+fi
+
+###############################################################################
+# 6. Persist session environment: venv on PATH + local DB config, so that
+#    `python`, `pytest`, and `manage.py` work without per-command env setup.
+###############################################################################
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export PATH=\"$VENV_DIR/bin:\$PATH\""
+    echo "export DATABASE_HOST=127.0.0.1"
+    echo "export DATABASE_PORT=5432"
+    echo "export DATABASE_NAME=diplicity"
+    echo "export DATABASE_USER=postgres"
+    echo "export DATABASE_PASSWORD=postgres"
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+log "Ready: backend venv (service/.venv), PostgreSQL (diplicity), frontend deps."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,44 @@ Features that are disabled when credentials are absent:
 - **Firebase / push notifications**: requires `FIREBASE_PROJECT_ID` (and other `FIREBASE_*` vars). `fcm_django` is removed from `INSTALLED_APPS` and the `/devices/` endpoint is not registered.
 - **Google OAuth login**: requires `GOOGLE_CLIENT_ID`. Login attempts will fail with an authentication error but the service continues to run.
 
+### Native (non-Docker) Workflow — Claude Code on the web
+
+Cloud sessions run without Docker. The `.claude/hooks/session-start.sh` SessionStart hook provisions everything natively so tests, linters, build, and codegen work out of the box. It is idempotent and re-runs cheaply on resume. What it sets up:
+
+- **Backend venv**: a Python 3.12 virtualenv at `service/.venv` with `requirements.txt` + `dev_requirements.txt` installed. Django 6 requires Python 3.12+, but the system default `python3` is 3.11 — **always use `service/.venv/bin/python`** (the hook also prepends it to `PATH` via `$CLAUDE_ENV_FILE`, so a plain `python`/`pytest`/`pip` resolves to the venv).
+- **PostgreSQL**: the native cluster is started and a `diplicity` database (role `postgres`/`postgres`) is created and migrated. The hook exports `DATABASE_HOST=127.0.0.1` and the other `DATABASE_*` vars for the session, so `manage.py` and `pytest` connect automatically.
+- **Frontend**: `npm install` in `packages/web`.
+- **Railway CLI**: installed via npm when `RAILWAY_API_TOKEN` is set.
+
+Manual equivalents (if running outside the hook):
+```bash
+# Backend env (already exported by the hook in cloud sessions)
+export PATH="$PWD/service/.venv/bin:$PATH"
+export DATABASE_HOST=127.0.0.1 DATABASE_PORT=5432 \
+       DATABASE_NAME=diplicity DATABASE_USER=postgres DATABASE_PASSWORD=postgres
+
+cd service
+python manage.py check
+python -m pytest -q --create-db        # pytest-django builds test_diplicity
+```
+
+**SQLite is not viable.** Some migrations contain Postgres-only raw SQL (e.g. `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`), which SQLite rejects with a syntax error during the test-DB build. Use the native PostgreSQL cluster, not a SQLite `DATABASE_URL`.
+
+**Railway production access requires network allowlisting.** Installing the CLI is not enough: every `railway` command (and `/prod-query`, `/debug-production`) reaches production through Railway's hosts, which are not in the **Trusted** default allowlist. To enable them, edit the Claude Code on the web **environment** (cloud icon → environment selector → gear icon), set **Network access** to **Custom**, and add to **Allowed domains**:
+
+```
+*.railway.com
+*.railway.app
+```
+
+`backboard.railway.com` is the GraphQL API behind `whoami`/`status`/`logs`; `railway run` (used by `/prod-query`) routes through additional Railway hosts, so the wildcards cover both. **Also tick "Also include default list of common package managers"** — otherwise the allowlist becomes only those two lines and the SessionStart hook's `npm install`/`pip install` break. Without this, commands fail with `Host not in allowlist` / "error decoding response body". (**Full** network access also works but allows any domain.)
+
+**Codegen reproducibility.** `manage.py spectacular` + `orval` regenerate `service/openapi-schema.yaml` and `packages/web/src/api/generated/endpoints.ts`. To reproduce the committed output byte-for-byte the generating environment must match production config, because two switches change the schema:
+- `DJANGO_DEBUG` must be **off** — when on, the DEBUG-gated `/api/test-sentry/` endpoint is added to the schema.
+- `FIREBASE_PROJECT_ID` must be **set** — when absent, `fcm_django` is dropped from `INSTALLED_APPS`, removing `/devices/` and the `FCMDevice` schema.
+
+A clean `git diff` after codegen in a cloud session (no Firebase, DEBUG off) shows only the `/devices/` + `FCMDevice` removal; that is environmental, not a stale-checkout signal.
+
 ## Key Commands
 
 ### Frontend (React/TypeScript)
@@ -674,7 +712,7 @@ Two separate environment variables control Railway access in cloud sessions:
 | `RAILWAY_API_TOKEN` | Account-scoped | `railway status`, `railway logs` — auth and observability |
 | `RAILWAY_TOKEN` | Project-scoped | `railway run` — inject production env vars to run management commands locally |
 
-The session-start hook checks both at startup. When `RAILWAY_TOKEN` is present it also installs the service's Python dependencies so that `manage.py shell` works with injected production env vars.
+The session-start hook checks both at startup and reports their availability. The service's Python dependencies needed by `railway run ... manage.py shell` are already installed in `service/.venv` (which the hook puts on `PATH`), so `railway run` picks them up automatically — no separate install step is required.
 
 ## Railway Access Tiers
 
@@ -688,7 +726,7 @@ Not all sessions have Railway access:
 
 If any `railway` command fails with an authentication or "not logged in" error, **stop immediately** — this is an expected missing-credential situation, not a bug to diagnose. Tell the user:
 
-> "Railway is not configured in this session. Production debugging requires the `RAILWAY_API_TOKEN` environment variable to be set in the claude.ai/code project settings."
+> "Railway is not configured in this session. Production debugging requires the `RAILWAY_API_TOKEN` environment variable to be set in the Claude Code on the web environment configuration (and Railway's hosts allowlisted via Custom network access)."
 
 Do not retry Railway commands, do not attempt workarounds, and do not use `/prod-query` or `/debug-production`.
 

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",


### PR DESCRIPTION
## Summary

Expanded the SessionStart hook to fully provision the local (non-Docker) development environment in Claude Code on the web, enabling tests, linters, and the dev server to work out of the box. The hook is idempotent and re-runs cheaply on session resume.

## Key Changes

- **Python 3.12 virtualenv**: Creates `service/.venv` with `requirements.txt` and `dev_requirements.txt` installed. Django 6 requires Python 3.12+, but the system default is 3.11, so the hook explicitly uses `python3.12`.
- **PostgreSQL setup**: Starts the native cluster, creates the `diplicity` database with role `postgres`/`postgres`, and applies all migrations so `manage.py runserver` and `pytest` work immediately.
- **Frontend dependencies**: Runs `npm install` in `packages/web`.
- **Railway CLI**: Installs the CLI when `RAILWAY_API_TOKEN` is set and validates API reachability (distinguishing authentication failures from network allowlist blocks).
- **Session environment persistence**: Exports `PATH` (venv), `DATABASE_*` vars, and other config via `$CLAUDE_ENV_FILE` so `python`, `pytest`, and `manage.py` work without per-command setup.
- **Comprehensive documentation**: Added detailed section to CLAUDE.md explaining the native workflow, manual equivalents, SQLite limitations, Railway network allowlisting requirements, and codegen reproducibility conditions.

## Implementation Details

- The hook checks for `CLAUDE_CODE_REMOTE=true` to run only in cloud sessions.
- PostgreSQL readiness is polled with a 15-second timeout; migrations are applied only if both the database and venv are ready.
- Railway CLI validation uses `railway whoami` to distinguish genuine API unreachability (403 "Host not in allowlist") from authentication errors.
- All setup steps include fallback warnings so missing tools (e.g., `python3.12`, PostgreSQL) don't block the session.
- Updated the Railway error message in CLAUDE.md to mention network allowlisting as a prerequisite.

https://claude.ai/code/session_01NZ3gjartHBqLJZhUk2Sstu