### PR TITLE
Replace Docker Compose with native Python for CI test workflows

### DIFF
--- a/.github/workflows/test-service-integration.yml
+++ b/.github/workflows/test-service-integration.yml
@@ -14,29 +14,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: diplicity
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: |
+          service/requirements.txt
+          service/dev_requirements.txt
 
-    - name: Create empty .env file for docker-compose
-      run: touch .env
-
-    - name: Set up Docker Compose
-      run: |
-        docker compose up -d db
-        # Wait for services to be ready
-        sleep 10
+    - name: Install dependencies
+      run: pip install -r requirements.txt -r dev_requirements.txt
+      working-directory: service
 
     - name: Run integration tests
-      run: |
-        docker compose run --rm service python3 -m pytest integration/tests.py -v --timeout=60
+      run: python -m pytest integration/tests.py -v --timeout=60
+      working-directory: service
       env:
         DATABASE_NAME: diplicity
         DATABASE_USER: postgres
         DATABASE_PASSWORD: postgres
-        DATABASE_HOST: db
+        DATABASE_HOST: localhost
         DATABASE_PORT: 5432
+        DJANGO_DEBUG: 'True'

--- a/.github/workflows/test-service.yml
+++ b/.github/workflows/test-service.yml
@@ -14,29 +14,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: diplicity
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: |
+          service/requirements.txt
+          service/dev_requirements.txt
 
-    - name: Create empty .env file for docker-compose
-      run: touch .env
-
-    - name: Set up Docker Compose
-      run: |
-        docker compose up -d db
-        # Wait for services to be ready
-        sleep 10
+    - name: Install dependencies
+      run: pip install -r requirements.txt -r dev_requirements.txt
+      working-directory: service
 
     - name: Run service tests
-      run: |
-        docker compose run --rm service python3 -m pytest -v --timeout=60 --ignore=integration/
+      run: python -m pytest -v --timeout=60 --ignore=integration/
+      working-directory: service
       env:
         DATABASE_NAME: diplicity
         DATABASE_USER: postgres
         DATABASE_PASSWORD: postgres
-        DATABASE_HOST: db
+        DATABASE_HOST: localhost
         DATABASE_PORT: 5432
+        DJANGO_DEBUG: 'True'


### PR DESCRIPTION
## Summary
Refactor GitHub Actions CI workflows to run tests natively using Python and GitHub's managed PostgreSQL service, eliminating Docker Compose and Docker Buildx dependencies.

## Key Changes
- **Replaced Docker Compose setup** with GitHub Actions `services` configuration for PostgreSQL 16
  - Postgres now runs as a managed service container with health checks
  - Removed manual `docker compose up -d db` and sleep-based waiting
  
- **Switched to native Python execution** instead of Docker-based test runs
  - Added `actions/setup-python@v5` with Python 3.12 and pip caching
  - Install dependencies directly: `pip install -r requirements.txt -r dev_requirements.txt`
  - Run pytest directly: `python -m pytest` instead of `docker compose run`
  
- **Updated database connection configuration**
  - Changed `DATABASE_HOST` from `db` (Docker service name) to `localhost`
  - Added `DJANGO_DEBUG: 'True'` environment variable for minimal backend setup
  
- **Applied to both workflows**
  - `test-service.yml` (unit tests)
  - `test-service-integration.yml` (integration tests)

## Implementation Details
- Leverages GitHub Actions' native service containers with built-in health checks (`pg_isready`)
- Aligns with the project's native (non-Docker) development workflow documented in CLAUDE.md
- Reduces CI complexity and improves test execution speed by eliminating container orchestration overhead
- Database credentials remain consistent with local Docker Compose defaults (`postgres`/`postgres`)

https://claude.ai/code/session_013SCTFxw5zEGi3scJBKFTPp