### PR TITLE
Multi-step create game form

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Diplicity React - Release Notes
 
+## Multi-Step Create Game Form (June 2026)
+
+### Improvement: Creating a game is split into clear steps
+
+The create game form is now organised into steps with a progress indicator at the top.
+The first "General" step covers the game name, mode, privacy options and variant selection
+(with the map preview), while the "Deadlines" step gathers the phase timing and advanced
+settings. This makes the form feel less dense — particularly the deadline options — and
+leaves room for more settings in the future. Sandbox games remain a single step.
+
 ## Unread Message Indicator on Game Cards (June 2026)
 
 ### Feature: See unread message counts without opening a game

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,12 @@
 
 ### Improvement: Creating a game is split into clear steps
 
-The create game form is now organised into steps with a progress indicator at the top.
-The first "General" step covers the game name, mode, privacy options and variant selection
-(with the map preview), while the "Deadlines" step gathers the phase timing and advanced
-settings. This makes the form feel less dense — particularly the deadline options — and
-leaves room for more settings in the future. Sandbox games remain a single step.
+The create game form is now organised into three steps with a progress indicator at the
+top: "General" (game name, mode, privacy options and variant selection with the map
+preview), "Deadlines" (phase timing), and "Advanced" (automatic extensions). This makes the
+form feel less dense — particularly the deadline options — and leaves room for more settings
+in the future. Sandbox is now a choice in the Mode dropdown (rather than a separate tab);
+selecting it turns the General step into a single-step "Create Game" flow.
 
 ## Unread Message Indicator on Game Cards (June 2026)
 

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .idea

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -10,7 +10,8 @@ class ResizeObserverMock {
   disconnect() {}
 }
 globalThis.ResizeObserver =
