### PR TITLE
Add bug report template and update Discord invite links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Report a bug in Diplicity
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: input
+    id: game_url
+    attributes:
+      label: Game URL
+      description: URL of the affected game, if applicable.
+      placeholder: "https://diplicity.com/game/..."
+
+  - type: input
+    id: screen_url
+    attributes:
+      label: Screen URL
+      description: URL of the screen where the bug occurs, if applicable.
+      placeholder: "https://diplicity.com/..."
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: If applicable, add a screenshot to help explain the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Report via Discord
-    url: https://discord.gg/QETtwGR
+    url: https://discord.gg/2TkZbBRPW
     about: Don't have a GitHub account? Report the bug in our Discord server.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report via Discord
+    url: https://discord.gg/QETtwGR
+    about: Don't have a GitHub account? Report the bug in our Discord server.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,7 +9,7 @@ The repo is built to be developed with an AI coding agent. A detailed [`CLAUDE.m
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 2. Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) (or another AI agent — point it at `CLAUDE.md`).
 3. Clone the repo.
-4. DM **Johnpooch** on the [Diplicity Hub Discord](https://discord.gg/QETtwGR) for the dev `.env` file. Drop it in the repo root. Keep the keys to yourself — they're shared on trust.
+4. DM **Johnpooch** on the [Diplicity Hub Discord](https://discord.gg/2TkZbBRPW) for the dev `.env` file. Drop it in the repo root. Keep the keys to yourself — they're shared on trust.
 5. Start the app:
    ```bash
    docker compose up service web db phase-resolver
@@ -46,4 +46,4 @@ Google OAuth is not configured for staging — use email/password login. The env
 
 ---
 
-Stuck or unsure how to approach a problem? Ask in the [Diplicity Hub Discord](https://discord.gg/QETtwGR). Don't wait until you're frustrated.
+Stuck or unsure how to approach a problem? Ask in the [Diplicity Hub Discord](https://discord.gg/2TkZbBRPW). Don't wait until you're frustrated.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Diplicity React project! This is a web version of the classic Dip
 
 ## Get involved
 
-We are looking for developers to get involved with the project. If you want to contribute, come say hi on the [Diplomacy Discord](https://discord.gg/QETtwGR), and see [DEVELOPER.md](DEVELOPER.md) for the contributor setup guide.
+We are looking for developers to get involved with the project. If you want to contribute, come say hi on the [Diplomacy Discord](https://discord.gg/2TkZbBRPW), and see [DEVELOPER.md](DEVELOPER.md) for the contributor setup guide.
 
 ## Project Overview
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -344,7 +344,7 @@ Database queries for variant data have been optimized, reducing load times when 
 Thanks to the Diplomacy community for trying the beta version of the app and sharing their feedback!
 
 **Join the conversation:**
-- [Diplomacy Discord](https://discord.gg/QETtwGR)
+- [Diplomacy Discord](https://discord.gg/2TkZbBRPW)
 - [Play now](https://diplicity.com)
 
 ---


### PR DESCRIPTION
## Summary
This PR adds a structured bug report template for GitHub Issues and updates all Discord invite links across documentation to use the current server invite.

## Changes
- **Added bug report issue template** (`.github/ISSUE_TEMPLATE/bug_report.yml`):
  - Structured form with required fields: description, steps to reproduce, expected behavior, and actual behavior
  - Optional fields for game URL, screen URL, and screenshots
  - Labeled automatically as "bug"

- **Added issue template configuration** (`.github/ISSUE_TEMPLATE/config.yml`):
  - Disables blank issues to encourage use of templates
  - Provides Discord server as alternative reporting channel for users without GitHub accounts

- **Updated Discord invite links** across documentation:
  - `README.md`: Updated contributor onboarding link
  - `DEVELOPER.md`: Updated two references (setup instructions and support section)
  - `RELEASE_NOTES.md`: Updated community link
  - Changed from `discord.gg/QETtwGR` to `discord.gg/2TkZbBRPW`

## Implementation Details
The bug report template follows GitHub's YAML format for issue forms, providing a consistent structure for bug reports while maintaining flexibility for edge cases. The template prioritizes reproduction steps and behavior comparison, which are essential for effective bug triage.

https://claude.ai/code/session_01U9rNzw6nHwb2EZKV88S2Uj