### PR TITLE
[UX A DAY] Add nation badge to game cards and orders screen

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Diplicity React - Release Notes
 
+## Nation Badge (June 2026)
+
+### Feature: Your nation is shown at a glance
+
+Your assigned nation now appears as a colour-coded badge next to the game name on each game
+card, so you can immediately see which power you are playing across your list of games. The
+same badge marks your own row ("you") on the orders screen. The badge is hidden for sandbox
+games and for games that haven't assigned nations yet.
+
 ## Game Creator Rename (June 2026)
 
 ### Change: "Game Master" badge is now "Game Creator"

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -55,7 +55,7 @@ const renderGameCard = (props: React.ComponentProps<typeof GameCard>) => {
 };
 
 const defaultProps = {
-  variant: { name: "Classical Diplomacy", id: "Classical" },
+  variant: { name: "Classical Diplomacy", id: "Classical", nations: [] },
   phaseId: 1,
   map: <div data-testid="map" />,
 };
@@ -96,7 +96,7 @@ describe("GameCard", () => {
       mockUseIsMobile.mockReturnValue(true);
       const game = mockActiveGames[0];
       renderGameCard({ game, ...defaultProps });
-      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      await userEvent.click(screen.getByRole("button", { name: (accessibleName: string) => accessibleName.includes(game.name) }));
       expect(mockNavigate).toHaveBeenCalledWith(
         `/game/${game.id}/phase/${game.currentPhaseId}`
       );
@@ -106,7 +106,7 @@ describe("GameCard", () => {
       mockUseIsMobile.mockReturnValue(false);
       const game = mockActiveGames[0];
       renderGameCard({ game, ...defaultProps });
-      await userEvent.click(screen.getByRole("button", { name: game.name }));
+      await userEvent.click(screen.getByRole("button", { name: (accessibleName: string) => accessibleName.includes(game.name) }));
       expect(mockNavigate).toHaveBeenCalledWith(
         `/game/${game.id}/phase/${game.currentPhaseId}/orders`
       );

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -12,6 +12,7 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 import { GameDropdownMenu } from "./GameDropdownMenu";
+import { NationBadge } from "./NationBadge";
 import { UserPlus, Lock, MessageSquareOff } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -29,7 +30,7 @@ import { useCheckNotificationPermission } from "@/hooks/useCheckNotificationPerm
 
 export interface GameCardProps {
   game: GameList;
-  variant: Pick<Variant, "name" | "id">;
+  variant: Pick<Variant, "name" | "id" | "nations">;
   map: React.ReactNode;
   className?: string;
 }
@@ -39,6 +40,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const phase = game.currentPhase;
+  const playerNation = game.members.find(m => m.isCurrentUser)?.nation ?? null;
   const joinGameMutation = useGameJoinCreate();
   const checkNotificationPermission = useCheckNotificationPermission();
 
@@ -106,6 +108,9 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                   {game.pressType === "no_press" && <MessageSquareOff className="h-3 w-3" aria-label="Gunboat" />}
                   {game.sandbox && (
                     <Badge variant="secondary">Sandbox</Badge>
+                  )}
+                  {!game.sandbox && (
+                    <NationBadge nations={variant.nations} nation={playerNation} />
                   )}
                 </CardTitle>
               </button>

--- a/packages/web/src/components/NationBadge.test.tsx
+++ b/packages/web/src/components/NationBadge.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { NationBadge } from "./NationBadge";
+
+const nations = [
+  { name: "Russia", color: "#F5F5F5" },
+  { name: "Germany", color: "#90A4AE" },
+  { name: "Turkey", color: "#202020" },
+];
+
+describe("NationBadge", () => {
+  it("renders nothing when nation is null", () => {
+    const { container } = render(<NationBadge nations={nations} nation={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("defaults the label to the nation name", () => {
+    render(<NationBadge nations={nations} nation="Germany" />);
+    expect(screen.getByText("Germany")).toBeInTheDocument();
+  });
+
+  it("renders custom children as the label", () => {
+    render(
+      <NationBadge nations={nations} nation="Germany">
+        you
+      </NationBadge>
+    );
+    expect(screen.getByText("you")).toBeInTheDocument();
+  });
+
+  it("uses dark text on a light nation colour", () => {
+    render(<NationBadge nations={nations} nation="Russia" />);
+    expect(screen.getByText("Russia")).toHaveStyle({ color: "#000000" });
+  });
+
+  it("uses light text on a dark nation colour", () => {
+    render(<NationBadge nations={nations} nation="Turkey" />);
+    expect(screen.getByText("Turkey")).toHaveStyle({ color: "#ffffff" });
+  });
+});

--- a/packages/web/src/components/NationBadge.tsx
+++ b/packages/web/src/components/NationBadge.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { findNationColor } from "./NationFlag";
+
+const getContrastColor = (hexColor: string | null): string => {
+  if (!hexColor) return "#ffffff";
+  const hex = hexColor.replace("#", "");
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "#000000" : "#ffffff";
+};
+
+interface NationBadgeProps {
+  nations: ReadonlyArray<{ name: string; color: string }>;
+  nation: string | null | undefined;
+  children?: React.ReactNode;
+}
+
+const NationBadge: React.FC<NationBadgeProps> = ({ nations, nation, children }) => {
+  if (!nation) return null;
+  const color = findNationColor(nations, nation);
+  return (
+    <Badge
+      className="leading-none"
+      style={{ backgroundColor: color ?? undefined, color: getContrastColor(color) }}
+    >
+      {children ?? nation}
+    </Badge>
+  );
+};
+
+export { NationBadge };

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/item";
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
+import { NationBadge } from "@/components/NationBadge";
 import { GameDropdownMenu } from "@/components/GameDropdownMenu";
 import { GameDetailAppBar } from "./AppBar";
 import { Panel } from "@/components/Panel";
@@ -341,7 +342,7 @@ const OrdersScreen: React.FC = () => {
                   nationGroups.find(g => g.member.isCurrentUser)?.nation ?? "",
                 ]}
               >
-                {nationGroups.map(({ nation, items }) => {
+                {nationGroups.map(({ nation, member, items }) => {
                   const nationColor = findNationColor(variant.nations, nation);
                   return (
                     <AccordionItem key={nation} value={nation}>
@@ -355,6 +356,14 @@ const OrdersScreen: React.FC = () => {
                           />
                           <span>{nation}</span>
                           <span className="text-muted-foreground">•</span>
+                          {member.isCurrentUser && nation && (
+                            <>
+                              <NationBadge nations={variant.nations} nation={nation}>
+                                you
+                              </NationBadge>
+                              <span className="text-muted-foreground">•</span>
+                            </>
+                          )}
                           <span className="inline-flex items-center gap-1 text-muted-foreground">
                             <Star className="size-3" />
                             <span>{getSupplyCenterCount(nation)}</span>


### PR DESCRIPTION
## Summary

Adds a colour-coded **Nation Badge** that surfaces the current user's assigned nation:

- On each **game card** (My Games / Find Games), the badge appears next to the game name, so you can see at a glance which power you're playing across your list of games.
- On the **Orders screen**, the same badge marks your own nation's row with a "you" label.
- The badge is **hidden for sandbox games** (the existing "Sandbox" badge shows instead) and for games that haven't assigned nations yet.

The badge background uses the nation's colour from the variant, with foreground text switched between black/white based on a luminance contrast calculation so the label stays readable on both light and dark nation colours.

## Part of the "Updated Game Card" epic

This is the **first small step** in a larger epic to refresh the game-card style. The intent is to move **slowly, in small self-contained PRs**, each adding one increment of the new card design, rather than landing one large redesign. This PR introduces the reusable `NationBadge` component and wires it into the card + orders surfaces; subsequent PRs will continue layering in the updated card style piece by piece.

## Changes

- **New** `NationBadge` component (`packages/web/src/components/NationBadge.tsx`) + unit tests — renders a coloured `Badge` for a nation, with automatic contrast-based text colour and a `null` render when no nation is set.
- `GameCard.tsx` — renders the badge next to the game name for non-sandbox games using the current user's member nation. `variant` prop widened to include `nations`.
- `OrdersScreen.tsx` — renders a "you" `NationBadge` on the current user's nation group.
- `GameCard.test.tsx` — accessible-name matcher relaxed to `includes(...)` since the badge text now forms part of the title button's accessible name.
- `RELEASE_NOTES.md` — player-facing entry.

## Review

Self-reviewed with `/code-review` (high effort). No correctness bugs found. Verified: `NationBadge` null-guards before touching the nations array; the sandbox/non-sandbox branches are mutually exclusive; the not-a-member and unassigned-nation cases correctly render nothing; all callers pass a full `Variant` (with `nations`); and nation colours in the data are 6-digit hex, so the contrast calculation is well-defined.

## Screenshots

**Game cards — your nation badge next to each game name:**

![game cards with nation badge](https://raw.githubusercontent.com/johnpooch/diplicity-react/8a517fbc80a4b0a30f9510fa7dddb4e8b90d8b69/shots/my-games.png)

**Orders screen — "you" badge on your nation (mobile):**

![orders screen you badge](https://raw.githubusercontent.com/johnpooch/diplicity-react/8a517fbc80a4b0a30f9510fa7dddb4e8b90d8b69/shots/orders-mobile.png)

**Sandbox game — nation badge hidden, "Sandbox" badge shown instead:**

![sandbox game card](https://raw.githubusercontent.com/johnpooch/diplicity-react/8a517fbc80a4b0a30f9510fa7dddb4e8b90d8b69/shots/my-games-sandbox.png)

**Sandbox orders screen (mobile):**

![sandbox orders screen](https://raw.githubusercontent.com/johnpooch/diplicity-react/8a517fbc80a4b0a30f9510fa7dddb4e8b90d8b69/shots/orders-sandbox-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
