### PR TITLE
Speed up backend test suite with pytest-xdist and test consolidation

### DIFF
--- a/.github/workflows/test-service.yml
+++ b/.github/workflows/test-service.yml
@@ -47,7 +47,7 @@ jobs:
       working-directory: service
 
     - name: Run service tests
-      run: python -m pytest -v --timeout=60 --ignore=integration/
+      run: python -m pytest -v --timeout=60 -n auto --ignore=integration/
       working-directory: service
       env:
         DATABASE_NAME: diplicity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -708,6 +708,9 @@ Before adding a fixture to a per-app conftest, check whether it belongs in the r
 
 - The root conftest forces `MD5PasswordHasher` for tests (session autouse `override_test_settings`), so `create_user` is cheap. Do not create users with the production hasher in tests.
 - Prefer the session-scoped users/clients and variant lookups over creating new ones per test.
+- **Full suite runs: use `pytest -n auto`** (pytest-xdist, in `dev_requirements.txt`). The suite is parallel-safe: each worker gets its own database (`test_diplicity_gwN`), there are no live-server/port-binding tests, no FileField/media writes, and all external I/O (Resend email, Google/Apple auth, Firebase notifications) is mocked. CI runs with `-n auto`. It is deliberately not in `addopts` so that single-file runs (the preferred local feedback loop) skip the worker startup cost.
+- **Use `pytest --reuse-db` locally** to skip recreating the test database (and rerunning migrations, ~6s) between runs. Pass `--create-db` again after pulling new migrations. Works with `-n auto` too.
+- No test uses `django_db(transaction=True)` — keep it that way unless a test genuinely needs real transaction semantics (`on_commit`, concurrency); use the `mock_immediate_on_commit` fixture instead of transactional tests.
 
 Follow this testing pattern:
 - Create pytest fixtures in the root `conftest.py` that return callable factory functions

--- a/service/dev_requirements.txt
+++ b/service/dev_requirements.txt
@@ -1,3 +1,4 @@
 pytest>=8.4.2,<9.0
 pytest-django>=4.12.0,<5.0
 pytest-timeout>=2.3.1,<3.0
+pytest-xdist>=3.8.0,<4.0

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1920,17 +1920,7 @@ class TestGameInfinitePhaseDuration:
 class TestSandboxGameCreation:
 
     @pytest.mark.django_db
