### PR TITLE
Use parallel pg_restore to speed up staging database restore

### DIFF
--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -427,13 +427,13 @@ jobs:
             unzip -q snapshot.zip
             wipe_staging_db
             echo "Restoring from snapshot..."
-            $PG_BIN/pg_restore --no-owner --no-acl --clean --if-exists -d "$STAGING_DB_URL" snapshot.pgdata
+            $PG_BIN/pg_restore --no-owner --no-acl --clean --if-exists --jobs=4 -d "$STAGING_DB_URL" snapshot.pgdata
             rm snapshot.zip snapshot.pgdata snapshot_timestamp.txt 2>/dev/null || true
           else
             echo "WARNING: No snapshot available; falling back to live pg_dump (slower)."
             $PG_BIN/pg_dump "$PRODUCTION_DATABASE_URL" --no-owner --no-acl --format=custom -f dump.pgdata
             wipe_staging_db
-            $PG_BIN/pg_restore --no-owner --no-acl --clean --if-exists -d "$STAGING_DB_URL" dump.pgdata
+            $PG_BIN/pg_restore --no-owner --no-acl --clean --if-exists --jobs=4 -d "$STAGING_DB_URL" dump.pgdata
             rm dump.pgdata
           fi
 


### PR DESCRIPTION
## Summary

- Adds `--jobs=4` to `pg_restore` in the staging deploy workflow (both the snapshot path and the live-dump fallback)
- `pg_restore` supports parallel restore with the custom archive format, parallelising data loading, index creation, and constraint creation across multiple connections
- The restore step currently takes ~2 min 11 sec; `--jobs=4` is expected to reduce that by 50–70%

## Context

After merging #678 (daily DB snapshot), the `pg_dump` step was eliminated and the download of the pre-built snapshot takes only ~4 seconds. The remaining bottleneck is `pg_restore` itself (~2 min 11 sec). Parallel restore is the most effective way to reduce this further without changing the overall approach.

## Test plan

- [ ] Add `deploy-to-staging` label to any open PR after merging and observe the "Restore database from snapshot" step duration
- [ ] Confirm the restore completes faster than the ~2 min 11 sec baseline

https://claude.ai/code/session_01QX1oPFVDm8GZ6YBnA3aVB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QX1oPFVDm8GZ6YBnA3aVB4)_