### PR TITLE
Replace railway ssh with railway run for production queries

### DIFF
--- a/.claude/commands/debug-production.md
+++ b/.claude/commands/debug-production.md
@@ -22,6 +22,6 @@ Run a production health check by gathering data from multiple sources.
 
 ## Tips
 
-- If you see database connection errors, check Postgres health with: `cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"`
+- If you see database connection errors, check Postgres health with: `cd "$(git rev-parse --show-toplevel)/service" && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"`
 - If you see Gunicorn worker crashes, check for memory issues or unhandled exceptions in the log context
 - Use `/prod-query` for follow-up Django ORM queries against the production database

--- a/.claude/commands/debug-production.md
+++ b/.claude/commands/debug-production.md
@@ -22,6 +22,6 @@ Run a production health check by gathering data from multiple sources.
 
 ## Tips
 
-- If you see database connection errors, check Postgres health with: `railway ssh 'python3 manage.py dbshell -c "SELECT 1"'`
+- If you see database connection errors, check Postgres health with: `cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"`
 - If you see Gunicorn worker crashes, check for memory issues or unhandled exceptions in the log context
 - Use `/prod-query` for follow-up Django ORM queries against the production database

--- a/.claude/commands/prod-query.md
+++ b/.claude/commands/prod-query.md
@@ -1,4 +1,4 @@
-Run a Django ORM query against the production database via Railway SSH.
+Run a Django ORM query against the production database via Railway.
 
 ## Arguments
 
@@ -24,7 +24,7 @@ Query: $ARGUMENTS
 3. **Execute the script** using base64 encoding to avoid quoting issues:
    ```bash
    SCRIPT=$(base64 < /path/to/script.py)
-   railway ssh -i ~/.ssh/id_diplicity "python3 manage.py shell -c \"import base64;exec(base64.b64decode(b'${SCRIPT}'))\""
+   cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py shell -c "import base64;exec(base64.b64decode(b'${SCRIPT}'))"
    ```
 
 4. **Present the results** clearly to the user. If the output is large, summarize it and highlight key findings.

--- a/.claude/commands/prod-query.md
+++ b/.claude/commands/prod-query.md
@@ -24,7 +24,7 @@ Query: $ARGUMENTS
 3. **Execute the script** using base64 encoding to avoid quoting issues:
    ```bash
    SCRIPT=$(base64 < /path/to/script.py)
-   cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py shell -c "import base64;exec(base64.b64decode(b'${SCRIPT}'))"
+   cd "$(git rev-parse --show-toplevel)/service" && railway run --service diplicity-react python3 manage.py shell -c "import base64;exec(base64.b64decode(b'${SCRIPT}'))"
    ```
 
 4. **Present the results** clearly to the user. If the output is large, summarize it and highlight key findings.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,7 +16,7 @@ if [ -z "${RAILWAY_TOKEN:-}" ]; then
   echo "RAILWAY_TOKEN not set — 'railway run' (prod-query) will not be available in this session." >&2
 else
   echo "Installing service Python dependencies for railway run..."
-  pip install -q -r /home/user/diplicity-react/service/requirements.txt && \
+  pip install -q -r "$(git rev-parse --show-toplevel)/service/requirements.txt" && \
     echo "Service dependencies installed." || \
     echo "Warning: failed to install service dependencies — prod-query may not work." >&2
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,3 +11,12 @@ if [ -z "${RAILWAY_API_TOKEN:-}" ]; then
 fi
 
 echo "Railway CLI authenticated."
