### PR TITLE
Fix 500 on token refresh when user has been deleted

### DIFF
--- a/service/login/tests_token_refresh.py
+++ b/service/login/tests_token_refresh.py
@@ -1,0 +1,24 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_token_refresh_with_deleted_user_returns_401(unauthenticated_client):
+    user = User.objects.create_user(
+        username="tobedeleted@example.com",
+        email="tobedeleted@example.com",
+        password="testpass123",
+    )
+    refresh = RefreshToken.for_user(user)
+    user.delete()
+
+    url = reverse("token-refresh")
+    response = unauthenticated_client.post(
+        url, {"refresh": str(refresh)}, format="json"
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/service/project/exception_handler.py
+++ b/service/project/exception_handler.py
@@ -1,0 +1,11 @@
+from django.contrib.auth import get_user_model
+from rest_framework.views import exception_handler
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+
+def custom_exception_handler(exc, context):
+    # simplejwt's TokenRefreshSerializer calls User.objects.get() without catching
+    # DoesNotExist when the token's user has been deleted; convert to 401.
+    if isinstance(exc, get_user_model().DoesNotExist):
+        exc = InvalidToken()
+    return exception_handler(exc, context)

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -265,6 +265,7 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "project.exception_handler.custom_exception_handler",
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
## What broke

`POST /api/token/refresh/` returned 500 when a valid refresh token was presented for a user account that had since been deleted.

## Root cause

simplejwt's `TokenRefreshSerializer.validate()` calls `User.objects.get()` to check whether the token's owner is still active, but does not catch `DoesNotExist`. The exception propagated unhandled through DRF, producing a 500 instead of a 401.

## Fix

A custom DRF exception handler (`project/exception_handler.py`) intercepts `User.DoesNotExist` and converts it to simplejwt's `InvalidToken`, which DRF renders as HTTP 401.

A regression test (`login/tests_token_refresh.py`) creates a user, issues a refresh token, deletes the user, then asserts the refresh endpoint returns 401.

Closes #740


---
_Generated by [Claude Code](https://claude.ai/code/session_01TQZk5yuQMzYqJZX7ymKp2S)_