### PR TITLE
Fix N+1 query on /options/ endpoint

### DIFF
--- a/service/order/views.py
+++ b/service/order/views.py
@@ -32,7 +32,7 @@ class OrderOptionsView(CurrentPhaseMixin, generics.RetrieveAPIView):
         phase = self.get_phase()
         province_lookup = {p.province_id: p for p in phase.variant.provinces.all()}
         transformed = phase.transformed_options or {}
-        members = phase.game.members.filter(user=request.user)
+        members = phase.game.members.select_related("nation").filter(user=request.user)
         nation_names = [m.nation.name for m in members]
 
         all_orders = []


### PR DESCRIPTION
## What broke

`GET /game/{game_id}/options/` was firing one `SELECT ... FROM nation_nation WHERE id = %s` per game member — 105 Sentry events captured before this was caught.

## Root cause

`phase.game.members.filter(user=request.user)` fetched `Member` rows without prefetching the `nation` FK. Accessing `m.nation.name` inside the list comprehension on the next line triggered a separate DB round-trip for every member.

## Fix

Added `.select_related("nation")` to the queryset so Django JOINs `nation_nation` in the initial query instead of lazily fetching it per row.

Closes #726


---
_Generated by [Claude Code](https://claude.ai/code/session_0148zDuiZJCGPRt8vUsDn6b2)_