### PR TITLE
Add GitHub CLI (gh) provisioning to session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -143,7 +143,32 @@ else
 fi
 
 ###############################################################################
-# 7. Persist session environment: venv on PATH + local DB config, so that
+# 7. GitHub CLI (gh). Authenticates automatically from $GH_TOKEN (set in the
+#    cloud environment config). The mcp__github__* tools cover most GitHub
+#    workflows; gh adds shell-driven access (gh api, gh pr, gh issue, gh label).
+#    Without GH_TOKEN it is left uninstalled, since it would be unauthenticated.
+###############################################################################
+if [ -n "${GH_TOKEN:-}" ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    log "Installing GitHub CLI"
+    apt-get install -y -q gh >/dev/null 2>&1 \
+      || ( apt-get update -qq >/dev/null 2>&1 && apt-get install -y -q gh >/dev/null 2>&1 ) \
+      || log "WARNING: gh install failed"
+  fi
+  if command -v gh >/dev/null 2>&1; then
+    # gh auth status validates GH_TOKEN against api.github.com.
+    if gh auth status >/dev/null 2>&1; then
+      log "GitHub CLI ready (authenticated via GH_TOKEN)."
+    else
+      log "WARNING: gh installed but 'gh auth status' failed — check GH_TOKEN validity/permissions."
+    fi
+  fi
+else
+  log "GH_TOKEN not set — GitHub CLI not installed (use the mcp__github__* tools instead)."
+fi
+
+###############################################################################
+# 8. Persist session environment: venv on PATH + local DB config, so that
 #    `python`, `pytest`, and `manage.py` work without per-command env setup.
 ###############################################################################
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then


### PR DESCRIPTION
## What this PR does

Adds automatic installation and authentication of the GitHub CLI (`gh`) tool during cloud session initialization, when `GH_TOKEN` is available. This enables shell-driven GitHub workflows (API calls, PR/issue management, labeling) alongside the existing MCP-based GitHub tools.

The hook now:
- Installs `gh` only if `GH_TOKEN` is set (avoiding unauthenticated installations)
- Validates authentication via `gh auth status`
- Logs appropriate warnings if installation or authentication fails
- Falls back to MCP tools if `GH_TOKEN` is absent

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] Tests cover the change — session-start hook is idempotent and tested in cloud CI
- [x] `RELEASE_NOTES.md` updated if the change is user-facing — N/A (internal tooling)

https://claude.ai/code/session_01M94r4iYXq1QbjLWf6QPTnd