### PR TITLE
[UX A DAY]: Sort started games by next deadline

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Diplicity React - Release Notes
 
+## Started Games Sorted by Deadline (June 2026)
+
+### Change: "Started" games are ordered by next deadline
+
+In My Games, your started games are now ordered by how soon their next deadline is, with
+the most urgent game at the top. Games set to resolve manually ("resolve when ready") and
+sandbox games sort to the bottom, so the games actually waiting on you are easiest to find.
+
 ## Game Creator Rename (June 2026)
 
 ### Change: "Game Master" badge is now "Game Creator"

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -14,12 +14,13 @@ import { useGamesListInfinite } from "@/hooks/useGamesListInfinite";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 
 const statuses = [
-  { value: "pending", label: "Staging", statusFilter: "pending" },
-  { value: "active", label: "Started", statusFilter: "active" },
+  { value: "pending", label: "Staging", statusFilter: "pending", ordering: undefined },
+  { value: "active", label: "Started", statusFilter: "active", ordering: "deadline" },
   {
     value: "completed",
     label: "Finished",
     statusFilter: "completed,abandoned",
+    ordering: undefined,
   },
 ] as const;
 
@@ -81,15 +82,17 @@ interface GameTabContentProps {
   statusFilter: string;
   emptyTitle: string;
   status: StatusValue;
+  ordering?: string;
 }
 
 const GameTabContent: React.FC<GameTabContentProps> = ({
   statusFilter,
   emptyTitle,
   status,
+  ordering,
 }) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useGamesListInfinite({ mine: true, status: statusFilter });
+    useGamesListInfinite({ mine: true, status: statusFilter, ordering });
   const { data: variants } = useVariantsListSuspense();
 
   const games = data.pages.flatMap(page => page.results);
@@ -160,6 +163,7 @@ const MyGames: React.FC = () => {
                   statusFilter={s.statusFilter}
                   emptyTitle={`No ${s.label.toLowerCase()} games`}
                   status={s.value}
+                  ordering={s.ordering}
                 />
               </Suspense>
             </QueryErrorBoundary>

--- a/service/game/filters.py
+++ b/service/game/filters.py
@@ -1,7 +1,8 @@
 import django_filters
-from django.db.models import Count, F
+from django.db.models import Count, F, OuterRef, Subquery
 
-from common.constants import GameStatus, MovementPhaseDuration
+from common.constants import GameStatus, MovementPhaseDuration, PhaseStatus
+from phase.models import Phase
 
 from .models import Game
 
@@ -56,4 +57,15 @@ class GameFilter(django_filters.FilterSet):
                 nation_count=Count("variant__nations", distinct=True),
                 slots_remaining=F("nation_count") - F("member_count"),
             ).order_by("slots_remaining", "-created_at")
+        if value == "deadline":
+            next_deadline = (
+                Phase.objects.filter(game=OuterRef("pk"), status=PhaseStatus.ACTIVE)
+                .order_by("-ordinal")
+                .values("scheduled_resolution")[:1]
+            )
+            return queryset.annotate(next_deadline=Subquery(next_deadline)).order_by(
+                "sandbox",
+                F("next_deadline").asc(nulls_last=True),
+                "-created_at",
+            )
         return queryset

--- a/service/game/tests/test_game_list_deadline_ordering.py
+++ b/service/game/tests/test_game_list_deadline_ordering.py
@@ -1,0 +1,64 @@
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+
+from common.constants import GameStatus, PhaseStatus
+
+list_viewname = "game-list"
+
+
+@pytest.mark.django_db
+def test_started_games_ordered_by_deadline_with_sandboxes_last(
+    authenticated_client, primary_user, classical_variant, game_factory, phase_factory
+):
+    now = timezone.now()
+
+    soon = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    soon.members.create(user=primary_user)
+    phase_factory(game=soon, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=1))
+
+    later = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    later.members.create(user=primary_user)
+    phase_factory(game=later, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=5))
+
+    manual = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    manual.members.create(user=primary_user)
+    phase_factory(game=manual, status=PhaseStatus.ACTIVE, scheduled_resolution=None)
+
+    sandbox = game_factory(variant=classical_variant, status=GameStatus.ACTIVE, sandbox=True)
+    sandbox.members.create(user=primary_user)
+    phase_factory(game=sandbox, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(minutes=10))
+
+    url = reverse(list_viewname) + "?mine=true&status=active&ordering=deadline"
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [g["id"] for g in response.data["results"]]
+    my_ids = {soon.id, later.id, manual.id, sandbox.id}
+    assert [i for i in ids if i in my_ids] == [soon.id, later.id, manual.id, sandbox.id]
+
+
+@pytest.mark.django_db
+def test_started_games_default_order_is_created_at(
+    authenticated_client, primary_user, classical_variant, game_factory, phase_factory
+):
+    now = timezone.now()
+
+    first = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    first.members.create(user=primary_user)
+    phase_factory(game=first, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=1))
+
+    second = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    second.members.create(user=primary_user)
+    phase_factory(game=second, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=5))
+
+    url = reverse(list_viewname) + "?mine=true&status=active"
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [g["id"] for g in response.data["results"]]
+    my_ids = {first.id, second.id}
+    assert [i for i in ids if i in my_ids] == [second.id, first.id]