-    def test_create_sandbox_game_success(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_sets_sandbox_true(self, authenticated_client, classical_variant):
+    def test_create_sandbox_game_success(self, authenticated_client, classical_variant, primary_user):
         url = reverse(sandbox_create_viewname)
         payload = {
             "name": "My Sandbox Game",
@@ -1941,99 +1931,14 @@ class TestSandboxGameCreation:
 
         game = Game.objects.get(id=response.data["id"])
         assert game.sandbox is True
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_sets_private_true(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.private is True
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_sets_infinite_duration(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.movement_phase_duration is None
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_sets_ordered_nation_assignment(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.nation_assignment == NationAssignment.ORDERED
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_creates_multiple_members(self, authenticated_client, classical_variant, primary_user):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.members.count() == 7
         assert all(member.user == primary_user for member in game.members.all())
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_does_not_create_channels(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.channels.count() == 0
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_starts_immediately(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
         assert game.status == GameStatus.ACTIVE
-
-    @pytest.mark.django_db
-    def test_create_sandbox_game_creates_phase_states(self, authenticated_client, classical_variant):
-        url = reverse(sandbox_create_viewname)
-        payload = {
-            "name": "My Sandbox Game",
-            "variant_id": classical_variant.id,
-        }
-        response = authenticated_client.post(url, payload, format="json")
-        assert response.status_code == status.HTTP_201_CREATED
-
-        game = Game.objects.get(id=response.data["id"])
-        current_phase = game.current_phase
-        assert current_phase.phase_states.count() == 7
+        assert game.current_phase.phase_states.count() == 7
 
     @pytest.mark.django_db
     def test_create_sandbox_game_missing_name(self, authenticated_client, classical_variant):

--- a/service/victory/tests.py
+++ b/service/victory/tests.py
@@ -10,163 +10,44 @@ from victory.serializers import VictorySerializer
 
 class TestCheckForSoloWinner:
 
-    def test_clear_solo_winner_at_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
+    @pytest.mark.parametrize(
+        "threshold,sc_counts,winner_index",
+        [
+            pytest.param(18, [18, 16], 0, id="clear_solo_winner_at_threshold"),
+            pytest.param(18, [20, 14], 0, id="solo_winner_above_threshold"),
+            pytest.param(18, [17, 16], None, id="no_winner_below_threshold"),
+            pytest.param(18, [18, 18], None, id="no_winner_when_tied_at_threshold"),
+            pytest.param(18, [19, 19], None, id="no_winner_when_tied_above_threshold"),
+            pytest.param(8, [8, 5], 0, id="variant_specific_threshold"),
+            pytest.param(18, [17, 17, 17], None, id="three_way_tie"),
+            pytest.param(18, [18, 10, 8, 7, 5, 3, 2], 0, id="clear_winner_with_multiple_players"),
+        ],
+    )
+    def test_check_for_solo_winner(
+        self,
+        game_factory,
+        phase_factory,
+        member_factory,
+        supply_center_factory,
+        threshold,
+        sc_counts,
+        winner_index,
     ):
-        game = game_factory(variant__solo_victory_sc_count=18)
+        game = game_factory(variant__solo_victory_sc_count=threshold)
         phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
 
-        winner = member_factory(game=game)
-        other_member = member_factory(game=game)
+        members = [member_factory(game=game) for _ in sc_counts]
 
-        for _ in range(18):
-            supply_center_factory(phase=phase, nation=winner.nation)
-
-        for _ in range(16):
-            supply_center_factory(phase=phase, nation=other_member.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result == winner
-
-    def test_solo_winner_above_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        winner = member_factory(game=game)
-        other_member = member_factory(game=game)
-
-        for _ in range(20):
-            supply_center_factory(phase=phase, nation=winner.nation)
-
-        for _ in range(14):
-            supply_center_factory(phase=phase, nation=other_member.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result == winner
-
-    def test_no_winner_below_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        member1 = member_factory(game=game)
-        member2 = member_factory(game=game)
-
-        for _ in range(17):
-            supply_center_factory(phase=phase, nation=member1.nation)
-
-        for _ in range(16):
-            supply_center_factory(phase=phase, nation=member2.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result is None
-
-    def test_no_winner_when_tied_at_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        member1 = member_factory(game=game)
-        member2 = member_factory(game=game)
-
-        for _ in range(18):
-            supply_center_factory(phase=phase, nation=member1.nation)
-
-        for _ in range(18):
-            supply_center_factory(phase=phase, nation=member2.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result is None
-
-    def test_no_winner_when_tied_above_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        member1 = member_factory(game=game)
-        member2 = member_factory(game=game)
-
-        for _ in range(19):
-            supply_center_factory(phase=phase, nation=member1.nation)
-
-        for _ in range(19):
-            supply_center_factory(phase=phase, nation=member2.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result is None
-
-    def test_variant_specific_threshold(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=8)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        winner = member_factory(game=game)
-        other_member = member_factory(game=game)
-
-        for _ in range(8):
-            supply_center_factory(phase=phase, nation=winner.nation)
-
-        for _ in range(5):
-            supply_center_factory(phase=phase, nation=other_member.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result == winner
-
-    def test_three_way_tie(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        member1 = member_factory(game=game)
-        member2 = member_factory(game=game)
-        member3 = member_factory(game=game)
-
-        for _ in range(17):
-            supply_center_factory(phase=phase, nation=member1.nation)
-
-        for _ in range(17):
-            supply_center_factory(phase=phase, nation=member2.nation)
-
-        for _ in range(17):
-            supply_center_factory(phase=phase, nation=member3.nation)
-
-        result = check_for_solo_winner(game, phase)
-
-        assert result is None
-
-    def test_clear_winner_with_multiple_players(
-        self, game_factory, phase_factory, member_factory, supply_center_factory
-    ):
-        game = game_factory(variant__solo_victory_sc_count=18)
-        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
-
-        winner = member_factory(game=game)
-        members = [member_factory(game=game) for _ in range(6)]
-
-        for _ in range(18):
-            supply_center_factory(phase=phase, nation=winner.nation)
-
-        sc_counts = [10, 8, 7, 5, 3, 2]
         for member, count in zip(members, sc_counts):
             for _ in range(count):
                 supply_center_factory(phase=phase, nation=member.nation)
 
         result = check_for_solo_winner(game, phase)
 
-        assert result == winner
+        if winner_index is None:
+            assert result is None
+        else:
+            assert result == members[winner_index]
 
 
 class TestVictoryManager:
@@ -301,7 +182,7 @@ class TestVictoryManager:
         with pytest.raises(IntegrityError):
             victory2 = Victory.objects.try_create_victory(phase)
 
-    def test_solo_victories_queryset(self, victory_factory, member_factory):
+    def test_solo_and_draw_victories_querysets(self, victory_factory, member_factory):
         solo_victory = victory_factory()
         solo_victory.members.add(member_factory())
 
@@ -313,13 +194,6 @@ class TestVictoryManager:
         assert solo_victories.count() == 1
         assert solo_victory in solo_victories
         assert draw_victory not in solo_victories
-
-    def test_draw_victories_queryset(self, victory_factory, member_factory):
-        solo_victory = victory_factory()
-        solo_victory.members.add(member_factory())
-
-        draw_victory = victory_factory()
-        draw_victory.members.add(member_factory(), member_factory())
 
         draw_victories = Victory.objects.draw_victories()
 
@@ -351,23 +225,19 @@ class TestVictoryManager:
 
 class TestVictoryModel:
 
-    def test_type_property_solo(self, victory_factory, member_factory):
+    @pytest.mark.parametrize(
+        "member_count,expected_type",
+        [
+            pytest.param(1, VictoryType.SOLO, id="solo"),
+            pytest.param(2, VictoryType.DRAW, id="draw"),
+            pytest.param(3, VictoryType.DRAW, id="draw_three_members"),
+        ],
+    )
+    def test_type_property(self, victory_factory, member_factory, member_count, expected_type):
         victory = victory_factory()
-        victory.members.add(member_factory())
+        victory.members.add(*[member_factory() for _ in range(member_count)])
 
-        assert victory.type == VictoryType.SOLO
-
-    def test_type_property_draw(self, victory_factory, member_factory):
-        victory = victory_factory()
-        victory.members.add(member_factory(), member_factory())
-
-        assert victory.type == VictoryType.DRAW
-
-    def test_type_property_draw_three_members(self, victory_factory, member_factory):
-        victory = victory_factory()
-        victory.members.add(member_factory(), member_factory(), member_factory())
-
-        assert victory.type == VictoryType.DRAW
+        assert victory.type == expected_type
 
     def test_cascade_delete_when_game_deleted(self, game_factory, victory_factory):
         game = game_factory()
@@ -420,6 +290,11 @@ class TestVictorySerializer:
         assert data['winning_phase_id'] == victory.winning_phase.id
         assert len(data['members']) == 1
         assert data['members'][0]['id'] == member.id
+        assert 'id' in data
+        assert 'type' in data
+        assert 'winning_phase_id' in data
+        assert 'members' in data
+        assert isinstance(data['members'], list)
 
     def test_serializes_draw_victory(self, victory_factory, member_factory, primary_user, secondary_user, tertiary_user):
         victory = victory_factory()
@@ -445,20 +320,3 @@ class TestVictorySerializer:
         assert member2.id in member_ids
         assert member3.id in member_ids
 
-    def test_includes_all_required_fields(self, victory_factory, member_factory, primary_user):
-        victory = victory_factory()
-        member = member_factory(user=primary_user)
-        victory.members.add(member)
-
-        factory = APIRequestFactory()
-        request = factory.get('/')
-        request.user = primary_user
-
-        serializer = VictorySerializer(victory, context={'request': request})
-        data = serializer.data
-
-        assert 'id' in data
-        assert 'type' in data
-        assert 'winning_phase_id' in data
-        assert 'members' in data
-        assert isinstance(data['members'], list)


### PR DESCRIPTION
## Summary

Parallelize the backend test suite in CI and trim redundant per-test setup. The full suite drops from ~98s to ~42s locally on 4 cores (1484 tests passing).

## Changes

- **CI parallelization**: add `pytest-xdist` to `dev_requirements.txt` and run the test-service workflow with `-n auto`. The suite is parallel-safe: each worker gets its own database (`test_diplicity_gwN`), there are no live-server/port-binding tests, no FileField/media writes, and all external I/O (Resend email, Google/Apple auth, Firebase notifications) is mocked.
- **Combine identical-setup tests**: the nine `TestSandboxGameCreation` success tests repeated the exact same POST and asserted one property each — now a single test with all assertions. The solo/draw victory queryset tests shared identical setup and are merged.
- **Parametrize near-identical groups**: `TestCheckForSoloWinner` (8 tests) and the `Victory.type` property tests (3 tests) are now parametrized, preserving the original case names via ids.
- **Remove one superseded test**: `test_includes_all_required_fields` had identical setup and code path as `test_serializes_solo_victory`; its assertions are folded into that test.
- **Docs**: CLAUDE.md now documents `-n auto` for full-suite runs, `--reuse-db` for local iteration, and the no-`transaction=True` policy.

Profiling first (`--durations=25`) showed a flat distribution with no individual hot spots, so the wins are structural rather than per-test. Audited areas with no action needed: zero `django_db(transaction=True)` tests exist; read-only reference fixtures are already session-scoped; all external network calls are already mocked.

## Test plan

- Full suite serial: 1484 passed in 98s
- Full suite `-n auto` (4 workers): 1484 passed in 42s
- Test count drop from 1494 is exactly the combined/merged tests above — every assertion still runs.

https://claude.ai/code/session_018GRgTeN2t6DSKkxStxpB27

---
_Generated by [Claude Code](https://claude.ai/code/session_018GRgTeN2t6DSKkxStxpB27)_