### PR TITLE
Document model field ordering and PR description requirements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ The Team ID is `G76UP8FNMS` (stored in `.env` as `CAPACITOR_IOS_TEAM_ID`).
 8. **Write tests alongside features** - Not as an afterthought
 9. **Update RELEASE_NOTES.md for user-facing changes** - When implementing features, improvements, or bug fixes that players would notice or care about, add an entry to RELEASE_NOTES.md. Internal refactors, code cleanup, or developer-only changes do not need release notes.
 10. **Self-review non-trivial PRs with `/review-pr`** - Convention: whenever a pull request is of any significant complexity, the author runs the `/review-pr` command against it before requesting human review, and addresses (or explicitly responds to) its findings. This applies to PRs authored by Claude sessions too. Trivial PRs (typo fixes, dependency bumps, doc-only changes) are exempt.
+11. **PR description must match the diff** - Before writing or finalising a PR description, run `git diff main` and confirm every change claimed in the description is visible in that output. Do not describe work that happened in a prior PR or session — describe only what is in this diff.
 
 ---
 
@@ -709,6 +710,8 @@ Follow this pattern:
 ## Models
 
 Models have two responsibilities: (1) defining the fields of the data structure; (2) defining properties for conveniently accessing related entities and deriving data.
+
+**Model body order:** Always declare in this sequence: fields → `class Meta` → `@property` methods → other methods (`__str__`, etc.). Never place a property or method above `class Meta`.
 
 Query optimization code should be defined on a custom QuerySet class. Follow this pattern:
 


### PR DESCRIPTION
## What this PR does

Adds two documentation guidelines to CLAUDE.md:
1. Establishes a required field ordering convention for Django models (fields → `class Meta` → `@property` methods → other methods)
2. Requires PR descriptions to match the actual diff and describe only changes in the current PR, not prior work

These conventions improve code consistency and PR clarity for future development.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] Tests cover the change — N/A (documentation only)
- [x] `RELEASE_NOTES.md` updated if the change is user-facing — N/A (internal developer guidance)

https://claude.ai/code/session_01G3kXoSpf6gfmqE5Gmtnn4R