### PR DESCRIPTION
## Summary

The "Started" tab of My Games now orders games by how soon their next deadline is — the most urgent game first. Games set to resolve manually ("resolve when ready") and sandbox games sort to the bottom, so the games actually waiting on you are easiest to find.

- **Frontend**: the Started tab passes a new `ordering=deadline` query param (the `Staging`/`Finished` tabs keep the default `-created_at`). No codegen needed — `ordering` already exists in the generated client.
- **Backend**: `GameFilter` gains a `deadline` ordering that annotates each game with its active phase's `scheduled_resolution` via a correlated subquery and orders by:
  1. `sandbox` ascending → sandboxes last
  2. `next_deadline` ascending, NULLs last → soonest deadline first; manual-resolution games after timed ones
  3. `-created_at` → deterministic tiebreaker

### Why server-side?

The My Games list is paginated (`page_size = 20`). A client-side sort would only reorder the games already fetched into the current pages — a game on page 2 with a sooner deadline would still render below page-1 games. Ordering has to happen in the DB before pagination slices the result. Ordering by the absolute `scheduled_resolution` ascending is equivalent to "shortest time left first" and avoids per-request `deadline - now` math.

## Test plan

- [x] `service/game/tests/test_game_list_deadline_ordering.py` (new): asserts `soon < later < manual(null) < sandbox` for `ordering=deadline`, and that tabs without the param still order by `-created_at`. Assertions are scoped to each test's own games because a `UserProfile` post-save signal seeds a "Practice Game" sandbox per user.
- [x] Existing list tests (`test_games_list_perf`, `test_anonymous_games`) — green, no regression.
- [x] `npx tsc -b --noEmit` — clean.

## Screenshots

**No screenshot.** The visual effect is produced entirely by backend ordering; under MSW mocks the games handler returns fixtures in registry order and does not replicate the deadline sort, so a mock screenshot would not demonstrate the change. The behaviour is verified by the backend tests above.

---

## Self code review (`/review-pr`)

**Does it make sense?** Yes. Server-side is the correct layer (pagination would break a client sort). The subquery picks the active phase unambiguously (`status=ACTIVE`, `order_by("-ordinal")[:1]` — an active game has exactly one active phase). The three-key ordering matches the requirement and is verified by tests on both the new and default paths. `ordering` already exists in the generated client, so no codegen is needed. Single-purpose; RELEASE_NOTES updated.

Checked the two likely pitfalls: the cross-app `from phase.models import Phase` import is consistent with `game/models.py` and introduces no cycle; `filter_mine`'s `.distinct()` combined with `order_by` on the subquery annotation works in Postgres (annotation + ordering fields are in the SELECT list) and is exercised by the `mine=true` tests.

**Does it meet the bar?** Yes, no blocking issues. The new branch is structurally identical to the adjacent `slots_remaining` branch; imports at top, no comments, tsc clean, no suppressions. Tests are API-level and assert on observable response ordering, correctly scoped around the seeded "Practice Game".

**Non-blocking suggestions:**
- `ordering: undefined` on the non-Started tab configs is deliberate (keeps `s.ordering` type-safe across the `as const` union), not an oversight.
- No `assertNumQueries` test for the new ordering. The subquery is a single scalar correlated subquery (not an N+1) and `test_games_list_perf` still passes, so this is optional — add one only if the list query budget is actively guarded.

**Verdict:** Looks good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
