### PR TITLE
Sort chat channels by most recent activity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Diplicity React - Release Notes
 
+## Chat Channels Sorted by Activity (June 2026)
+
+### Change: Chat channels are ordered by most recent activity
+
+In a game's chat, your channels are now ordered by how recently each one had activity, with
+the most recently active channel near the top. The public "Public Press" channel is always
+pinned to the top, and channels with no messages yet sort to the bottom.
+
 ## Nation Badge (June 2026)
 
 ### Feature: Your nation is shown at a glance

--- a/service/channel/models.py
+++ b/service/channel/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.models import Q, Count, Subquery, OuterRef, IntegerField, Value
+from django.db.models import Q, Count, Subquery, OuterRef, IntegerField, Value, Max, F
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from common.models import BaseModel
@@ -22,6 +22,13 @@ class ChannelQuerySet(models.QuerySet):
     def with_related_data(self):
         return self.prefetch_related(
             "messages", "messages__sender", "messages__sender__user", "members", "members__user"
+        )
+
+    def order_for_list(self):
+        return self.annotate(last_activity=Max("messages__created_at")).order_by(
+            "private",
+            F("last_activity").desc(nulls_last=True),
+            "-created_at",
         )
 
     def with_unread_counts(self, user):
@@ -67,6 +74,9 @@ class ChannelManager(models.Manager):
 
     def with_unread_counts(self, user):
         return self.get_queryset().with_unread_counts(user)
+
+    def order_for_list(self):
+        return self.get_queryset().order_for_list()
 
 
 class Channel(BaseModel):

--- a/service/channel/tests/test_channel.py
+++ b/service/channel/tests/test_channel.py
@@ -1,7 +1,9 @@
 import pytest
+from datetime import timedelta
 from unittest.mock import patch
 from django.apps import apps
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from channel.models import Channel, ChannelMessage
 
@@ -169,6 +171,79 @@ class TestChannelListView:
         assert "Other Game Channel" not in channel_names
         assert "Private Member" in channel_names
         assert "Public Channel" in channel_names
+
+
+class TestChannelListOrdering:
+
+    @pytest.mark.django_db
+    def test_public_channel_first_even_with_older_activity(
+        self, authenticated_client, active_game_with_phase_state
+    ):
+        game = active_game_with_phase_state
+        member = game.members.first()
+
+        public_channel = Channel.objects.create(game=game, name="Public Press", private=False)
+        private_channel = Channel.objects.create(game=game, name="Private", private=True)
+        private_channel.members.add(member)
+
+        public_message = ChannelMessage.objects.create(channel=public_channel, sender=member, body="old")
+        private_message = ChannelMessage.objects.create(channel=private_channel, sender=member, body="new")
+        ChannelMessage.objects.filter(id=public_message.id).update(created_at=timezone.now() - timedelta(days=2))
+        ChannelMessage.objects.filter(id=private_message.id).update(created_at=timezone.now())
+
+        url = reverse("channel-list", args=[game.id])
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        names = [ch["name"] for ch in response.data]
+        assert names == ["Public Press", "Private"]
+
+    @pytest.mark.django_db
+    def test_private_channels_sorted_by_most_recent_activity(
+        self, authenticated_client, active_game_with_phase_state
+    ):
+        game = active_game_with_phase_state
+        member = game.members.first()
+
+        Channel.objects.create(game=game, name="Public Press", private=False)
+        older = Channel.objects.create(game=game, name="Older", private=True)
+        newer = Channel.objects.create(game=game, name="Newer", private=True)
+        older.members.add(member)
+        newer.members.add(member)
+
+        older_message = ChannelMessage.objects.create(channel=older, sender=member, body="older")
+        newer_message = ChannelMessage.objects.create(channel=newer, sender=member, body="newer")
+        ChannelMessage.objects.filter(id=older_message.id).update(created_at=timezone.now() - timedelta(hours=1))
+        ChannelMessage.objects.filter(id=newer_message.id).update(created_at=timezone.now())
+
+        url = reverse("channel-list", args=[game.id])
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        names = [ch["name"] for ch in response.data]
+        assert names == ["Public Press", "Newer", "Older"]
+
+    @pytest.mark.django_db
+    def test_channels_without_messages_sorted_last(
+        self, authenticated_client, active_game_with_phase_state
+    ):
+        game = active_game_with_phase_state
+        member = game.members.first()
+
+        Channel.objects.create(game=game, name="Public Press", private=False)
+        with_message = Channel.objects.create(game=game, name="With Message", private=True)
+        without_message = Channel.objects.create(game=game, name="Without Message", private=True)
+        with_message.members.add(member)
+        without_message.members.add(member)
+
+        ChannelMessage.objects.create(channel=with_message, sender=member, body="hello")
+
+        url = reverse("channel-list", args=[game.id])
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        names = [ch["name"] for ch in response.data]
+        assert names == ["Public Press", "With Message", "Without Message"]
 
 
 class TestChannelMessageCreateView:

--- a/service/channel/views.py
+++ b/service/channel/views.py
@@ -37,4 +37,5 @@ class ChannelListView(SelectedGameMixin, generics.ListAPIView):
             Channel.objects.accessible_to_user(self.request.user, self.get_game())
             .with_unread_counts(self.request.user)
             .with_related_data()
+            .order_for_list()
         )


### PR DESCRIPTION
## What this does

Adds a deterministic order to the chat channel list. A new `ChannelQuerySet.order_for_list()` annotates each channel with `last_activity = Max(messages__created_at)` and orders by:

1. `private` ascending — the public **Public Press** channel (`private=False`) is always pinned to the top.
2. `last_activity` descending with `nulls_last=True` — most recently active channels next, channels with no messages last.
3. `-created_at` as a stable tiebreaker.

`ChannelListView` chains the new method onto its existing queryset. The sort lives entirely in the backend; the frontend keeps rendering the API order verbatim, so no frontend changes are needed.

## Why it makes sense

- Public Press sorts first regardless of its own activity because `private` ascending dominates the ordering, and there is exactly one public channel per game (`game/serializers.py`).
- `Max(messages__created_at)` captures the latest activity whether sent or received (no sender filter).
- The new `Max` annotation coexists safely with the existing filtered `Count(distinct=True)` from `with_unread_counts` — both share a single join/GROUP BY; `distinct=True` protects the count and `Max` is unaffected by row multiplication.

## Tests

Added `TestChannelListOrdering` with three API-level tests asserting on the response body:
- Public channel stays first even when a private channel has newer activity.
- Private channels are ordered by most recent message.
- Channels without messages sort last.

Full channel suite passes (49 tests).

## No codegen / no screenshots

- **No codegen**: the API response *shape* is unchanged — only the order of the array elements differs — so no OpenAPI/client regeneration is required.
- **No screenshots**: there are no visual changes. The reordering is a pure data-ordering change in the backend; the channel list UI renders identical rows in a different order, and there is no way to convey "these are now sorted" in a static screenshot without a contrived before/after of specific fixture data. Mock mode (MSW) serves channels in fixture order and does not exercise the backend sort, so screenshots would not reflect this change anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)