### PR TITLE
Fix TypeError in check_for_solo_winner for variants without solo victory condition

### DIFF
--- a/service/victory/tests.py
+++ b/service/victory/tests.py
@@ -49,6 +49,25 @@ class TestCheckForSoloWinner:
         else:
             assert result == members[winner_index]
 
+    def test_returns_none_when_variant_has_no_solo_victory_condition(
+        self,
+        game_factory,
+        phase_factory,
+        member_factory,
+        supply_center_factory,
+    ):
+        game = game_factory()
+        game.variant.victory_conditions = [{"type": "timed-resolution", "year": 1910, "resolution": "shared-draw"}]
+        game.variant.save()
+
+        phase = phase_factory(game=game, type=PhaseType.ADJUSTMENT, season="Fall")
+
+        member = member_factory(game=game)
+        for _ in range(30):
+            supply_center_factory(phase=phase, nation=member.nation)
+
+        assert check_for_solo_winner(game, phase) is None
+
 
 class TestVictoryManager:
 

--- a/service/victory/utils.py
+++ b/service/victory/utils.py
@@ -3,6 +3,8 @@ from django.db.models import Count
 
 def check_for_solo_winner(game, phase):
     required_sc_count = game.variant.solo_victory_supply_centers
+    if required_sc_count is None:
+        return None
 
     counts_by_nation = {
         row["nation"]: row["count"]


### PR DESCRIPTION
## What broke

`POST /game/{game_id}/resolve-phase/` crashed with `TypeError: '>=' not supported between instances of 'int' and 'NoneType'` for games using variants that have no supply-center-majority victory condition (e.g. US Civil War Sandbox). 14 events, escalating.

## Root cause

`Variant.solo_victory_supply_centers` returns `None` when the variant's `victory_conditions` list has no `supply-center-majority` entry. `check_for_solo_winner` read this into `required_sc_count` and then immediately used it in `highest_count >= required_sc_count` without guarding against `None`.

## Fix

Added an early `return None` in `victory/utils.py` when `required_sc_count is None` — a variant without a supply-center-majority condition cannot produce a solo winner, so returning `None` is both correct and safe.

Added a regression test that sets `victory_conditions` to a timed-resolution-only list and verifies the function returns `None` even when one player dominates the board.

Closes #728