### PR TITLE
Mask player identities in anonymous-game notifications

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Diplicity React - Release Notes
 
+## Notifications Respect Anonymous Games (June 2026)
+
+### Fix: Push notifications no longer reveal player identities in anonymous games
+
+In anonymous games, push notifications previously leaked who performed certain actions. Draw
+proposal and chat notifications now show "Anonymous" instead of the real name, and pause,
+resume, and deadline-extension notifications no longer append the acting player's username.
+Identities are still revealed once a game finishes, matching the rest of the app. Non-anonymous
+games are unaffected.
+
 ## Unread Message Indicator on Game Cards (June 2026)
 
 ### Feature: See unread message counts without opening a game

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -445,6 +445,10 @@ class Game(BaseModel):
     def manager_label(self):
         return "the Game Master" if self.game_master_id is not None else "the game creator"
 
+    @property
+    def anonymity_active(self):
+        return self.anonymous and self.status != GameStatus.COMPLETED
+
     def get_phase_duration_seconds(self, phase_type):
         if phase_type == PhaseType.MOVEMENT:
             return self.movement_phase_duration_seconds

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -473,10 +473,11 @@ class GamePauseSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         actor = self.context["request"].user
         instance.pause()
+        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
         send_game_management_notification(
             instance,
             title=instance.name,
-            body=f"Game paused by {instance.manager_label} ({actor.username})",
+            body=f"Game paused by {instance.manager_label}{actor_suffix}",
             notification_type="game_paused",
             exclude_user_id=actor.id,
         )
@@ -497,10 +498,11 @@ class GameUnpauseSerializer(serializers.Serializer):
         instance.unpause()
         new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
         deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
+        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
         send_game_management_notification(
             instance,
             title=instance.name,
-            body=f"Game resumed by {instance.manager_label} ({actor.username}). New deadline: {deadline_str}",
+            body=f"Game resumed by {instance.manager_label}{actor_suffix}. New deadline: {deadline_str}",
             notification_type="game_resumed",
             exclude_user_id=actor.id,
         )
@@ -530,10 +532,11 @@ class GameExtendDeadlineSerializer(serializers.Serializer):
         instance.extend_deadline(validated_data["duration"])
         new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
         deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
+        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
         send_game_management_notification(
             instance,
             title=instance.name,
-            body=f"Deadline extended by {instance.manager_label} ({actor.username}). New deadline: {deadline_str}",
+            body=f"Deadline extended by {instance.manager_label}{actor_suffix}. New deadline: {deadline_str}",
             notification_type="game_deadline_extended",
             exclude_user_id=actor.id,
         )

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -2823,6 +2823,7 @@ class TestGamePauseNotification:
         self,
         authenticated_client,
         active_game_factory,
+        primary_user,
         mock_send_notification_to_users,
         mock_immediate_on_commit,
     ):
@@ -2837,7 +2838,31 @@ class TestGamePauseNotification:
         call_kwargs = mock_send_notification_to_users.call_args[1]
         assert call_kwargs["notification_type"] == "game_paused"
         assert "Game paused by the game creator" in call_kwargs["body"]
+        assert f"({primary_user.username})" in call_kwargs["body"]
         assert call_kwargs["data"]["game_id"] == str(game.id)
