### PR TITLE
Add expandable, zoomable map preview

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Diplicity React - Release Notes
 
+## Expandable, Zoomable Map Preview (June 2026)
+
+### Feature: Inspect a variant's map before committing to a game
+
+The map previews shown when creating a game and when viewing a game's info are now
+expandable. Tap a preview to open it full-screen, where you can pinch, scroll, or use the
+on-screen controls to zoom and pan around the map. This makes it easy to study a variant's
+board in detail before deciding to create or join a game.
+
 ## Unread Message Indicator on Game Cards (June 2026)
 
 ### Feature: See unread message counts without opening a game

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files

--- a/packages/web/src/components/ExpandableMapPreview.test.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.test.tsx
@@ -33,9 +33,10 @@ vi.mock("./InteractiveMap/toRenderState", () => ({
 }));
 
 const variant = {
+  name: "Classical",
   nations: [],
   svgUrl: "https://example.com/map.svg",
-} as Pick<Variant, "nations" | "svgUrl">;
+} as Pick<Variant, "name" | "nations" | "svgUrl">;
 
 const phase = {} as VariantTemplatePhase;
 
@@ -57,9 +58,7 @@ describe("ExpandableMapPreview", () => {
   });
 
   it("renders the preview with an expand control and no dialog initially", () => {
-    render(
-      <ExpandableMapPreview variant={variant} phase={phase} variantName="Classical" />
-    );
+    render(<ExpandableMapPreview variant={variant} phase={phase} />);
 
     expect(screen.getByTestId("map-preview")).toBeInTheDocument();
     expect(
@@ -69,9 +68,7 @@ describe("ExpandableMapPreview", () => {
   });
 
   it("opens a zoomable dialog with only a close button when clicked", () => {
-    render(
-      <ExpandableMapPreview variant={variant} phase={phase} variantName="Classical" />
-    );
+    render(<ExpandableMapPreview variant={variant} phase={phase} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Expand map preview" }));
 

--- a/packages/web/src/components/ExpandableMapPreview.test.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.test.tsx
@@ -17,7 +17,7 @@ vi.mock("react-zoom-pan-pinch", () => ({
 }));
 
 vi.mock("../hooks/useDsvg", () => ({
-  useDsvg: () => ({ data: "<svg></svg>" }),
+  useDsvg: () => ({ data: '<svg viewBox="0 0 100 100"></svg>' }),
 }));
 
 vi.mock("./InteractiveMap/mapRenderer", () => ({
@@ -42,6 +42,20 @@ const phase = {} as VariantTemplatePhase;
 
 describe("ExpandableMapPreview", () => {
   beforeAll(() => {
+    globalThis.ResizeObserver = class {
+      callback: ResizeObserverCallback;
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+      observe() {
+        this.callback(
+          [{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry],
+          this
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    };
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({

--- a/packages/web/src/components/ExpandableMapPreview.test.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.test.tsx
@@ -8,18 +8,8 @@ vi.mock("./MapPreview", () => ({
 }));
 
 vi.mock("react-zoom-pan-pinch", () => ({
-  TransformWrapper: ({
-    children,
-  }: {
-    children: (controls: {
-      zoomIn: () => void;
-      zoomOut: () => void;
-      resetTransform: () => void;
-    }) => React.ReactNode;
-  }) => (
-    <div data-testid="transform-wrapper">
-      {children({ zoomIn: vi.fn(), zoomOut: vi.fn(), resetTransform: vi.fn() })}
-    </div>
+  TransformWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="transform-wrapper">{children}</div>
   ),
   TransformComponent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="transform-component">{children}</div>
@@ -78,7 +68,7 @@ describe("ExpandableMapPreview", () => {
     expect(screen.queryByTestId("transform-wrapper")).not.toBeInTheDocument();
   });
 
-  it("opens a zoomable dialog when the preview is clicked", () => {
+  it("opens a zoomable dialog with only a close button when clicked", () => {
     render(
       <ExpandableMapPreview variant={variant} phase={phase} variantName="Classical" />
     );
@@ -86,9 +76,12 @@ describe("ExpandableMapPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Expand map preview" }));
 
     expect(screen.getByTestId("transform-wrapper")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeInTheDocument();
     expect(screen.getByText("Classical map")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom in" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom out" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reset zoom" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/ExpandableMapPreview.test.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { ExpandableMapPreview } from "./ExpandableMapPreview";
+import type { Variant, VariantTemplatePhase } from "@/api/generated/endpoints";
+
+vi.mock("./MapPreview", () => ({
+  MapPreview: () => <div data-testid="map-preview" />,
+}));
+
+vi.mock("react-zoom-pan-pinch", () => ({
+  TransformWrapper: ({
+    children,
+  }: {
+    children: (controls: {
+      zoomIn: () => void;
+      zoomOut: () => void;
+      resetTransform: () => void;
+    }) => React.ReactNode;
+  }) => (
+    <div data-testid="transform-wrapper">
+      {children({ zoomIn: vi.fn(), zoomOut: vi.fn(), resetTransform: vi.fn() })}
+    </div>
+  ),
+  TransformComponent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="transform-component">{children}</div>
+  ),
+}));
+
+vi.mock("../hooks/useDsvg", () => ({
+  useDsvg: () => ({ data: "<svg></svg>" }),
+}));
+
+vi.mock("./InteractiveMap/mapRenderer", () => ({
+  DiplicityMap: class {
+    render() {
+      return "<svg></svg>";
+    }
+  },
+}));
+
+vi.mock("./InteractiveMap/toRenderState", () => ({
+  toRenderState: () => ({}),
+}));
+
+const variant = {
+  nations: [],
+  svgUrl: "https://example.com/map.svg",
+} as Pick<Variant, "nations" | "svgUrl">;
+
+const phase = {} as VariantTemplatePhase;
+
+describe("ExpandableMapPreview", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("renders the preview with an expand control and no dialog initially", () => {
+    render(
+      <ExpandableMapPreview variant={variant} phase={phase} variantName="Classical" />
+    );
+
+    expect(screen.getByTestId("map-preview")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Expand map preview" })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("transform-wrapper")).not.toBeInTheDocument();
+  });
+
+  it("opens a zoomable dialog when the preview is clicked", () => {
+    render(
+      <ExpandableMapPreview variant={variant} phase={phase} variantName="Classical" />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand map preview" }));
+
+    expect(screen.getByTestId("transform-wrapper")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeInTheDocument();
+    expect(screen.getByText("Classical map")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ExpandableMapPreview.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from "react";
+import { Expand, Minus, Plus, RotateCcw } from "lucide-react";
+import {
+  TransformWrapper,
+  TransformComponent,
+} from "react-zoom-pan-pinch";
+
+import type {
+  PhaseRetrieve,
+  Variant,
+  VariantTemplatePhase,
+} from "../api/generated/endpoints";
+import { useDsvg } from "../hooks/useDsvg";
+import { DiplicityMap } from "./InteractiveMap/mapRenderer";
+import { toRenderState } from "./InteractiveMap/toRenderState";
+import { MapPreview } from "./MapPreview";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type VariantForPreview = Pick<Variant, "nations" | "svgUrl">;
+
+type ExpandableMapPreviewProps = {
+  variant: VariantForPreview;
+  phase: PhaseRetrieve | VariantTemplatePhase;
+  variantName?: string;
+  style?: React.CSSProperties;
+  className?: string;
+};
+
+const ZoomableMap: React.FC<{
+  variant: VariantForPreview;
+  phase: PhaseRetrieve | VariantTemplatePhase;
+}> = ({ variant, phase }) => {
+  const { data: dsvg } = useDsvg(variant.svgUrl, true);
+
+  const svg = useMemo(() => {
+    if (!dsvg) return null;
+    const renderState = toRenderState(variant, phase, [], [], []);
+    return new DiplicityMap(dsvg)
+      .render(renderState)
+      .replace(
+        "<svg ",
+        '<svg preserveAspectRatio="xMidYMid meet" width="100%" height="100%" '
+      );
+  }, [dsvg, variant, phase]);
+
+  if (!svg) {
+    return <Skeleton className="w-full h-full" />;
+  }
+
+  return (
+    <TransformWrapper
+      minScale={1}
+      maxScale={8}
+      centerOnInit
+      doubleClick={{ mode: "zoomIn", step: 0.7 }}
+    >
+      {({ zoomIn, zoomOut, resetTransform }) => (
+        <>
+          <TransformComponent
+            wrapperStyle={{ width: "100%", height: "100%" }}
+            contentStyle={{ width: "100%", height: "100%" }}
+          >
+            <div
+              className="w-full h-full"
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </TransformComponent>
+          <div className="absolute bottom-4 right-4 flex flex-col gap-2">
+            <Button
+              size="icon"
+              variant="secondary"
+              className="rounded-full shadow-lg"
+              onClick={() => zoomIn()}
+              aria-label="Zoom in"
+            >
+              <Plus />
+            </Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              className="rounded-full shadow-lg"
+              onClick={() => zoomOut()}
+              aria-label="Zoom out"
+            >
+              <Minus />
+            </Button>
+            <Button
+              size="icon"
+              variant="secondary"
+              className="rounded-full shadow-lg"
+              onClick={() => resetTransform()}
+              aria-label="Reset zoom"
+            >
+              <RotateCcw />
+            </Button>
+          </div>
+        </>
+      )}
+    </TransformWrapper>
+  );
+};
+
+const ExpandableMapPreview: React.FC<ExpandableMapPreviewProps> = ({
+  variant,
+  phase,
+  variantName,
+  style,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`group relative block w-full cursor-zoom-in ${className ?? ""}`}
+        style={style}
+        aria-label="Expand map preview"
+      >
+        <MapPreview
+          variant={variant}
+          phase={phase}
+          style={{ width: "100%", height: "100%" }}
+        />
+        <span className="absolute bottom-2 right-2 flex size-8 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm transition-opacity group-hover:bg-background">
+          <Expand className="size-4" />
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          aria-describedby={undefined}
+          className="h-[90vh] w-[95vw] max-w-5xl gap-0 overflow-hidden p-0"
+        >
+          <DialogTitle className="sr-only">
+            {variantName ? `${variantName} map` : "Map preview"}
+          </DialogTitle>
+          <div className="relative h-full w-full">
+            <ZoomableMap variant={variant} phase={phase} />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export { ExpandableMapPreview };

--- a/packages/web/src/components/ExpandableMapPreview.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.tsx
@@ -1,9 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Expand, X } from "lucide-react";
-import {
-  TransformWrapper,
-  TransformComponent,
-} from "react-zoom-pan-pinch";
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 import type {
   PhaseRetrieve,
@@ -11,11 +8,11 @@ import type {
   VariantTemplatePhase,
 } from "../api/generated/endpoints";
 import { useDsvg } from "../hooks/useDsvg";
+import { parseDsvg } from "./InteractiveMap/dsvgParser";
 import { DiplicityMap } from "./InteractiveMap/mapRenderer";
 import { toRenderState } from "./InteractiveMap/toRenderState";
 import { MapPreview } from "./MapPreview";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   Dialog,
   DialogClose,
@@ -36,37 +33,68 @@ const ZoomableMap: React.FC<{
   variant: VariantForPreview;
   phase: PhaseRetrieve | VariantTemplatePhase;
 }> = ({ variant, phase }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const { data: dsvg } = useDsvg(variant.svgUrl, true);
 
+  const viewBox = useMemo(() => (dsvg ? parseDsvg(dsvg).viewBox : null), [dsvg]);
   const svg = useMemo(() => {
     if (!dsvg) return null;
     const renderState = toRenderState(variant, phase, [], [], []);
     return new DiplicityMap(dsvg)
       .render(renderState)
-      .replace(
-        "<svg ",
-        '<svg preserveAspectRatio="xMidYMid meet" width="100%" height="100%" '
-      );
+      .replace("<svg ", '<svg width="100%" height="100%" ');
   }, [dsvg, variant, phase]);
 
-  if (!svg) {
-    return <Skeleton className="w-full h-full" />;
-  }
+  const [container, setContainer] = useState<{
+    width: number;
+    height: number;
+  }>();
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setContainer({ width, height });
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const containedScale =
+    container && viewBox
+      ? Math.min(container.width / viewBox.width, container.height / viewBox.height)
+      : 1;
 
   return (
-    <TransformWrapper
-      minScale={1}
-      maxScale={8}
-      centerOnInit
-      doubleClick={{ mode: "zoomIn", step: 0.7 }}
-    >
-      <TransformComponent
-        wrapperStyle={{ width: "100%", height: "100%" }}
-        contentStyle={{ width: "100%", height: "100%" }}
-      >
-        <div className="w-full h-full" dangerouslySetInnerHTML={{ __html: svg }} />
-      </TransformComponent>
-    </TransformWrapper>
+    <div ref={containerRef} className="h-full w-full">
+      {svg && viewBox && container ? (
+        <TransformWrapper
+          key={`${container.width}x${container.height}`}
+          minScale={1}
+          maxScale={8}
+          centerOnInit
+          limitToBounds
+          centerZoomedOut
+          disablePadding
+          doubleClick={{ mode: "zoomIn", step: 0.7 }}
+          panning={{ velocityDisabled: true }}
+          velocityAnimation={{ disabled: true }}
+        >
+          <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>
+            <div
+              style={{
+                width: viewBox.width * containedScale,
+                height: viewBox.height * containedScale,
+              }}
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </TransformComponent>
+        </TransformWrapper>
+      ) : null}
+    </div>
   );
 };
 

--- a/packages/web/src/components/ExpandableMapPreview.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Expand, Minus, Plus, RotateCcw } from "lucide-react";
+import { Expand, X } from "lucide-react";
 import {
   TransformWrapper,
   TransformComponent,
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -60,48 +61,12 @@ const ZoomableMap: React.FC<{
       centerOnInit
       doubleClick={{ mode: "zoomIn", step: 0.7 }}
     >
-      {({ zoomIn, zoomOut, resetTransform }) => (
-        <>
-          <TransformComponent
-            wrapperStyle={{ width: "100%", height: "100%" }}
-            contentStyle={{ width: "100%", height: "100%" }}
-          >
-            <div
-              className="w-full h-full"
-              dangerouslySetInnerHTML={{ __html: svg }}
-            />
-          </TransformComponent>
-          <div className="absolute bottom-4 right-4 flex flex-col gap-2">
-            <Button
-              size="icon"
-              variant="secondary"
-              className="rounded-full shadow-lg"
-              onClick={() => zoomIn()}
-              aria-label="Zoom in"
-            >
-              <Plus />
-            </Button>
-            <Button
-              size="icon"
-              variant="secondary"
-              className="rounded-full shadow-lg"
-              onClick={() => zoomOut()}
-              aria-label="Zoom out"
-            >
-              <Minus />
-            </Button>
-            <Button
-              size="icon"
-              variant="secondary"
-              className="rounded-full shadow-lg"
-              onClick={() => resetTransform()}
-              aria-label="Reset zoom"
-            >
-              <RotateCcw />
-            </Button>
-          </div>
-        </>
-      )}
+      <TransformComponent
+        wrapperStyle={{ width: "100%", height: "100%" }}
+        contentStyle={{ width: "100%", height: "100%" }}
+      >
+        <div className="w-full h-full" dangerouslySetInnerHTML={{ __html: svg }} />
+      </TransformComponent>
     </TransformWrapper>
   );
 };
@@ -136,12 +101,22 @@ const ExpandableMapPreview: React.FC<ExpandableMapPreviewProps> = ({
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
+          showCloseButton={false}
           aria-describedby={undefined}
-          className="h-[90vh] w-[95vw] max-w-5xl gap-0 overflow-hidden p-0"
+          className="h-[100dvh] w-screen max-w-none gap-0 overflow-hidden rounded-none border-0 bg-black/95 p-0"
         >
           <DialogTitle className="sr-only">
             {variantName ? `${variantName} map` : "Map preview"}
           </DialogTitle>
+          <DialogClose asChild>
+            <Button
+              size="icon"
+              aria-label="Close"
+              className="absolute right-4 top-[calc(var(--safe-area-top)+1rem)] z-10 size-10 rounded-full bg-black/60 text-white hover:bg-black/80"
+            >
+              <X className="size-5" />
+            </Button>
+          </DialogClose>
           <div className="relative h-full w-full">
             <ZoomableMap variant={variant} phase={phase} />
           </div>

--- a/packages/web/src/components/ExpandableMapPreview.tsx
+++ b/packages/web/src/components/ExpandableMapPreview.tsx
@@ -23,12 +23,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-type VariantForPreview = Pick<Variant, "nations" | "svgUrl">;
+type VariantForPreview = Pick<Variant, "name" | "nations" | "svgUrl">;
 
 type ExpandableMapPreviewProps = {
   variant: VariantForPreview;
   phase: PhaseRetrieve | VariantTemplatePhase;
-  variantName?: string;
   style?: React.CSSProperties;
   className?: string;
 };
@@ -74,7 +73,6 @@ const ZoomableMap: React.FC<{
 const ExpandableMapPreview: React.FC<ExpandableMapPreviewProps> = ({
   variant,
   phase,
-  variantName,
   style,
   className,
 }) => {
@@ -105,9 +103,7 @@ const ExpandableMapPreview: React.FC<ExpandableMapPreviewProps> = ({
           aria-describedby={undefined}
           className="h-[100dvh] w-screen max-w-none gap-0 overflow-hidden rounded-none border-0 bg-black/95 p-0"
         >
-          <DialogTitle className="sr-only">
-            {variantName ? `${variantName} map` : "Map preview"}
-          </DialogTitle>
+          <DialogTitle className="sr-only">{`${variant.name} map`}</DialogTitle>
           <DialogClose asChild>
             <Button
               size="icon"

--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -222,7 +222,6 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
               <ExpandableMapPreview
                 variant={variant}
                 phase={currentPhase}
-                variantName={variant.name}
                 style={{ width: "100%" }}
               />
             </div>

--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -218,16 +218,16 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
             />
           )}
           {variant && currentPhase ? (
-            <div className="w-full aspect-square overflow-hidden">
+            <div className="w-full overflow-hidden rounded-lg">
               <ExpandableMapPreview
                 variant={variant}
                 phase={currentPhase}
                 variantName={variant.name}
-                style={{ width: "100%", height: "100%" }}
+                style={{ width: "100%" }}
               />
             </div>
           ) : (
-            <Skeleton className="w-full aspect-square rounded-lg" />
+            <Skeleton className="w-full h-64 rounded-lg" />
           )}
         </ScreenCardContent>
       </ScreenCard>

--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -11,7 +11,7 @@ import {
   useVariantsListSuspense,
 } from "@/api/generated/endpoints";
 import { getCurrentPhaseId, formatDateTime, formatTimeAgo } from "@/util";
-import { MapPreview } from "@/components/MapPreview";
+import { ExpandableMapPreview } from "@/components/ExpandableMapPreview";
 import { CardTitle } from "@/components/ui/card";
 import {
   ScreenCard,
@@ -219,9 +219,10 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
           )}
           {variant && currentPhase ? (
             <div className="w-full aspect-square overflow-hidden">
-              <MapPreview
+              <ExpandableMapPreview
                 variant={variant}
                 phase={currentPhase}
+                variantName={variant.name}
                 style={{ width: "100%", height: "100%" }}
               />
             </div>

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -200,7 +200,6 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
         <ExpandableMapPreview
           variant={selectedVariant}
           phase={selectedVariant.templatePhase}
-          variantName={selectedVariant.name}
           style={{ width: "100%", height: "100%" }}
         />
       ) : null}

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -36,7 +36,7 @@ import {
 } from "@/components/ui/form";
 
 import { randomGameName } from "@/util";
-import { MapPreview } from "@/components/MapPreview";
+import { ExpandableMapPreview } from "@/components/ExpandableMapPreview";
 import { DeadlineSummary } from "@/components/DeadlineSummary";
 import {
   DURATION_OPTIONS,
@@ -197,9 +197,10 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
       />
 
       {selectedVariant?.templatePhase ? (
-        <MapPreview
+        <ExpandableMapPreview
           variant={selectedVariant}
           phase={selectedVariant.templatePhase}
+          variantName={selectedVariant.name}
           style={{ width: "100%", height: "100%" }}
         />
       ) : null}


### PR DESCRIPTION
## Summary

Closes #732.

Makes the variant map previews — shown both **during game creation** and on the **game info screen** (reached when browsing a game to join) — expandable. Tapping a preview opens a **dark, full-screen image viewer** (Reddit-style) where you can pinch, double-tap, scroll to zoom and drag to pan around the map. This makes it easy to study a variant's board in detail before deciding to create or join a game.

## Changes

- **`components/ui/dialog.tsx`** — adds the shadcn Dialog primitive (the repo only had `alert-dialog` and `sheet`; `@radix-ui/react-dialog` was already a dependency).
- **`components/ExpandableMapPreview.tsx`** — wraps the existing static `MapPreview` with an expand affordance overlaid on the map's bottom-right, and renders a full-screen zoomable/pannable map on a dark backdrop using `react-zoom-pan-pinch` (the same lib the in-game map uses). The only chrome is a single padded, dark, circular close button (positioned clear of the device notch via the existing `--safe-area-top` var).
- **`screens/Home/CreateGame.tsx`** and **`components/GameInfoContent.tsx`** — use `ExpandableMapPreview` (the two non-gameplay map preview sites). Game Info renders the preview at the map's natural aspect ratio so the expand affordance overlays the map consistently with Create Game.
- **`ExpandableMapPreview.test.tsx`** — verifies the expand control renders, no dialog shows initially, and clicking opens the zoomable dialog with only a close button.
- **`RELEASE_NOTES.md`** — user-facing entry.

## Verification

- `npx tsc -b --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run ExpandableMapPreview.test.tsx` — 2 passing

## Screenshots

Collapsed preview on the game info screen — the expand control overlays the bottom-right of the map:

![collapsed preview](https://raw.githubusercontent.com/johnpooch/diplicity-react/854adf19a5ee0465ebbd28d64095eb55967b26ed/shots/refined-collapsed.png)

Expanded dark, full-screen viewer (single close button, no zoom-control chrome):

![dark viewer](https://raw.githubusercontent.com/johnpooch/diplicity-react/854adf19a5ee0465ebbd28d64095eb55967b26ed/shots/refined-dialog.png)

https://claude.ai/code/session_017ye4rpWutRFEhMWaDX3Mce