### PR TITLE
Separate integration tests into dedicated workflow

### DIFF
--- a/.github/workflows/test-service-integration.yml
+++ b/.github/workflows/test-service-integration.yml
@@ -1,4 +1,4 @@
-name: Test Service
+name: Test Service (Integration)
 
 on:
   push:
@@ -31,9 +31,9 @@ jobs:
         # Wait for services to be ready
         sleep 10
 
-    - name: Run service tests
+    - name: Run integration tests
       run: |
-        docker compose run --rm service python3 -m pytest -v --timeout=60 --ignore=integration/
+        docker compose run --rm service python3 -m pytest integration/tests.py -v --timeout=60
       env:
         DATABASE_NAME: diplicity
         DATABASE_USER: postgres


### PR DESCRIPTION
## Summary
Split integration tests into a separate GitHub Actions workflow to allow unit tests and integration tests to run independently with different configurations and timeouts.

## Changes
- **New workflow**: `.github/workflows/test-service-integration.yml`
  - Runs integration tests against a live Docker Compose database setup
  - Sets up PostgreSQL service container before running tests
  - Executes only `integration/tests.py` with a 60-second timeout per test
  - Configured to run on push to `main` and on pull requests

- **Modified workflow**: `.github/workflows/test-service.yml`
  - Updated unit test command to exclude integration tests: `--ignore=integration/`
  - Prevents integration tests from running in the unit test workflow

## Implementation Details
- Integration tests now require the database to be running (via `docker compose up -d db`)
- Both workflows set the same database environment variables for consistency
- The 10-second sleep after starting the database ensures services are ready before tests run
- Separation allows faster feedback on unit tests while keeping integration tests in a separate, longer-running job

https://claude.ai/code/session_01EiMwaJiP6pZWMdHWWZYjXT