### PR TITLE
Fix AttributeError when source_unit is None in Order.step

### DIFF
--- a/service/order/models.py
+++ b/service/order/models.py
@@ -263,6 +263,7 @@ class Order(BaseModel):
             self.order_type == OrderType.MOVE
             and self.target
             and self.target.named_coasts.exists()
+            and self.source_unit
             and self.source_unit.type == UnitType.FLEET
             and not self.named_coast
         ):


### PR DESCRIPTION
## What broke

`POST /game/{game_id}/orders/` raised a 500 `AttributeError: 'NoneType' object has no attribute 'type'` when `Order.step` reached the named-coast check for a MOVE order. Affected 68 events on Sentry (DIPLICITY-API-6W), observed on the Spice Island test game.

## Root cause

`Order.source_unit` explicitly returns `None` when no unit is found at the source province (`return units[0] if units else None`). The `step` property called `self.source_unit.type` without a `None` guard:

```python
# before
and self.source_unit.type == UnitType.FLEET
```

## Fix

One-line guard added before the `.type` access:

```python
# after
and self.source_unit
and self.source_unit.type == UnitType.FLEET
```

If there is no source unit, the fleet-to-named-coast check is irrelevant and the order falls through to `COMPLETED` as expected.

Closes #724


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kzkiw1UwidDG1iMCiMEaSJ)_