-  globalThis.ResizeObserver ?? (ResizeObserverMock as unknown as typeof ResizeObserver);
+  globalThis.ResizeObserver ??
+  (ResizeObserverMock as unknown as typeof ResizeObserver);
 
 if (!window.matchMedia) {
   window.matchMedia = (query: string) =>
@@ -56,9 +57,8 @@ vi.mock("react-router", async importOriginal => {
 });
 
 vi.mock("@/api/generated/endpoints", async importOriginal => {
-  const actual = await importOriginal<
-    typeof import("@/api/generated/endpoints")
-  >();
+  const actual =
+    await importOriginal<typeof import("@/api/generated/endpoints")>();
   return {
     ...actual,
     useVariantsListSuspense: vi.fn(),
@@ -238,7 +238,16 @@ describe("CreateGame — find-similar intervention", () => {
     } as unknown as ReturnType<typeof useSandboxGameCreate>);
   });
 
-  const switchToDurationMode = async (user: ReturnType<typeof userEvent.setup>) => {
+  const goToDeadlinesStep = async (
+    user: ReturnType<typeof userEvent.setup>
+  ) => {
+    await user.click(screen.getByRole("button", { name: /next/i }));
+  };
+
+  const switchToDurationMode = async (
+    user: ReturnType<typeof userEvent.setup>
+  ) => {
+    await goToDeadlinesStep(user);
     await user.click(screen.getByRole("tab", { name: /duration/i }));
   };
 
@@ -250,6 +259,7 @@ describe("CreateGame — find-similar intervention", () => {
     const user = userEvent.setup();
     const findSimilarFn = stubFindSimilar(null);
     renderCreateGame();
+    await goToDeadlinesStep(user);
     await submit(user);
 
     await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
@@ -262,8 +272,8 @@ describe("CreateGame — find-similar intervention", () => {
     const user = userEvent.setup();
     const findSimilarFn = stubFindSimilar(null);
     renderCreateGame();
-    await switchToDurationMode(user);
     await user.click(screen.getByRole("checkbox", { name: /private/i }));
+    await switchToDurationMode(user);
     await submit(user);
 
     await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
@@ -352,19 +362,24 @@ describe("CreateGame — game master option", () => {
   });
 
   const submit = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole("button", { name: /next/i }));
     await user.click(screen.getByRole("button", { name: /create game/i }));
   };
 
   it("disables the game master checkbox when the game is not private", () => {
     renderCreateGame();
-    expect(screen.getByRole("checkbox", { name: /game master/i })).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: /game master/i })
+    ).toBeDisabled();
   });
 
   it("enables the game master checkbox when the game is private", async () => {
     const user = userEvent.setup();
     renderCreateGame();
     await user.click(screen.getByRole("checkbox", { name: /private/i }));
-    expect(screen.getByRole("checkbox", { name: /game master/i })).toBeEnabled();
+    expect(
+      screen.getByRole("checkbox", { name: /game master/i })
+    ).toBeEnabled();
   });
 
   it("submits gameMaster false by default", async () => {
@@ -405,5 +420,61 @@ describe("CreateGame — game master option", () => {
     await submit(user);
     await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
     expect(createGameMutateAsync.mock.calls[0][0].data.gameMaster).toBe(false);
+  });
+});
+
+describe("CreateGame — multi-step navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsFixture,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+
+    mockedUseGameCreate.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({ id: "created-game" }),
+      isPending: false,
+    } as unknown as ReturnType<typeof useGameCreate>);
+
+    mockedUseSandboxGameCreate.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useSandboxGameCreate>);
+  });
+
+  it("starts on the General step with no Create Game button", () => {
+    renderCreateGame();
+
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create game/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: /duration/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("advances to the Deadlines step and back", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByRole("tab", { name: /duration/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /create game/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: /private/i })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(
+      screen.getByRole("checkbox", { name: /private/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create game/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -252,6 +252,7 @@ describe("CreateGame — find-similar intervention", () => {
   };
 
   const submit = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole("button", { name: /next/i }));
     await user.click(screen.getByRole("button", { name: /create game/i }));
   };
 
@@ -363,6 +364,7 @@ describe("CreateGame — game master option", () => {
 
   const submit = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
     await user.click(screen.getByRole("button", { name: /create game/i }));
   };
 
@@ -454,7 +456,7 @@ describe("CreateGame — multi-step navigation", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("advances to the Deadlines step and back", async () => {
+  it("advances General → Deadlines → Advanced, then back", async () => {
     const user = userEvent.setup();
     renderCreateGame();
 
@@ -462,19 +464,109 @@ describe("CreateGame — multi-step navigation", () => {
 
     expect(screen.getByRole("tab", { name: /duration/i })).toBeInTheDocument();
     expect(
+      screen.queryByRole("checkbox", { name: /private/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create game/i })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByText("Automatic Extensions")).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /create game/i })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("checkbox", { name: /private/i })
+      screen.queryByRole("tab", { name: /duration/i })
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /back/i }));
 
-    expect(
-      screen.getByRole("checkbox", { name: /private/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /duration/i })).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /create game/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("CreateGame — sandbox mode", () => {
+  let sandboxMutateAsync: ReturnType<typeof vi.fn>;
+  let createGameMutateAsync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sandboxMutateAsync = vi.fn().mockResolvedValue({ id: "sandbox-game" });
+    createGameMutateAsync = vi.fn().mockResolvedValue({ id: "created-game" });
+
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsFixture,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+
+    mockedUseGameCreate.mockReturnValue({
+      mutateAsync: createGameMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useGameCreate>);
+
+    mockedUseSandboxGameCreate.mockReturnValue({
+      mutateAsync: sandboxMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useSandboxGameCreate>);
+  });
+
+  const selectSandboxMode = async (
+    user: ReturnType<typeof userEvent.setup>
+  ) => {
+    await user.click(screen.getByRole("combobox", { name: /mode/i }));
+    await user.click(screen.getByRole("option", { name: /sandbox/i }));
+  };
+
+  it("disables and unchecks private and game master when sandbox is selected", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await user.click(screen.getByRole("checkbox", { name: /private/i }));
+    expect(screen.getByRole("checkbox", { name: /private/i })).toBeChecked();
+
+    await selectSandboxMode(user);
+
+    const privateCheckbox = screen.getByRole("checkbox", { name: /private/i });
+    const gameMasterCheckbox = screen.getByRole("checkbox", {
+      name: /game master/i,
+    });
+    expect(privateCheckbox).toBeDisabled();
+    expect(privateCheckbox).not.toBeChecked();
+    expect(gameMasterCheckbox).toBeDisabled();
+    expect(gameMasterCheckbox).not.toBeChecked();
+  });
+
+  it("shows a Create Game button on the General step (no Next) in sandbox mode", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await selectSandboxMode(user);
+
+    expect(
+      screen.getByRole("button", { name: /create game/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /next/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("creates a sandbox game and navigates to it", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await selectSandboxMode(user);
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(sandboxMutateAsync).toHaveBeenCalled());
+    const payload = sandboxMutateAsync.mock.calls[0][0].data;
+    expect(payload).toEqual({
+      name: expect.any(String),
+      variantId: "classical",
+    });
+    expect(createGameMutateAsync).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/game/sandbox-game");
   });
 });

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState, useEffect } from "react";
+import React, { Suspense, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -19,7 +19,6 @@ import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CardDescription } from "@/components/ui/card";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
@@ -79,13 +78,13 @@ import {
 import { useCheckNotificationPermission } from "@/hooks/useCheckNotificationPermission";
 import { CREATE_GAME_PARAM } from "@/utils/routes";
 
-const standardGameSchema = z.object({
+const gameSchema = z.object({
   name: z
     .string()
     .min(1, "Game name is required")
     .max(100, "Game name must be less than 100 characters"),
   variantId: z.string().min(1, "Please select a variant"),
-  mode: z.enum(["standard", "gunboat"] as const),
+  mode: z.enum(["standard", "gunboat", "sandbox"] as const),
   nationAssignment: z.enum(["random", "ordered"] as const),
   private: z.boolean(),
   gameMaster: z.boolean(),
@@ -105,20 +104,10 @@ const standardGameSchema = z.object({
   nmrExtensionsAllowed: z.enum(["0", "1", "2"] as const),
 });
 
-const sandboxGameSchema = z.object({
-  sandboxGame: z.object({
-    name: z
-      .string()
-      .min(1, "Game name is required")
-      .max(100, "Game name must be less than 100 characters"),
-    variantId: z.string().min(1, "Please select a variant"),
-  }),
-});
+type GameFormValues = z.infer<typeof gameSchema>;
+type GameMode = GameFormValues["mode"];
 
-type StandardGameFormValues = z.infer<typeof standardGameSchema>;
-type SandboxGameFormValues = z.infer<typeof sandboxGameSchema>;
-
-const modeToBackendFields = (mode: StandardGameFormValues["mode"]) =>
+const modeToBackendFields = (mode: "standard" | "gunboat") =>
   ({
     anonymous: mode === "gunboat",
     pressType: mode === "gunboat" ? "no_press" : "full_press",
@@ -267,9 +256,9 @@ function getBrowserTimezone(): string {
   return validTimezones.includes(tz) ? tz : "America/New_York";
 }
 
-const STANDARD_STEPS = ["General", "Deadlines"] as const;
+const STEPS = ["General", "Deadlines", "Advanced"] as const;
 
-const STEP_FIELDS: Record<number, (keyof StandardGameFormValues)[]> = {
+const STEP_FIELDS: Record<number, (keyof GameFormValues)[]> = {
   0: ["name", "variantId", "mode", "private", "gameMaster"],
   1: [
     "deadlineMode",
@@ -279,77 +268,94 @@ const STEP_FIELDS: Record<number, (keyof StandardGameFormValues)[]> = {
     "fixedDeadlineTimezone",
     "movementFrequency",
     "retreatFrequency",
-    "nmrExtensionsAllowed",
   ],
+  2: ["nmrExtensionsAllowed"],
 };
 
+interface StepperStep {
+  label: string;
+  disabled?: boolean;
+}
+
 interface StepperProps {
-  steps: readonly string[];
+  steps: readonly StepperStep[];
   currentStep: number;
 }
 
 const Stepper: React.FC<StepperProps> = ({ steps, currentStep }) => (
   <div className="flex items-center">
-    {steps.map((label, index) => (
-      <React.Fragment key={label}>
-        <div className="flex items-center gap-2">
+    {steps.map((step, index) => {
+      const isComplete = !step.disabled && index < currentStep;
+      const isCurrent = !step.disabled && index === currentStep;
+      return (
+        <React.Fragment key={step.label}>
           <div
             className={cn(
-              "flex size-7 items-center justify-center rounded-full border text-sm font-medium",
-              index < currentStep &&
-                "border-primary bg-primary text-primary-foreground",
-              index === currentStep && "border-primary text-primary",
-              index > currentStep &&
-                "border-muted-foreground/30 text-muted-foreground"
+              "flex items-center gap-2",
+              step.disabled && "opacity-50"
             )}
           >
-            {index < currentStep ? <Check className="size-4" /> : index + 1}
+            <div
+              className={cn(
+                "flex size-7 items-center justify-center rounded-full border text-sm font-medium",
+                isComplete &&
+                  "border-primary bg-primary text-primary-foreground",
+                isCurrent && "border-primary text-primary",
+                !isComplete &&
+                  !isCurrent &&
+                  "border-muted-foreground/30 text-muted-foreground"
+              )}
+            >
+              {isComplete ? <Check className="size-4" /> : index + 1}
+            </div>
+            <span
+              className={cn(
+                "text-sm font-medium",
+                isCurrent ? "text-foreground" : "text-muted-foreground"
+              )}
+            >
+              {step.label}
+            </span>
           </div>
-          <span
-            className={cn(
-              "text-sm font-medium",
-              index === currentStep
-                ? "text-foreground"
-                : "text-muted-foreground"
-            )}
-          >
-            {label}
-          </span>
-        </div>
-        {index < steps.length - 1 && (
-          <div
-            className={cn(
-              "mx-3 h-px flex-1",
-              index < currentStep ? "bg-primary" : "bg-border"
-            )}
-          />
-        )}
-      </React.Fragment>
-    ))}
+          {index < steps.length - 1 && (
+            <div
+              className={cn(
+                "mx-3 h-px flex-1",
+                index < currentStep ? "bg-primary" : "bg-border"
+              )}
+            />
+          )}
+        </React.Fragment>
+      );
+    })}
   </div>
 );
 
-interface CreateStandardGameFormProps {
-  onSubmit: (data: StandardGameFormValues) => Promise<void>;
+interface CreateGameFormProps {
+  onStandardSubmit: (data: GameFormValues) => Promise<void>;
+  onSandboxSubmit: (data: GameFormValues) => Promise<void>;
   isSubmitting: boolean;
   variants: Variant[];
   initialVariantId?: string;
   initialPrivate?: boolean;
+  initialMode?: GameMode;
 }
 
-const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
-  onSubmit,
+const CreateGameForm: React.FC<CreateGameFormProps> = ({
+  onStandardSubmit,
+  onSandboxSubmit,
   isSubmitting,
   variants,
   initialVariantId,
   initialPrivate,
+  initialMode,
 }) => {
-  const form = useForm<StandardGameFormValues>({
-    resolver: zodResolver(standardGameSchema),
+  const form = useForm<GameFormValues>({
+    resolver: zodResolver(gameSchema),
     defaultValues: {
       name: randomGameName(),
       variantId: initialVariantId ?? variants[0]?.id ?? "",
-      mode: "standard",
+      mode: initialMode ?? "standard",
       nationAssignment: "random" as NationAssignmentEnum,
       private: initialPrivate ?? false,
       gameMaster: false,
@@ -365,14 +371,20 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
   });
 
   const [step, setStep] = useState(0);
-  const lastStep = STANDARD_STEPS.length - 1;
 
   const selectedVariant = variants?.find(v => v.id === form.watch("variantId"));
   const deadlineMode = form.watch("deadlineMode");
   const isPrivate = form.watch("private");
+  const isSandbox = form.watch("mode") === "sandbox";
+  const lastStep = isSandbox ? 0 : STEPS.length - 1;
   const isInitialVariantDraft =
     initialVariantId !== undefined &&
     variants.find(v => v.id === initialVariantId)?.status === "draft";
+
+  const stepperSteps: StepperStep[] = STEPS.map((label, index) => ({
+    label,
+    disabled: isSandbox && index > 0,
+  }));
 
   const handleNext = async () => {
     const valid = await form.trigger(STEP_FIELDS[step]);
@@ -388,13 +400,17 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
       await handleNext();
       return;
     }
-    await onSubmit(data);
+    if (data.mode === "sandbox") {
+      await onSandboxSubmit(data);
+    } else {
+      await onStandardSubmit(data);
+    }
   });
 
   return (
     <Form {...form}>
       <form onSubmit={handleFormSubmit} className="space-y-6">
-        <Stepper steps={STANDARD_STEPS} currentStep={step} />
+        <Stepper steps={stepperSteps} currentStep={step} />
 
         {step === 0 && (
           <div className="space-y-4">
@@ -407,7 +423,13 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                 <FormItem>
                   <FormLabel>Mode</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
+                    onValueChange={value => {
+                      field.onChange(value);
+                      if (value === "sandbox") {
+                        form.setValue("private", false);
+                        form.setValue("gameMaster", false);
+                      }
+                    }}
                     value={field.value}
                     disabled={isSubmitting}
                   >
@@ -419,12 +441,15 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                     <SelectContent>
                       <SelectItem value="standard">Standard</SelectItem>
                       <SelectItem value="gunboat">Gunboat</SelectItem>
+                      <SelectItem value="sandbox">Sandbox</SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>
-                    {field.value === "gunboat"
-                      ? "Player names are anonymized and messaging is disabled"
-                      : "Standard play"}
+                    {field.value === "gunboat" &&
+                      "Player names are anonymized and messaging is disabled"}
+                    {field.value === "sandbox" &&
+                      "Practice by controlling all nations. No time limits—resolve when ready."}
+                    {field.value === "standard" && "Standard play"}
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -459,7 +484,9 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                           form.setValue("gameMaster", false);
                         }
                       }}
-                      disabled={isSubmitting || isInitialVariantDraft}
+                      disabled={
+                        isSubmitting || isInitialVariantDraft || isSandbox
+                      }
                     />
                   </FormControl>
                   <div className="space-y-1 leading-none">
@@ -482,7 +509,7 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
                     <Checkbox
                       checked={field.value}
                       onCheckedChange={field.onChange}
-                      disabled={isSubmitting || !isPrivate}
+                      disabled={isSubmitting || !isPrivate || isSandbox}
                     />
                   </FormControl>
                   <div className="space-y-1 leading-none">
@@ -510,286 +537,279 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
         )}
 
         {step === 1 && (
-          <div className="space-y-6">
-            <div className="space-y-4">
-              <h2 className="text-lg font-semibold">Deadlines</h2>
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">Deadlines</h2>
 
-              <FormField
-                control={form.control}
-                name="deadlineMode"
-                render={({ field }) => (
-                  <FormItem>
-                    <Tabs
-                      value={field.value}
-                      onValueChange={field.onChange}
-                      className="w-full"
-                    >
-                      <TabsList className="w-full">
-                        <TabsTrigger value="fixed_time" className="flex-1">
-                          Fixed Time
-                        </TabsTrigger>
-                        <TabsTrigger value="duration" className="flex-1">
-                          Duration
-                        </TabsTrigger>
-                      </TabsList>
+            <FormField
+              control={form.control}
+              name="deadlineMode"
+              render={({ field }) => (
+                <FormItem>
+                  <Tabs
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    className="w-full"
+                  >
+                    <TabsList className="w-full">
+                      <TabsTrigger value="fixed_time" className="flex-1">
+                        Fixed Time
+                      </TabsTrigger>
+                      <TabsTrigger value="duration" className="flex-1">
+                        Duration
+                      </TabsTrigger>
+                    </TabsList>
 
-                      <TabsContent value="duration" className="space-y-4 pt-4">
-                        <div className="grid w-full grid-cols-2 gap-4">
-                          <FormField
-                            control={form.control}
-                            name="movementPhaseDuration"
-                            render={({ field: durationField }) => (
-                              <FormItem>
-                                <FormLabel>Movement</FormLabel>
-                                <Select
-                                  onValueChange={durationField.onChange}
-                                  value={durationField.value}
-                                  disabled={isSubmitting}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {DURATION_OPTIONS.map(option => (
-                                      <SelectItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="retreatPhaseDuration"
-                            render={({ field: retreatField }) => (
-                              <FormItem>
-                                <FormLabel>Retreat/Adjustment</FormLabel>
-                                <Select
-                                  onValueChange={retreatField.onChange}
-                                  value={retreatField.value ?? undefined}
-                                  disabled={isSubmitting}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                      <SelectValue placeholder="Same as movement" />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {DURATION_OPTIONS.map(option => (
-                                      <SelectItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent
-                        value="fixed_time"
-                        className="space-y-4 pt-4"
-                      >
-                        <div className="grid w-full grid-cols-2 gap-4">
-                          <FormField
-                            control={form.control}
-                            name="fixedDeadlineTime"
-                            render={({ field: timeField }) => (
-                              <FormItem>
-                                <FormLabel>Time</FormLabel>
+                    <TabsContent value="duration" className="space-y-4 pt-4">
+                      <div className="grid w-full grid-cols-2 gap-4">
+                        <FormField
+                          control={form.control}
+                          name="movementPhaseDuration"
+                          render={({ field: durationField }) => (
+                            <FormItem>
+                              <FormLabel>Movement</FormLabel>
+                              <Select
+                                onValueChange={durationField.onChange}
+                                value={durationField.value}
+                                disabled={isSubmitting}
+                              >
                                 <FormControl>
-                                  <Input
-                                    type="time"
-                                    className="appearance-none"
-                                    value={timeField.value ?? ""}
-                                    onChange={timeField.onChange}
-                                    disabled={isSubmitting}
-                                  />
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue />
+                                  </SelectTrigger>
                                 </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
+                                <SelectContent>
+                                  {DURATION_OPTIONS.map(option => (
+                                    <SelectItem
+                                      key={option.value}
+                                      value={option.value}
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
-                          <FormField
-                            control={form.control}
-                            name="fixedDeadlineTimezone"
-                            render={({ field: tzField }) => (
-                              <FormItem>
-                                <FormLabel>Timezone</FormLabel>
-                                <Select
-                                  onValueChange={tzField.onChange}
-                                  value={tzField.value ?? undefined}
+                        <FormField
+                          control={form.control}
+                          name="retreatPhaseDuration"
+                          render={({ field: retreatField }) => (
+                            <FormItem>
+                              <FormLabel>Retreat/Adjustment</FormLabel>
+                              <Select
+                                onValueChange={retreatField.onChange}
+                                value={retreatField.value ?? undefined}
+                                disabled={isSubmitting}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                                    <SelectValue placeholder="Same as movement" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {DURATION_OPTIONS.map(option => (
+                                    <SelectItem
+                                      key={option.value}
+                                      value={option.value}
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+                    </TabsContent>
+
+                    <TabsContent value="fixed_time" className="space-y-4 pt-4">
+                      <div className="grid w-full grid-cols-2 gap-4">
+                        <FormField
+                          control={form.control}
+                          name="fixedDeadlineTime"
+                          render={({ field: timeField }) => (
+                            <FormItem>
+                              <FormLabel>Time</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="time"
+                                  className="appearance-none"
+                                  value={timeField.value ?? ""}
+                                  onChange={timeField.onChange}
                                   disabled={isSubmitting}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full">
-                                      <SelectValue placeholder="Select" />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {TIMEZONE_OPTIONS.map(option => (
-                                      <SelectItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </div>
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
-                        <div className="grid w-full grid-cols-2 gap-4">
-                          <FormField
-                            control={form.control}
-                            name="movementFrequency"
-                            render={({ field: freqField }) => (
-                              <FormItem>
-                                <FormLabel>Movement</FormLabel>
-                                <Select
-                                  onValueChange={freqField.onChange}
-                                  value={freqField.value ?? undefined}
-                                  disabled={isSubmitting}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {FREQUENCY_OPTIONS.map(option => (
-                                      <SelectItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
+                        <FormField
+                          control={form.control}
+                          name="fixedDeadlineTimezone"
+                          render={({ field: tzField }) => (
+                            <FormItem>
+                              <FormLabel>Timezone</FormLabel>
+                              <Select
+                                onValueChange={tzField.onChange}
+                                value={tzField.value ?? undefined}
+                                disabled={isSubmitting}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Select" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {TIMEZONE_OPTIONS.map(option => (
+                                    <SelectItem
+                                      key={option.value}
+                                      value={option.value}
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
 
-                          <FormField
-                            control={form.control}
-                            name="retreatFrequency"
-                            render={({ field: retreatFreqField }) => (
-                              <FormItem>
-                                <FormLabel>Retreat/Adjustment</FormLabel>
-                                <Select
-                                  onValueChange={retreatFreqField.onChange}
-                                  value={retreatFreqField.value ?? undefined}
-                                  disabled={isSubmitting}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                      <SelectValue placeholder="Same as movement" />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {FREQUENCY_OPTIONS.map(option => (
-                                      <SelectItem
-                                        key={option.value}
-                                        value={option.value}
-                                      >
-                                        {option.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </div>
-                      </TabsContent>
-                    </Tabs>
-                  </FormItem>
-                )}
-              />
+                      <div className="grid w-full grid-cols-2 gap-4">
+                        <FormField
+                          control={form.control}
+                          name="movementFrequency"
+                          render={({ field: freqField }) => (
+                            <FormItem>
+                              <FormLabel>Movement</FormLabel>
+                              <Select
+                                onValueChange={freqField.onChange}
+                                value={freqField.value ?? undefined}
+                                disabled={isSubmitting}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {FREQUENCY_OPTIONS.map(option => (
+                                    <SelectItem
+                                      key={option.value}
+                                      value={option.value}
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
-              <Alert className="mt-4">
-                <Clock className="h-4 w-4" />
-                <AlertDescription>
-                  <DeadlineSummary
-                    game={{
-                      movementPhaseDuration:
-                        form.watch("movementPhaseDuration") ?? null,
-                      retreatPhaseDuration:
-                        form.watch("retreatPhaseDuration") ?? null,
-                      deadlineMode,
-                      fixedDeadlineTime:
-                        form.watch("fixedDeadlineTime") ?? null,
-                      fixedDeadlineTimezone:
-                        form.watch("fixedDeadlineTimezone") ?? null,
-                      movementFrequency:
-                        form.watch("movementFrequency") ?? null,
-                      retreatFrequency: form.watch("retreatFrequency") ?? null,
-                    }}
-                  />
-                </AlertDescription>
-              </Alert>
-            </div>
+                        <FormField
+                          control={form.control}
+                          name="retreatFrequency"
+                          render={({ field: retreatFreqField }) => (
+                            <FormItem>
+                              <FormLabel>Retreat/Adjustment</FormLabel>
+                              <Select
+                                onValueChange={retreatFreqField.onChange}
+                                value={retreatFreqField.value ?? undefined}
+                                disabled={isSubmitting}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                                    <SelectValue placeholder="Same as movement" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {FREQUENCY_OPTIONS.map(option => (
+                                    <SelectItem
+                                      key={option.value}
+                                      value={option.value}
+                                    >
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </div>
+                    </TabsContent>
+                  </Tabs>
+                </FormItem>
+              )}
+            />
 
-            <hr className="border-t" />
+            <Alert className="mt-4">
+              <Clock className="h-4 w-4" />
+              <AlertDescription>
+                <DeadlineSummary
+                  game={{
+                    movementPhaseDuration:
+                      form.watch("movementPhaseDuration") ?? null,
+                    retreatPhaseDuration:
+                      form.watch("retreatPhaseDuration") ?? null,
+                    deadlineMode,
+                    fixedDeadlineTime: form.watch("fixedDeadlineTime") ?? null,
+                    fixedDeadlineTimezone:
+                      form.watch("fixedDeadlineTimezone") ?? null,
+                    movementFrequency: form.watch("movementFrequency") ?? null,
+                    retreatFrequency: form.watch("retreatFrequency") ?? null,
+                  }}
+                />
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
 
-            <div className="space-y-4">
-              <h2 className="text-lg font-semibold">Advanced</h2>
+        {step === 2 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">Advanced</h2>
 
-              <FormField
-                control={form.control}
-                name="nmrExtensionsAllowed"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Automatic Extensions</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value}
-                      disabled={isSubmitting}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {NMR_EXTENSION_OPTIONS.map(option => (
-                          <SelectItem key={option.value} value={option.value}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormDescription>
-                      Automatic extensions when players miss the deadline
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            <FormField
+              control={form.control}
+              name="nmrExtensionsAllowed"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Automatic Extensions</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isSubmitting}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {NMR_EXTENSION_OPTIONS.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Automatic extensions when players miss the deadline
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </div>
         )}
 
@@ -833,79 +853,6 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
   );
 };
 
-interface CreateSandboxGameFormProps {
-  onSubmit: (data: SandboxGameFormValues) => Promise<void>;
-  isSubmitting: boolean;
-  variants: Variant[];
-}
-
-const CreateSandboxGameForm: React.FC<CreateSandboxGameFormProps> = ({
-  onSubmit,
-  isSubmitting,
-  variants,
-}) => {
-  const form = useForm<SandboxGameFormValues>({
-    resolver: zodResolver(sandboxGameSchema),
-    defaultValues: {
-      sandboxGame: {
-        name: randomGameName(),
-        variantId: variants[0]?.id ?? "",
-      },
-    },
-  });
-
-  const selectedVariant = variants?.find(
-    v => v.id === form.watch("sandboxGame.variantId")
-  ) as Variant;
-
-  return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <CardDescription>
-          Practice by controlling all nations. No time limits—resolve when
-          ready.
-        </CardDescription>
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">General</h2>
-
-          <FormField
-            control={form.control}
-            name="sandboxGame.name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Game Name</FormLabel>
-                <FormControl>
-                  <Input {...field} disabled={isSubmitting} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <hr className="border-t" />
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Variant</h2>
-
-          <VariantSelector
-            control={form.control}
-            name="sandboxGame.variantId"
-            disabled={isSubmitting}
-            variants={variants}
-            selectedVariant={selectedVariant}
-          />
-        </div>
-
-        <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting ? "Creating..." : "Create Sandbox Game"}
-        </Button>
-      </form>
-    </Form>
-  );
-};
-
 const CreateGame: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -919,6 +866,8 @@ const CreateGame: React.FC = () => {
   const initialVariantId =
     searchParams.get(CREATE_GAME_PARAM.variantId) ?? undefined;
   const initialPrivate = searchParams.get(CREATE_GAME_PARAM.private) === "true";
+  const initialMode: GameMode =
+    searchParams.get("sandbox") === "true" ? "sandbox" : "standard";
 
   const initialVariant = React.useMemo(
     () =>
@@ -941,37 +890,11 @@ const CreateGame: React.FC = () => {
   const checkNotificationPermission = useCheckNotificationPermission();
 
   const [similarMatch, setSimilarMatch] = useState<GameList | null>(null);
-  const [pendingFormData, setPendingFormData] =
-    useState<StandardGameFormValues | null>(null);
-
-  const getInitialTab = (): "standard" | "sandbox" => {
-    return searchParams.get("sandbox") === "true" ? "sandbox" : "standard";
-  };
-
-  const [currentTab, setCurrentTab] = useState<"standard" | "sandbox">(
-    getInitialTab()
+  const [pendingFormData, setPendingFormData] = useState<GameFormValues | null>(
+    null
   );
 
-  useEffect(() => {
-    const newTab = getInitialTab();
-    setCurrentTab(newTab);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
-
-  const handleTabChange = (value: string) => {
-    const newTab = value as "standard" | "sandbox";
-    setCurrentTab(newTab);
-
-    const newSearchParams = new URLSearchParams(searchParams);
-    if (newTab === "sandbox") {
-      newSearchParams.set("sandbox", "true");
-    } else {
-      newSearchParams.delete("sandbox");
-    }
-    navigate(`?${newSearchParams.toString()}`, { replace: true });
-  };
-
-  const submitCreateGame = async (data: StandardGameFormValues) => {
+  const submitCreateGame = async (data: GameFormValues) => {
     try {
       const formattedTime = data.fixedDeadlineTime
         ? `${data.fixedDeadlineTime}:00`
@@ -984,7 +907,9 @@ const CreateGame: React.FC = () => {
           nationAssignment: data.nationAssignment,
           private: data.private,
           gameMaster: data.gameMaster,
-          ...modeToBackendFields(data.mode),
+          ...modeToBackendFields(
+            data.mode === "gunboat" ? "gunboat" : "standard"
+          ),
           deadlineMode: data.deadlineMode,
           movementPhaseDuration:
             data.deadlineMode === "duration"
@@ -1015,7 +940,7 @@ const CreateGame: React.FC = () => {
     }
   };
 
-  const handleStandardGameSubmit = async (data: StandardGameFormValues) => {
+  const handleStandardGameSubmit = async (data: GameFormValues) => {
     const skipSimilarCheck =
       data.private ||
       data.deadlineMode !== "duration" ||
@@ -1059,10 +984,10 @@ const CreateGame: React.FC = () => {
     setPendingFormData(null);
   };
 
-  const handleSandboxGameSubmit = async (data: SandboxGameFormValues) => {
+  const handleSandboxGameSubmit = async (data: GameFormValues) => {
     try {
       const game = await createSandboxGameMutation.mutateAsync({
-        data: data.sandboxGame,
+        data: { name: data.name, variantId: data.variantId },
       });
       toast.success("Sandbox game created successfully");
       navigate(`/game/${game.id}`);
@@ -1077,42 +1002,22 @@ const CreateGame: React.FC = () => {
 
   return (
     <div className="space-y-4">
-      <Tabs value={currentTab} onValueChange={handleTabChange}>
-        <TabsList className="w-full">
-          <TabsTrigger value="standard" className="flex-1">
-            Standard
-          </TabsTrigger>
-          <TabsTrigger value="sandbox" className="flex-1">
-            Sandbox
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="standard">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateStandardGameForm
-                onSubmit={handleStandardGameSubmit}
-                isSubmitting={createGameMutation.isPending}
-                variants={variants}
-                initialVariantId={initialVariantId}
-                initialPrivate={initialPrivate}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-
-        <TabsContent value="sandbox">
-          <ScreenCard>
-            <ScreenCardContent>
-              <CreateSandboxGameForm
-                onSubmit={handleSandboxGameSubmit}
-                isSubmitting={createSandboxGameMutation.isPending}
-                variants={variants}
-              />
-            </ScreenCardContent>
-          </ScreenCard>
-        </TabsContent>
-      </Tabs>
+      <ScreenCard>
+        <ScreenCardContent>
+          <CreateGameForm
+            onStandardSubmit={handleStandardGameSubmit}
+            onSandboxSubmit={handleSandboxGameSubmit}
+            isSubmitting={
+              createGameMutation.isPending ||
+              createSandboxGameMutation.isPending
+            }
+            variants={variants}
+            initialVariantId={initialVariantId}
+            initialPrivate={initialPrivate}
+            initialMode={initialMode}
+          />
+        </ScreenCardContent>
+      </ScreenCard>
 
       <AlertDialog
         open={similarMatch !== null}
@@ -1172,4 +1077,4 @@ const CreateGameSuspense: React.FC = () => {
 };
 
 export { CreateGameSuspense as CreateGame, modeToBackendFields };
-export type { CreateStandardGameFormProps, CreateSandboxGameFormProps };
+export type { CreateGameFormProps };

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -3,7 +3,17 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { BookOpen, Calendar, Clock, Map, User, Users } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Calendar,
+  Check,
+  Clock,
+  Map,
+  User,
+  Users,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -35,6 +45,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 
+import { cn } from "@/lib/utils";
 import { randomGameName } from "@/util";
 import { MapPreview } from "@/components/MapPreview";
 import { DeadlineSummary } from "@/components/DeadlineSummary";
@@ -107,10 +118,11 @@ const sandboxGameSchema = z.object({
 type StandardGameFormValues = z.infer<typeof standardGameSchema>;
 type SandboxGameFormValues = z.infer<typeof sandboxGameSchema>;
 
-const modeToBackendFields = (mode: StandardGameFormValues["mode"]) => ({
-  anonymous: mode === "gunboat",
-  pressType: mode === "gunboat" ? "no_press" : "full_press",
-} as const);
+const modeToBackendFields = (mode: StandardGameFormValues["mode"]) =>
+  ({
+    anonymous: mode === "gunboat",
+    pressType: mode === "gunboat" ? "no_press" : "full_press",
+  }) as const;
 
 interface MetadataRow {
   label: string;
@@ -133,7 +145,9 @@ const GameMetadataTable: React.FC<GameMetadataTableProps> = ({ rows }) => {
               {row.icon}
               <span className="text-sm">{row.label}</span>
             </div>
-            <p className="text-sm text-muted-foreground whitespace-pre-line pl-7">{row.text}</p>
+            <p className="text-sm text-muted-foreground whitespace-pre-line pl-7">
+              {row.text}
+            </p>
           </div>
         ) : (
           <div key={index} className="flex items-center justify-between p-4">
@@ -221,16 +235,24 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
             value: selectedVariant?.author,
             icon: <User className="size-4" />,
           },
-          ...(selectedVariant?.description ? [{
-            label: "Description",
-            text: selectedVariant.description,
-            icon: <Map className="size-4" />,
-          }] : []),
-          ...(selectedVariant?.rules ? [{
-            label: "Rules",
-            text: selectedVariant.rules,
-            icon: <BookOpen className="size-4" />,
-          }] : []),
+          ...(selectedVariant?.description
+            ? [
+                {
+                  label: "Description",
+                  text: selectedVariant.description,
+                  icon: <Map className="size-4" />,
+                },
+              ]
+            : []),
+          ...(selectedVariant?.rules
+            ? [
+                {
+                  label: "Rules",
+                  text: selectedVariant.rules,
+                  icon: <BookOpen className="size-4" />,
+                },
+              ]
+            : []),
         ]}
       />
     </div>
@@ -239,9 +261,73 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
 
 function getBrowserTimezone(): string {
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const validTimezones = TIMEZONE_OPTIONS.map(o => o.value) as readonly string[];
+  const validTimezones = TIMEZONE_OPTIONS.map(
+    o => o.value
+  ) as readonly string[];
   return validTimezones.includes(tz) ? tz : "America/New_York";
 }
+
+const STANDARD_STEPS = ["General", "Deadlines"] as const;
+
+const STEP_FIELDS: Record<number, (keyof StandardGameFormValues)[]> = {
+  0: ["name", "variantId", "mode", "private", "gameMaster"],
+  1: [
+    "deadlineMode",
+    "movementPhaseDuration",
+    "retreatPhaseDuration",
+    "fixedDeadlineTime",
+    "fixedDeadlineTimezone",
+    "movementFrequency",
+    "retreatFrequency",
+    "nmrExtensionsAllowed",
+  ],
+};
+
+interface StepperProps {
+  steps: readonly string[];
+  currentStep: number;
+}
+
+const Stepper: React.FC<StepperProps> = ({ steps, currentStep }) => (
+  <div className="flex items-center">
+    {steps.map((label, index) => (
+      <React.Fragment key={label}>
+        <div className="flex items-center gap-2">
+          <div
+            className={cn(
+              "flex size-7 items-center justify-center rounded-full border text-sm font-medium",
+              index < currentStep &&
+                "border-primary bg-primary text-primary-foreground",
+              index === currentStep && "border-primary text-primary",
+              index > currentStep &&
+                "border-muted-foreground/30 text-muted-foreground"
+            )}
+          >
+            {index < currentStep ? <Check className="size-4" /> : index + 1}
+          </div>
+          <span
+            className={cn(
+              "text-sm font-medium",
+              index === currentStep
+                ? "text-foreground"
+                : "text-muted-foreground"
+            )}
+          >
+            {label}
+          </span>
+        </div>
+        {index < steps.length - 1 && (
+          <div
+            className={cn(
+              "mx-3 h-px flex-1",
+              index < currentStep ? "bg-primary" : "bg-border"
+            )}
+          />
+        )}
+      </React.Fragment>
+    ))}
+  </div>
+);
 
 interface CreateStandardGameFormProps {
   onSubmit: (data: StandardGameFormValues) => Promise<void>;
@@ -278,6 +364,9 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
     },
   });
 
+  const [step, setStep] = useState(0);
+  const lastStep = STANDARD_STEPS.length - 1;
+
   const selectedVariant = variants?.find(v => v.id === form.watch("variantId"));
   const deadlineMode = form.watch("deadlineMode");
   const isPrivate = form.watch("private");
@@ -285,407 +374,460 @@ const CreateStandardGameForm: React.FC<CreateStandardGameFormProps> = ({
     initialVariantId !== undefined &&
     variants.find(v => v.id === initialVariantId)?.status === "draft";
 
+  const handleNext = async () => {
+    const valid = await form.trigger(STEP_FIELDS[step]);
+    if (valid) {
+      setStep(s => Math.min(s + 1, lastStep));
+    }
+  };
+
+  const handleBack = () => setStep(s => Math.max(s - 1, 0));
+
+  const handleFormSubmit = form.handleSubmit(async data => {
+    if (step < lastStep) {
+      await handleNext();
+      return;
+    }
+    await onSubmit(data);
+  });
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">General</h2>
+      <form onSubmit={handleFormSubmit} className="space-y-6">
+        <Stepper steps={STANDARD_STEPS} currentStep={step} />
 
-          <FormField
-            control={form.control}
-            name="mode"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Mode</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={isSubmitting}
-                >
+        {step === 0 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">General</h2>
+
+            <FormField
+              control={form.control}
+              name="mode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mode</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={isSubmitting}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="standard">Standard</SelectItem>
+                      <SelectItem value="gunboat">Gunboat</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    {field.value === "gunboat"
+                      ? "Player names are anonymized and messaging is disabled"
+                      : "Standard play"}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Game Name</FormLabel>
                   <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
+                    <Input {...field} disabled={isSubmitting} />
                   </FormControl>
-                  <SelectContent>
-                    <SelectItem value="standard">Standard</SelectItem>
-                    <SelectItem value="gunboat">Gunboat</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  {field.value === "gunboat"
-                    ? "Player names are anonymized and messaging is disabled"
-                    : "Standard play"}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Game Name</FormLabel>
-                <FormControl>
-                  <Input {...field} disabled={isSubmitting} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="private"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={checked => {
+                        field.onChange(checked);
+                        if (!checked) {
+                          form.setValue("gameMaster", false);
+                        }
+                      }}
+                      disabled={isSubmitting || isInitialVariantDraft}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>Private</FormLabel>
+                    <FormDescription>
+                      Make this game private (only accessible via direct link,
+                      not shown in public listings)
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
 
-          <FormField
-            control={form.control}
-            name="private"
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                <FormControl>
-                  <Checkbox
-                    checked={field.value}
-                    onCheckedChange={checked => {
-                      field.onChange(checked);
-                      if (!checked) {
-                        form.setValue("gameMaster", false);
-                      }
-                    }}
-                    disabled={isSubmitting || isInitialVariantDraft}
-                  />
-                </FormControl>
-                <div className="space-y-1 leading-none">
-                  <FormLabel>Private</FormLabel>
-                  <FormDescription>
-                    Make this game private (only accessible via direct link, not
-                    shown in public listings)
-                  </FormDescription>
-                </div>
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="gameMaster"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={isSubmitting || !isPrivate}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>Game Master</FormLabel>
+                    <FormDescription>
+                      Run this game as a non-playing Game Master. You won't take
+                      a nation, but you can pause the game, extend deadlines,
+                      and remove players. Only available in private games.
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
 
-          <FormField
-            control={form.control}
-            name="gameMaster"
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                <FormControl>
-                  <Checkbox
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    disabled={isSubmitting || !isPrivate}
-                  />
-                </FormControl>
-                <div className="space-y-1 leading-none">
-                  <FormLabel>Game Master</FormLabel>
-                  <FormDescription>
-                    Run this game as a non-playing Game Master. You won't take a
-                    nation, but you can pause the game, extend deadlines, and
-                    remove players. Only available in private games.
-                  </FormDescription>
-                </div>
-              </FormItem>
-            )}
-          />
-        </div>
+            <hr className="border-t" />
 
-        <hr className="border-t" />
+            <VariantSelector
+              control={form.control}
+              name="variantId"
+              disabled={isSubmitting || isInitialVariantDraft}
+              variants={variants}
+              selectedVariant={selectedVariant}
+            />
+          </div>
+        )}
 
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Deadlines</h2>
+        {step === 1 && (
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold">Deadlines</h2>
 
-          <FormField
-            control={form.control}
-            name="deadlineMode"
-            render={({ field }) => (
-              <FormItem>
-                <Tabs
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  className="w-full"
-                >
-                  <TabsList className="w-full">
-                    <TabsTrigger value="fixed_time" className="flex-1">
-                      Fixed Time
-                    </TabsTrigger>
-                    <TabsTrigger value="duration" className="flex-1">
-                      Duration
-                    </TabsTrigger>
-                  </TabsList>
+              <FormField
+                control={form.control}
+                name="deadlineMode"
+                render={({ field }) => (
+                  <FormItem>
+                    <Tabs
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      className="w-full"
+                    >
+                      <TabsList className="w-full">
+                        <TabsTrigger value="fixed_time" className="flex-1">
+                          Fixed Time
+                        </TabsTrigger>
+                        <TabsTrigger value="duration" className="flex-1">
+                          Duration
+                        </TabsTrigger>
+                      </TabsList>
 
-                  <TabsContent value="duration" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementPhaseDuration"
-                        render={({ field: durationField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={durationField.onChange}
-                              value={durationField.value}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      <TabsContent value="duration" className="space-y-4 pt-4">
+                        <div className="grid w-full grid-cols-2 gap-4">
+                          <FormField
+                            control={form.control}
+                            name="movementPhaseDuration"
+                            render={({ field: durationField }) => (
+                              <FormItem>
+                                <FormLabel>Movement</FormLabel>
+                                <Select
+                                  onValueChange={durationField.onChange}
+                                  value={durationField.value}
+                                  disabled={isSubmitting}
+                                >
+                                  <FormControl>
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {DURATION_OPTIONS.map(option => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="retreatPhaseDuration"
-                        render={({ field: retreatField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatField.onChange}
-                              value={retreatField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {DURATION_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
+                          <FormField
+                            control={form.control}
+                            name="retreatPhaseDuration"
+                            render={({ field: retreatField }) => (
+                              <FormItem>
+                                <FormLabel>Retreat/Adjustment</FormLabel>
+                                <Select
+                                  onValueChange={retreatField.onChange}
+                                  value={retreatField.value ?? undefined}
+                                  disabled={isSubmitting}
+                                >
+                                  <FormControl>
+                                    <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                                      <SelectValue placeholder="Same as movement" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {DURATION_OPTIONS.map(option => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </div>
+                      </TabsContent>
 
-                  <TabsContent value="fixed_time" className="space-y-4 pt-4">
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTime"
-                        render={({ field: timeField }) => (
-                          <FormItem>
-                            <FormLabel>Time</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="time"
-                                className="appearance-none"
-                                value={timeField.value ?? ""}
-                                onChange={timeField.onChange}
-                                disabled={isSubmitting}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      <TabsContent
+                        value="fixed_time"
+                        className="space-y-4 pt-4"
+                      >
+                        <div className="grid w-full grid-cols-2 gap-4">
+                          <FormField
+                            control={form.control}
+                            name="fixedDeadlineTime"
+                            render={({ field: timeField }) => (
+                              <FormItem>
+                                <FormLabel>Time</FormLabel>
+                                <FormControl>
+                                  <Input
+                                    type="time"
+                                    className="appearance-none"
+                                    value={timeField.value ?? ""}
+                                    onChange={timeField.onChange}
+                                    disabled={isSubmitting}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="fixedDeadlineTimezone"
-                        render={({ field: tzField }) => (
-                          <FormItem>
-                            <FormLabel>Timezone</FormLabel>
-                            <Select
-                              onValueChange={tzField.onChange}
-                              value={tzField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                            <FormControl>
-                              <SelectTrigger className="w-full">
-                                <SelectValue placeholder="Select" />
-                              </SelectTrigger>
-                            </FormControl>
-                              <SelectContent>
-                                {TIMEZONE_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
+                          <FormField
+                            control={form.control}
+                            name="fixedDeadlineTimezone"
+                            render={({ field: tzField }) => (
+                              <FormItem>
+                                <FormLabel>Timezone</FormLabel>
+                                <Select
+                                  onValueChange={tzField.onChange}
+                                  value={tzField.value ?? undefined}
+                                  disabled={isSubmitting}
+                                >
+                                  <FormControl>
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue placeholder="Select" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {TIMEZONE_OPTIONS.map(option => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </div>
 
-                    <div className="grid w-full grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="movementFrequency"
-                        render={({ field: freqField }) => (
-                          <FormItem>
-                            <FormLabel>Movement</FormLabel>
-                            <Select
-                              onValueChange={freqField.onChange}
-                              value={freqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full">
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                        <div className="grid w-full grid-cols-2 gap-4">
+                          <FormField
+                            control={form.control}
+                            name="movementFrequency"
+                            render={({ field: freqField }) => (
+                              <FormItem>
+                                <FormLabel>Movement</FormLabel>
+                                <Select
+                                  onValueChange={freqField.onChange}
+                                  value={freqField.value ?? undefined}
+                                  disabled={isSubmitting}
+                                >
+                                  <FormControl>
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {FREQUENCY_OPTIONS.map(option => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="retreatFrequency"
-                        render={({ field: retreatFreqField }) => (
-                          <FormItem>
-                            <FormLabel>Retreat/Adjustment</FormLabel>
-                            <Select
-                              onValueChange={retreatFreqField.onChange}
-                              value={retreatFreqField.value ?? undefined}
-                              disabled={isSubmitting}
-                            >
-                              <FormControl>
-                                <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
-                                  <SelectValue placeholder="Same as movement" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {FREQUENCY_OPTIONS.map(option => (
-                                  <SelectItem
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </TabsContent>
-                </Tabs>
-              </FormItem>
-            )}
-          />
-
-          <Alert className="mt-4">
-            <Clock className="h-4 w-4" />
-            <AlertDescription>
-              <DeadlineSummary
-                game={{
-                  movementPhaseDuration:
-                    form.watch("movementPhaseDuration") ?? null,
-                  retreatPhaseDuration:
-                    form.watch("retreatPhaseDuration") ?? null,
-                  deadlineMode,
-                  fixedDeadlineTime:
-                    form.watch("fixedDeadlineTime") ?? null,
-                  fixedDeadlineTimezone:
-                    form.watch("fixedDeadlineTimezone") ?? null,
-                  movementFrequency:
-                    form.watch("movementFrequency") ?? null,
-                  retreatFrequency:
-                    form.watch("retreatFrequency") ?? null,
-                }}
+                          <FormField
+                            control={form.control}
+                            name="retreatFrequency"
+                            render={({ field: retreatFreqField }) => (
+                              <FormItem>
+                                <FormLabel>Retreat/Adjustment</FormLabel>
+                                <Select
+                                  onValueChange={retreatFreqField.onChange}
+                                  value={retreatFreqField.value ?? undefined}
+                                  disabled={isSubmitting}
+                                >
+                                  <FormControl>
+                                    <SelectTrigger className="w-full min-w-0 [&>[data-slot=select-value]]:min-w-0">
+                                      <SelectValue placeholder="Same as movement" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {FREQUENCY_OPTIONS.map(option => (
+                                      <SelectItem
+                                        key={option.value}
+                                        value={option.value}
+                                      >
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </div>
+                      </TabsContent>
+                    </Tabs>
+                  </FormItem>
+                )}
               />
-            </AlertDescription>
-          </Alert>
+
+              <Alert className="mt-4">
+                <Clock className="h-4 w-4" />
+                <AlertDescription>
+                  <DeadlineSummary
+                    game={{
+                      movementPhaseDuration:
+                        form.watch("movementPhaseDuration") ?? null,
+                      retreatPhaseDuration:
+                        form.watch("retreatPhaseDuration") ?? null,
+                      deadlineMode,
+                      fixedDeadlineTime:
+                        form.watch("fixedDeadlineTime") ?? null,
+                      fixedDeadlineTimezone:
+                        form.watch("fixedDeadlineTimezone") ?? null,
+                      movementFrequency:
+                        form.watch("movementFrequency") ?? null,
+                      retreatFrequency: form.watch("retreatFrequency") ?? null,
+                    }}
+                  />
+                </AlertDescription>
+              </Alert>
+            </div>
+
+            <hr className="border-t" />
+
+            <div className="space-y-4">
+              <h2 className="text-lg font-semibold">Advanced</h2>
+
+              <FormField
+                control={form.control}
+                name="nmrExtensionsAllowed"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Automatic Extensions</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      disabled={isSubmitting}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {NMR_EXTENSION_OPTIONS.map(option => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Automatic extensions when players miss the deadline
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          {step > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleBack}
+              disabled={isSubmitting}
+              className="flex-1"
+            >
+              <ArrowLeft />
+              Back
+            </Button>
+          )}
+          {step < lastStep ? (
+            <Button
+              key="next"
+              type="button"
+              onClick={handleNext}
+              className="flex-1"
+            >
+              Next
+              <ArrowRight />
+            </Button>
+          ) : (
+            <Button
+              key="submit"
+              type="button"
+              onClick={() => handleFormSubmit()}
+              className="flex-1"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Creating..." : "Create Game"}
+            </Button>
+          )}
         </div>
-
-        <hr className="border-t" />
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Variant</h2>
-
-          <VariantSelector
-            control={form.control}
-            name="variantId"
-            disabled={isSubmitting || isInitialVariantDraft}
-            variants={variants}
-            selectedVariant={selectedVariant}
-          />
-        </div>
-
-        <hr className="border-t" />
-
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Advanced</h2>
-
-          <FormField
-            control={form.control}
-            name="nmrExtensionsAllowed"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Automatic Extensions</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={isSubmitting}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {NMR_EXTENSION_OPTIONS.map(option => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  Automatic extensions when players miss the deadline
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <Button type="submit" className="w-full" disabled={isSubmitting}>
-          {isSubmitting ? "Creating..." : "Create Game"}
-        </Button>
       </form>
     </Form>
   );
@@ -774,15 +916,22 @@ const CreateGame: React.FC = () => {
     [allVariants]
   );
 
-  const initialVariantId = searchParams.get(CREATE_GAME_PARAM.variantId) ?? undefined;
+  const initialVariantId =
+    searchParams.get(CREATE_GAME_PARAM.variantId) ?? undefined;
   const initialPrivate = searchParams.get(CREATE_GAME_PARAM.private) === "true";
 
   const initialVariant = React.useMemo(
-    () => (initialVariantId ? allVariants.find(v => v.id === initialVariantId) : undefined),
+    () =>
+      initialVariantId
+        ? allVariants.find(v => v.id === initialVariantId)
+        : undefined,
     [allVariants, initialVariantId]
   );
   const variants = React.useMemo(() => {
-    if (initialVariant && !publishedVariants.some(v => v.id === initialVariant.id)) {
+    if (
+      initialVariant &&
+      !publishedVariants.some(v => v.id === initialVariant.id)
+    ) {
       return [initialVariant, ...publishedVariants];
     }
     return publishedVariants;
@@ -976,7 +1125,9 @@ const CreateGame: React.FC = () => {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>A similar game is already forming</AlertDialogTitle>
+            <AlertDialogTitle>
+              A similar game is already forming
+            </AlertDialogTitle>
             <AlertDialogDescription>
               Join it instead to start playing sooner.
             </AlertDialogDescription>
@@ -986,7 +1137,10 @@ const CreateGame: React.FC = () => {
               <p className="font-semibold">{similarMatch.name}</p>
               <p className="text-muted-foreground">
                 {similarMatch.members.length}
-                {matchedVariant ? ` / ${matchedVariant.nations.length}` : ""} players
+                {matchedVariant
+                  ? ` / ${matchedVariant.nations.length}`
+                  : ""}{" "}
+                players
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary

Splits the standard create-game form into multiple steps with a visible progress stepper, so it feels less dense and leaves room for future settings. Closes #731.

The form is organised into **three** steps fronted by a numbered stepper:

- **General** — game name, mode, private / game-master toggles, and variant selection (with the map preview).
- **Deadlines** — fixed-time vs duration, movement/retreat frequencies, and the deadline summary.
- **Advanced** — automatic extensions.

**Sandbox** is a choice in the **Mode** dropdown (alongside Standard and Gunboat) rather than a separate tab. When Sandbox is selected: Private and Game Master are unchecked and disabled, the Deadlines and Advanced steps are greyed out in the stepper, and the General-step button reads **"Create Game"** (a single-step flow). A typed/bookmarked `?sandbox=true` URL preselects Sandbox.

## Implementation notes

- The two separate Standard/Sandbox forms are merged into one (`mode ∈ {standard, gunboat, sandbox}`); the sandbox submit path sends only `{ name, variantId }`.
- The `Stepper` takes per-step `{ label, disabled }` objects, so any subset of steps can be disabled (not just a trailing cut-off).
- Step navigation validates only the current step's fields (`form.trigger`) before advancing; the final submit validates everything. React Hook Form retains values for unmounted steps.
- The footer buttons use explicit `onClick` handlers rather than a native `type="submit"` button, avoiding a bug where the async "Next" handler let React re-render mid-click and swap in a submit button at the same DOM position.

## Tests

- `CreateGame.test.tsx`: navigation helpers updated for the 3-step flow; multi-step describe walks General → Deadlines → Advanced and back; added a **sandbox** describe block (selecting Sandbox disables/unchecks Private & Game Master, shows "Create Game" with no "Next", and creates a sandbox game navigating to `/game/<id>`).
- All 18 tests pass; `tsc -b --noEmit` and ESLint are clean.

## Screenshots

### Step 1 — General (Standard)
![general](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/step1-general.png)

### Step 2 — Deadlines
![deadlines](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/step2-deadlines.png)

### Step 3 — Advanced
![advanced](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/step3-advanced.png)

### Sandbox mode (Deadlines/Advanced greyed, single-step)
![sandbox](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/sandbox-general.png)

### Mobile (390×844)
![general mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/step1-general-mobile.png)
![sandbox mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/fdd0115e59383908022be7ce3eb099da1d96189b/shots/sandbox-general-mobile.png)

https://claude.ai/code/session_01L2vRtsBG3x1mtNUtjdCwNB