### PR TITLE
Add order status and member status badges to game cards

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -362,6 +362,27 @@ export interface GameListCurrentPhase {
   readonly remainingTime: number;
 }
 
+export type OrderStatusEnum =
+  (typeof OrderStatusEnum)[keyof typeof OrderStatusEnum];
+
+export const OrderStatusEnum = {
+  orders_required: "orders_required",
+  orders_submitted: "orders_submitted",
+  no_orders_required: "no_orders_required",
+} as const;
+
+/**
+ * * `nmr` - nmr
+ * `civil_disorder` - civil_disorder
+ */
+export type MemberStatusEnum =
+  (typeof MemberStatusEnum)[keyof typeof MemberStatusEnum];
+
+export const MemberStatusEnum = {
+  nmr: "nmr",
+  civil_disorder: "civil_disorder",
+} as const;
+
 export interface Member {
   readonly id: number;
   /** @nullable */
@@ -429,6 +450,9 @@ export interface GameList {
   readonly retreatFrequency: string | null;
   readonly pressType: string;
   readonly totalUnreadMessageCount: number;
+  /** @nullable */
+  readonly orderStatus: OrderStatusEnum | null;
+  readonly memberStatus: readonly MemberStatusEnum[];
 }
 
 export interface GameFindSimilar {
@@ -475,6 +499,9 @@ export interface GameRetrieve {
   readonly retreatFrequency: string | null;
   readonly pressType: string;
   readonly totalUnreadMessageCount: number;
+  /** @nullable */
+  readonly orderStatus: OrderStatusEnum | null;
+  readonly memberStatus: readonly MemberStatusEnum[];
 }
 
 export interface NationFlagUpload {

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -209,6 +209,46 @@ describe("GameCard", () => {
     });
   });
 
+  describe("order and member status badges", () => {
+    it("shows 'Required' badge when orderStatus is orders_required", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: "orders_required", memberStatus: [] }, ...defaultProps });
+      expect(screen.getByText("Required")).toBeInTheDocument();
+    });
+
+    it("shows 'Submitted' badge when orderStatus is orders_submitted", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: "orders_submitted", memberStatus: [] }, ...defaultProps });
+      expect(screen.getByText("Submitted")).toBeInTheDocument();
+    });
+
+    it("shows 'Not required' badge when orderStatus is no_orders_required", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: "no_orders_required", memberStatus: [] }, ...defaultProps });
+      expect(screen.getByText("Not required")).toBeInTheDocument();
+    });
+
+    it("shows no order status badge when orderStatus is null", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: [] }, ...defaultProps });
+      expect(screen.queryByText("Required")).not.toBeInTheDocument();
+      expect(screen.queryByText("Submitted")).not.toBeInTheDocument();
+      expect(screen.queryByText("Not required")).not.toBeInTheDocument();
+    });
+
+    it("shows 'NMR' badge when memberStatus includes nmr", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: ["nmr"] }, ...defaultProps });
+      expect(screen.getByText("NMR")).toBeInTheDocument();
+    });
+
+    it("shows 'CD' badge when memberStatus includes civil_disorder", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: ["civil_disorder"] }, ...defaultProps });
+      expect(screen.getByText("CD")).toBeInTheDocument();
+    });
+
+    it("shows no member status badges when memberStatus is empty", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: [] }, ...defaultProps });
+      expect(screen.queryByText("NMR")).not.toBeInTheDocument();
+      expect(screen.queryByText("CD")).not.toBeInTheDocument();
+    });
+  });
+
   describe("sandbox visual treatment", () => {
     it("displays a Sandbox badge when game.sandbox is true", () => {
       renderGameCard({

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/card";
 import { GameDropdownMenu } from "./GameDropdownMenu";
 import { NationBadge } from "./NationBadge";
-import { UserPlus, Lock, MessageSquareOff, Mail } from "lucide-react";
+import { UserPlus, Lock, MessageSquareOff, Mail, Clock, Check, AlertTriangle, UserX } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { RemainingTimeDisplay } from "./RemainingTimeDisplay";
@@ -111,6 +111,61 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                   )}
                   {!game.sandbox && (
                     <NationBadge nations={variant.nations} nation={playerNation} />
+                  )}
+                  {game.orderStatus === "orders_required" && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge className="gap-1 bg-amber-500 text-white hover:bg-amber-500">
+                          <Clock className="size-3" />
+                          Required
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>You have orders to submit this phase</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {game.orderStatus === "orders_submitted" && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge className="gap-1 bg-green-600 text-white hover:bg-green-600">
+                          <Check className="size-3" />
+                          Submitted
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>Your orders are submitted for this phase</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {game.orderStatus === "no_orders_required" && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge className="gap-1 bg-green-600 text-white hover:bg-green-600">
+                          <Check className="size-3" />
+                          Not required
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>No orders are needed from you this phase</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {game.memberStatus.includes("nmr") && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge variant="destructive" className="gap-1">
+                          <AlertTriangle className="size-3" />
+                          NMR
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>No Move Received — you did not submit orders in the previous phase</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {game.memberStatus.includes("civil_disorder") && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge variant="destructive" className="gap-1">
+                          <UserX className="size-3" />
+                          CD
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent>Civil Disorder — your units are acting without orders</TooltipContent>
+                    </Tooltip>
                   )}
                   {game.totalUnreadMessageCount > 0 && (
                     <Badge variant="default" className="gap-1">

--- a/packages/web/src/mocks/fixtures/builders.ts
+++ b/packages/web/src/mocks/fixtures/builders.ts
@@ -124,6 +124,8 @@ export const makeGame = (
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
     ...overrides,
   };
 };

--- a/packages/web/src/mocks/fixtures/games.ts
+++ b/packages/web/src/mocks/fixtures/games.ts
@@ -128,7 +128,10 @@ const buildActiveMovement = () => {
   return makeFixture({
     description:
       "Active game in the Spring 1901 movement phase. The current user (England) has entered 2 of 3 orders. Includes public and private chat channels.",
-    game: makeGame("active-movement", "Spring Awakening", members, [phase]),
+    game: makeGame("active-movement", "Spring Awakening", members, [phase], {
+      orderStatus: "orders_required",
+      memberStatus: [],
+    }),
     phases: [phase],
     ordersByPhase: {
       101: [
@@ -205,7 +208,10 @@ const buildActiveRetreat = () => {
       spring,
       fallMove,
       retreat,
-    ]),
+    ], {
+      orderStatus: "orders_required",
+      memberStatus: [],
+    }),
     phases: [spring, fallMove, retreat],
     ordersByPhase: {
       202: [
@@ -286,7 +292,10 @@ const buildActiveBuild = () => {
       spring,
       fallMove,
       adjustment,
-    ]),
+    ], {
+      orderStatus: "orders_required",
+      memberStatus: [],
+    }),
     phases: [spring, fallMove, adjustment],
     ordersByPhase: {
       302: [

--- a/packages/web/src/mocks/legacy.ts
+++ b/packages/web/src/mocks/legacy.ts
@@ -341,6 +341,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "game-2",
@@ -375,6 +377,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "game-3",
@@ -409,6 +413,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "game-4",
@@ -443,6 +449,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "game-5",
@@ -482,6 +490,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "game-6",
@@ -521,6 +531,8 @@ export const mockGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
 ];
 
@@ -573,6 +585,8 @@ export const mockSandboxGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
   {
     id: "sandbox-2",
@@ -607,6 +621,8 @@ export const mockSandboxGames: GameList[] = [
     retreatFrequency: null,
     pressType: "full_press",
     totalUnreadMessageCount: 0,
+    orderStatus: null,
+    memberStatus: [],
   },
 ];
 

--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -169,6 +169,8 @@ const matchedGame: GameList = {
   retreatFrequency: null,
   pressType: "full_press",
   totalUnreadMessageCount: 0,
+  orderStatus: null,
+  memberStatus: [],
 };
 
 const renderCreateGame = () => {

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -71,6 +71,8 @@ class GameListSerializer(serializers.Serializer):
     current_phase_id = serializers.SerializerMethodField()
     current_phase = serializers.SerializerMethodField()
     phase_confirmed = serializers.SerializerMethodField()
+    order_status = serializers.SerializerMethodField()
+    member_status = serializers.SerializerMethodField()
     private = serializers.BooleanField(read_only=True)
     anonymous = serializers.BooleanField(read_only=True)
     movement_phase_duration = serializers.CharField(read_only=True, allow_null=True)
@@ -142,6 +144,52 @@ class GameListSerializer(serializers.Serializer):
                 return False
             return obj.phase_confirmed(user)
 
+    @extend_schema_field(serializers.ChoiceField(
+        choices=["orders_required", "orders_submitted", "no_orders_required"],
+        allow_null=True,
+    ))
+    def get_order_status(self, obj):
+        user = self.context["request"].user
+        if not user.is_authenticated or obj.status != "active":
+            return None
+        current_phase = obj.current_phase
+        if current_phase is None:
+            return None
+        for phase_state in current_phase.phase_states.all():
+            if phase_state.member.user_id == user.id:
+                if phase_state.orders_confirmed:
+                    return "orders_submitted"
+                if not phase_state.has_possible_orders:
+                    return "no_orders_required"
+                return "orders_required"
+        return None
+
+    @extend_schema_field(serializers.ListField(
+        child=serializers.ChoiceField(choices=["nmr", "civil_disorder"]),
+    ))
+    def get_member_status(self, obj):
+        user = self.context["request"].user
+        if not user.is_authenticated:
+            return []
+        current_member = next(
+            (m for m in obj.members.all() if m.user_id == user.id), None
+        )
+        if current_member is None:
+            return []
+        statuses = []
+        if current_member.civil_disorder:
+            statuses.append("civil_disorder")
+        phases = list(obj.phases.all())
+        completed_phases = [p for p in phases if p.status == "completed"]
+        if completed_phases:
+            prev_phase = max(completed_phases, key=lambda p: p.ordinal)
+            for phase_state in prev_phase.phase_states.all():
+                if phase_state.member.user_id == user.id:
+                    if phase_state.orders_outcome == "nmr":
+                        statuses.append("nmr")
+                    break
+        return statuses
+
 
 class GameFindSimilarSerializer(serializers.Serializer):
     game = GameListSerializer(allow_null=True)
@@ -165,6 +213,8 @@ class GameRetrieveSerializer(serializers.Serializer):
     variant_id = serializers.CharField(source="variant.id", read_only=True)
     nation_assignment = serializers.CharField(read_only=True)
     phase_confirmed = serializers.SerializerMethodField()
+    order_status = serializers.SerializerMethodField()
+    member_status = serializers.SerializerMethodField()
     movement_phase_duration = serializers.CharField(read_only=True, allow_null=True)
     retreat_phase_duration = serializers.CharField(read_only=True, allow_null=True)
     private = serializers.BooleanField(read_only=True)
@@ -247,6 +297,52 @@ class GameRetrieveSerializer(serializers.Serializer):
             if not user.is_authenticated:
                 return False
             return obj.phase_confirmed(user)
+
+    @extend_schema_field(serializers.ChoiceField(
+        choices=["orders_required", "orders_submitted", "no_orders_required"],
+        allow_null=True,
+    ))
+    def get_order_status(self, obj):
+        user = self.context["request"].user
+        if not user.is_authenticated or obj.status != "active":
+            return None
+        current_phase = obj.current_phase
+        if current_phase is None:
+            return None
+        for phase_state in current_phase.phase_states.all():
+            if phase_state.member.user_id == user.id:
+                if phase_state.orders_confirmed:
+                    return "orders_submitted"
+                if not phase_state.has_possible_orders:
+                    return "no_orders_required"
+                return "orders_required"
+        return None
+
+    @extend_schema_field(serializers.ListField(
+        child=serializers.ChoiceField(choices=["nmr", "civil_disorder"]),
+    ))
+    def get_member_status(self, obj):
+        user = self.context["request"].user
+        if not user.is_authenticated:
+            return []
+        current_member = next(
+            (m for m in obj.members.all() if m.user_id == user.id), None
+        )
+        if current_member is None:
+            return []
+        statuses = []
+        if current_member.civil_disorder:
+            statuses.append("civil_disorder")
+        phases = list(obj.phases.all())
+        completed_phases = [p for p in phases if p.status == "completed"]
+        if completed_phases:
+            prev_phase = max(completed_phases, key=lambda p: p.ordinal)
+            for phase_state in prev_phase.phase_states.all():
+                if phase_state.member.user_id == user.id:
+                    if phase_state.orders_outcome == "nmr":
+                        statuses.append("nmr")
+                    break
+        return statuses
 
     def to_representation(self, instance):
         with tracer.start_as_current_span("game.serializers.to_representation") as span:

--- a/service/game/tests/test_game_list_status_fields.py
+++ b/service/game/tests/test_game_list_status_fields.py
@@ -1,0 +1,248 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from common.constants import GameStatus, PhaseStatus
+from game.models import Game
+from phase.models import PhaseState
+
+
+LIST_URL = reverse("game-list")
+
+
+def _get_game_data(response, game_id):
+    results = response.data.get("results", response.data)
+    for item in results:
+        if item["id"] == game_id:
+            return item
+    return None
+
+
+@pytest.fixture
+def active_game_with_member_and_phase_state(
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Status Field Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    member = game.members.create(user=primary_user, nation=classical_england_nation)
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase_state = phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_confirmed=False,
+    )
+    return game, member, phase, phase_state
+
+
+@pytest.mark.django_db
+def test_order_status_orders_required(
+    authenticated_client,
+    active_game_with_member_and_phase_state,
+):
+    game, member, phase, phase_state = active_game_with_member_and_phase_state
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] == "orders_required"
+
+
+@pytest.mark.django_db
+def test_order_status_orders_submitted(
+    authenticated_client,
+    active_game_with_member_and_phase_state,
+):
+    game, member, phase, phase_state = active_game_with_member_and_phase_state
+    phase_state.orders_confirmed = True
+    phase_state.save()
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] == "orders_submitted"
+
+
+@pytest.mark.django_db
+def test_order_status_no_orders_required(
+    authenticated_client,
+    active_game_with_member_and_phase_state,
+):
+    game, member, phase, phase_state = active_game_with_member_and_phase_state
+    phase_state.has_possible_orders = False
+    phase_state.orders_confirmed = False
+    phase_state.save()
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] == "no_orders_required"
+
+
+@pytest.mark.django_db
+def test_order_status_null_for_pending_game(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+):
+    game = Game.objects.create(
+        name="Pending Status Field Test Game",
+        variant=classical_variant,
+        status=GameStatus.PENDING,
+    )
+    game.members.create(user=primary_user)
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] is None
+
+
+@pytest.mark.django_db
+def test_order_status_null_when_not_a_member(
+    authenticated_client,
+    db,
+    secondary_user,
+    classical_variant,
+    classical_france_nation,
+):
+    game = Game.objects.create(
+        name="Non-Member Status Field Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    other_member = game.members.create(user=secondary_user, nation=classical_france_nation)
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase.phase_states.create(
+        member=other_member,
+        has_possible_orders=True,
+        orders_confirmed=False,
+    )
+
+    response = authenticated_client.get(LIST_URL)
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] is None
+
+
+@pytest.mark.django_db
+def test_member_status_includes_civil_disorder(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Civil Disorder Status Field Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    member = game.members.create(
+        user=primary_user,
+        nation=classical_england_nation,
+        civil_disorder=True,
+    )
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase.phase_states.create(member=member, has_possible_orders=True)
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert "civil_disorder" in data["member_status"]
+
+
+@pytest.mark.django_db
+def test_member_status_includes_nmr(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="NMR Status Field Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    member = game.members.create(user=primary_user, nation=classical_england_nation)
+
+    prev_phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.COMPLETED,
+        ordinal=1,
+    )
+    prev_phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_outcome=PhaseState.OrdersOutcome.NMR,
+    )
+
+    current_phase = game.phases.create(
+        variant=classical_variant,
+        season="Fall",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=2,
+    )
+    current_phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_confirmed=False,
+    )
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert "nmr" in data["member_status"]
+
+
+@pytest.mark.django_db
+def test_member_status_empty_when_no_flags(
+    authenticated_client,
+    active_game_with_member_and_phase_state,
+):
+    game, member, phase, phase_state = active_game_with_member_and_phase_state
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["member_status"] == []


### PR DESCRIPTION
## Summary

Closes #744.

- **Backend**: two new computed fields on `GameListSerializer` and `GameRetrieveSerializer`:
  - `order_status` — `"orders_required"` / `"orders_submitted"` / `"no_orders_required"` / `null` (null for non-active games or non-members)
  - `member_status` — list of `"civil_disorder"` and/or `"nmr"` flags for the current user
- **Frontend**: `GameCard` renders coloured, icon-labelled badges with tooltips for each status value; mock fixtures and legacy mocks updated with the new fields

## How it works

**`order_status`** inspects the current user's `PhaseState` on the active phase:
- `orders_confirmed=True` → `orders_submitted`
- `has_possible_orders=False` → `no_orders_required`
- otherwise → `orders_required`

**`member_status`** checks:
- `member.civil_disorder` → `"civil_disorder"`
- most recent completed phase's `orders_outcome == "nmr"` → `"nmr"`

Both methods work entirely off data already prefetched by `with_list_data()` — no additional queries.

## Badges

| Status | Colour | Icon | Tooltip |
|---|---|---|---|
| Orders required | Amber | Clock | "You have orders to submit this phase" |
| Orders submitted | Green | Check | "Your orders are submitted for this phase" |
| Not required | Green | Check | "No orders are needed from you this phase" |
| NMR | Red (destructive) | AlertTriangle | "No Move Received — you did not submit orders in the previous phase" |
| CD | Red (destructive) | UserX | "Civil Disorder — your units are acting without orders" |

## Screenshots

Mobile (390×844):
![Home screen mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/5205e925d98981ea46ee4ffee5d506c38b258698/shots/home-mobile.png)

Desktop (1280×800):
![Home screen desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/5205e925d98981ea46ee4ffee5d506c38b258698/shots/home-desktop.png)

## Test plan

- [x] 8 new backend tests covering all `order_status` and `member_status` values
- [x] 7 new `GameCard` frontend tests covering all badge states
- [x] TypeScript build clean (only pre-existing Firebase errors in cloud env)
- [x] Visual: amber "Required" badge visible on all three active game fixtures

https://claude.ai/code/session_016ZxfosRkpbJkcAHiT3HjDH

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZxfosRkpbJkcAHiT3HjDH)_