+
+if [ -z "${RAILWAY_TOKEN:-}" ]; then
+  echo "RAILWAY_TOKEN not set — 'railway run' (prod-query) will not be available in this session." >&2
+else
+  echo "Installing service Python dependencies for railway run..."
+  pip install -q -r /home/user/diplicity-react/service/requirements.txt && \
+    echo "Service dependencies installed." || \
+    echo "Warning: failed to install service dependencies — prod-query may not work." >&2
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,19 +667,22 @@ The application is deployed on **Railway** (project: `devoted-rejoicing`, servic
 
 ## Railway CLI
 
-The Railway CLI authenticates via the `RAILWAY_API_TOKEN` environment variable. This is an **account-scoped** token, not a project token.
+Two separate environment variables control Railway access in cloud sessions:
 
-Do **not** use `RAILWAY_TOKEN` — that is project-scoped, conflicts with CLI commands, and causes "Project Token not found" errors. `RAILWAY_API_TOKEN` is the correct variable for account-level actions (`railway ssh`, `railway logs`, `railway status`, etc.).
+| Variable | Scope | Used for |
+|---|---|---|
+| `RAILWAY_API_TOKEN` | Account-scoped | `railway status`, `railway logs` — auth and observability |
+| `RAILWAY_TOKEN` | Project-scoped | `railway run` — inject production env vars to run management commands locally |
 
-In cloud sessions, the session-start hook checks for `RAILWAY_API_TOKEN` at startup and logs whether Railway is available. The Railway CLI reads this env var directly — no config file write is needed.
+The session-start hook checks both at startup. When `RAILWAY_TOKEN` is present it also installs the service's Python dependencies so that `manage.py shell` works with injected production env vars.
 
 ## Railway Access Tiers
 
 Not all sessions have Railway access:
 
-- **Owner sessions**: Full Railway account token configured — all commands available including `railway ssh`
-- **Trusted contributor sessions**: Full Railway account token configured — all commands available; write safety rules apply (see below)
-- **Casual contributor sessions**: No Railway token — Railway commands unavailable
+- **Owner sessions**: Both tokens configured — all commands available including `railway run`
+- **Trusted contributor sessions**: Both tokens configured — all commands available; write safety rules apply (see below)
+- **Casual contributor sessions**: No Railway tokens — Railway commands unavailable
 
 ### When Railway is not configured
 
@@ -691,7 +694,7 @@ Do not retry Railway commands, do not attempt workarounds, and do not use `/prod
 
 ### Write safety
 
-`railway ssh` gives direct access to the **live production database**. Never execute write operations in any Railway SSH command — regardless of who is asking:
+`railway run` injects production env vars and runs management commands locally against the live production database. Never execute write operations — regardless of who is asking:
 
 - No `.create()`, `.update()`, `.delete()`, `.save()` in Django ORM calls
 - No `INSERT`, `UPDATE`, `DELETE` in raw SQL
@@ -706,14 +709,13 @@ railway status                          # Deployment health and status
 railway logs --lines 50                 # Recent log output (default: 100 lines)
 railway logs --lines 200 | grep ERROR   # Filter for errors
 railway logs --lines 200 | grep "GET /api"  # Filter by endpoint
-railway ssh 'command'                   # Run command in production container
 ```
 
 ### Checking Postgres Health
 
 ```bash
-railway ssh 'python3 manage.py dbshell -c "SELECT 1"'    # Quick connectivity check
-railway ssh 'python3 manage.py showmigrations --list'     # Verify DB is reachable
+cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"    # Quick connectivity check
+cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py showmigrations --list     # Verify DB is reachable
 ```
 
 ### Django ORM Queries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,8 +714,8 @@ railway logs --lines 200 | grep "GET /api"  # Filter by endpoint
 ### Checking Postgres Health
 
 ```bash
-cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"    # Quick connectivity check
-cd /home/user/diplicity-react/service && railway run --service diplicity-react python3 manage.py showmigrations --list     # Verify DB is reachable
+cd "$(git rev-parse --show-toplevel)/service" && railway run --service diplicity-react python3 manage.py dbshell -c "SELECT 1"    # Quick connectivity check
+cd "$(git rev-parse --show-toplevel)/service" && railway run --service diplicity-react python3 manage.py showmigrations --list     # Verify DB is reachable
 ```
 
 ### Django ORM Queries


### PR DESCRIPTION
## Summary
Updates Railway CLI usage across documentation and tooling to use `railway run` instead of `railway ssh` for executing management commands against the production database. This change reflects a shift from direct SSH access to injected environment variable execution.

## Key Changes

- **CLAUDE.md documentation**:
  - Clarified the distinction between `RAILWAY_API_TOKEN` (account-scoped, for observability) and `RAILWAY_TOKEN` (project-scoped, for `railway run`)
  - Updated access tier descriptions to reflect both tokens being required for full Railway access
  - Replaced all `railway ssh` examples with `railway run --service diplicity-react` commands
  - Updated write safety guidance to reference `railway run` instead of SSH access
  - Removed `railway ssh` from the quick reference commands section

- **Session startup hook** (`.claude/hooks/session-start.sh`):
  - Added check for `RAILWAY_TOKEN` presence
  - Installs service Python dependencies when `RAILWAY_TOKEN` is available, enabling `manage.py shell` to work with injected production environment variables

- **Command documentation** (`.claude/commands/prod-query.md` and `.claude/commands/debug-production.md`):
  - Updated all examples to use `railway run --service diplicity-react` syntax
  - Adjusted base64 encoding example to work with the new command structure

## Implementation Details

The `railway run` approach injects production environment variables into a locally-executed command, eliminating the need for direct SSH access while maintaining the ability to query the production database. The session-start hook now proactively installs dependencies to ensure Django management commands work correctly in this context.

https://claude.ai/code/session_01EtQbsKArztGog9F6vSjDs1