+
+    @pytest.mark.django_db
+    def test_pause_anonymous_game_omits_actor_identity(
+        self,
+        authenticated_client,
+        active_game_factory,
+        primary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game = active_game_factory()
+        game.anonymous = True
+        game.save()
+        mock_send_notification_to_users.reset_mock()
+
+        url = reverse(pause_viewname, args=[game.id])
+        response = authenticated_client.patch(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        mock_send_notification_to_users.assert_called_once()
+        body = mock_send_notification_to_users.call_args[1]["body"]
+        assert body == "Game paused by the game creator"
+        assert primary_user.username not in body
 
 
 class TestGameUnpauseNotification:
@@ -2847,6 +2872,7 @@ class TestGameUnpauseNotification:
         self,
         authenticated_client,
         active_game_factory,
+        primary_user,
         mock_send_notification_to_users,
         mock_immediate_on_commit,
     ):
@@ -2863,7 +2889,32 @@ class TestGameUnpauseNotification:
         call_kwargs = mock_send_notification_to_users.call_args[1]
         assert call_kwargs["notification_type"] == "game_resumed"
         assert "Game resumed by the game creator" in call_kwargs["body"]
+        assert f"({primary_user.username})" in call_kwargs["body"]
         assert "New deadline:" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_unpause_anonymous_game_omits_actor_identity(
+        self,
+        authenticated_client,
+        active_game_factory,
+        primary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game = active_game_factory()
+        game.anonymous = True
+        game.pause()
+        game.save()
+        mock_send_notification_to_users.reset_mock()
+
+        url = reverse(unpause_viewname, args=[game.id])
+        response = authenticated_client.patch(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        mock_send_notification_to_users.assert_called_once()
+        body = mock_send_notification_to_users.call_args[1]["body"]
+        assert body.startswith("Game resumed by the game creator. New deadline:")
+        assert primary_user.username not in body
 
 
 class TestGameExtendDeadlineNotification:
@@ -2873,6 +2924,7 @@ class TestGameExtendDeadlineNotification:
         self,
         authenticated_client,
         active_game_factory,
+        primary_user,
         mock_send_notification_to_users,
         mock_immediate_on_commit,
     ):
@@ -2889,6 +2941,32 @@ class TestGameExtendDeadlineNotification:
         call_kwargs = mock_send_notification_to_users.call_args[1]
         assert call_kwargs["notification_type"] == "game_deadline_extended"
         assert "Deadline extended by the game creator" in call_kwargs["body"]
+        assert f"({primary_user.username})" in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_extend_deadline_anonymous_game_omits_actor_identity(
+        self,
+        authenticated_client,
+        active_game_factory,
+        primary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game = active_game_factory()
+        game.anonymous = True
+        game.save()
+        mock_send_notification_to_users.reset_mock()
+
+        url = reverse(extend_deadline_viewname, args=[game.id])
+        response = authenticated_client.patch(
+            url, {"duration": MovementPhaseDuration.ONE_HOUR}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        mock_send_notification_to_users.assert_called_once()
+        body = mock_send_notification_to_users.call_args[1]["body"]
+        assert body.startswith("Deadline extended by the game creator. New deadline:")
+        assert primary_user.username not in body
 
 
 class TestGameNmrExtensions:

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -41,8 +41,8 @@ def send_draw_proposal_notification(sender, instance, created, **kwargs):
     if not user_ids:
         return
 
-    proposer_name = instance.created_by.name
     game = instance.game
+    proposer_name = "Anonymous" if game.anonymity_active else instance.created_by.name
     phase = instance.phase
     link = (
         f"{settings.FRONTEND_URL}/game/{game.id}/phase/{phase.id}/draw-proposals"
@@ -75,8 +75,8 @@ def send_channel_message_notification(sender, instance, created, **kwargs):
     if not user_ids:
         return
 
-    sender_name = instance.sender.name
     game = instance.channel.game
+    sender_name = "Anonymous" if game.anonymity_active else instance.sender.name
     current_phase = game.phases.last()
     link = (
         f"{settings.FRONTEND_URL}/game/{game.id}/phase/{current_phase.id}/chat/channel/{instance.channel.id}"

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -103,6 +103,22 @@ def test_channel_message_notification_deleted_user(active_game, in_memory_procra
     assert jobs[0]["args"]["body"].startswith("Deleted User: ")
 
 
+@pytest.mark.django_db
+def test_channel_message_notification_masks_sender_in_anonymous_game(active_game, in_memory_procrastinate):
+    active_game.anonymous = True
+    active_game.save()
+    sender_member = active_game.members.first()
+    channel = Channel.objects.create(game=active_game, name="Global Press", private=False)
+
+    ChannelMessage.objects.create(channel=channel, sender=sender_member, body="Hello everyone")
+
+    jobs = _notification_jobs(in_memory_procrastinate, "channel_message")
+    assert len(jobs) == 1
+    body = jobs[0]["args"]["body"]
+    assert body.startswith("Anonymous: ")
+    assert sender_member.name not in body
+
+
 class TestDrawProposalNotification:
 
     @pytest.mark.django_db
@@ -121,6 +137,24 @@ class TestDrawProposalNotification:
         assert set(args["user_ids"]) == {secondary_user.id}
         assert italy.name in args["body"]
         assert args["title"] == game.name
+
+    @pytest.mark.django_db
+    def test_proposer_masked_in_anonymous_game(
+        self,
+        draw_notification_game_factory,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany = draw_notification_game_factory()
+        game.anonymous = True
+        game.save()
+        DrawProposal.objects.create_proposal(game=game, created_by=italy)
+
+        jobs = _notification_jobs(in_memory_procrastinate, "draw_proposal")
+        assert len(jobs) == 1
+        body = jobs[0]["args"]["body"]
+        assert body == "Anonymous has proposed a draw. Respond to it now."
+        assert italy.name not in body
 
     @pytest.mark.django_db
     def test_proposer_excluded_from_notification(


### PR DESCRIPTION
## Summary

Fixes #674. Push notification bodies bypassed the anonymous-game masking the API already applies (`BaseMemberSerializer._is_masked`), leaking real player identities in anonymous games. Flagged in review of #636 (https://github.com/johnpooch/diplicity-react/pull/636#discussion_r3405500794).

Three notification types leaked identity while an anonymous game was in progress:

| Notification | Leak | Fix |
|---|---|---|
| `game_paused` / `game_resumed` / `game_deadline_extended` | appended `(actor.username)` | drop the username suffix when anonymity is active, keep the role label (`manager_label`) |
| `draw_proposal` | used proposer's real display name | substitute `"Anonymous"` |
| `channel_message` | used sender's real display name | substitute `"Anonymous"` |

## Implementation

- **`game/models.py`** — new derived property `Game.anonymity_active` (`anonymous and status != COMPLETED`), mirroring the serializer masking condition minus the per-viewer exception (notifications go to other members).
- **`game/serializers.py`** — pause/unpause/extend-deadline build the actor suffix conditionally: `"" if instance.anonymity_active else f" ({actor.username})"`.
- **`notification/signals.py`** — draw-proposal and channel-message notifications use `"Anonymous"` when `game.anonymity_active`. This covers private-channel messages too, matching how the API masks members even within private channels.

Non-anonymous games are unchanged. Identities are still revealed once a game completes (`anonymity_active` becomes false), consistent with the API and with the existing end-of-game `game_draw` / `game_solo_loss` notifications, which fire only after completion and are intentionally left as-is.

## Tests

- `game/tests.py` — anonymous-game variants for pause/unpause/extend asserting the username is omitted; existing non-anonymous tests strengthened to assert the username IS present.
- `notification/tests.py` — anonymous-game tests for `draw_proposal` and `channel_message` asserting the body shows `"Anonymous"` and not the real name.

```
notification/tests.py + game pause/unpause/extend/GM notification tests + test_anonymous_games.py — all passing
python manage.py check — no issues
```

## Visual changes

None — backend-only (notification text). No schema/migration changes (field-less property), so no codegen.

https://claude.ai/code/session_01Gh2KBHTTAZ13xpbTCanU8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gh2KBHTTAZ13xpbTCanU8W)_