### PR TITLE
Add backlog hygiene: stale bot, WIP limits, issue template, CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Report via Discord
     url: https://discord.gg/2TkZbBRPW
     about: Don't have a GitHub account? Report the bug in our Discord server.
+  - name: Not sure what to build? Start a Discussion first
+    url: https://github.com/johnpooch/diplicity-react/discussions/new
+    about: If the right approach is not yet obvious, open a Discussion before creating an issue.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,26 @@
+name: Task / Feature
+description: A new feature, improvement, or task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What are we doing? (1–2 sentences)
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why / background. Leave blank if the goal is self-explanatory.
+    validations:
+      required: false
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach
+      description: How we will do it. Leave blank unless an approach has been discussed.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,6 @@
 - [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
 - [ ] Tests cover the change
 - [ ] `RELEASE_NOTES.md` updated if the change is user-facing
+- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)
+
+<!-- Project target: ≤ 5 open PRs. If opening this pushes the count over, close or merge another first. -->

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 7
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: pinned,no-stale
+          exempt-pr-labels: pinned,no-stale
+          stale-issue-message: >
+            This issue has been inactive for 7 days and will be closed in 7 days
+            unless there is further activity. If it is still relevant, leave a
+            comment or update it. Add the `pinned` label to exempt it permanently.
+          stale-pr-message: >
+            This pull request has been inactive for 7 days and will be closed in
+            7 days unless there is further activity. If it is still being worked
+            on, push a commit or leave a comment. Add the `pinned` label to exempt
+            it permanently.
+          close-issue-message: >
+            Closing due to inactivity. If this is still relevant, reopen it with
+            updated context.
+          close-pr-message: >
+            Closing due to inactivity. If you would like to continue this work,
+            reopen the PR or open a new one.

--- a/.github/workflows/wip-limits.yml
+++ b/.github/workflows/wip-limits.yml
@@ -1,0 +1,64 @@
+name: WIP limits
+
+on:
+  pull_request:
+    types: [opened, reopened]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-pr-limit:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open`
+            });
+            const count = data.total_count;
+
+            if (count > 5) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: [
+                  '> [!WARNING]',
+                  `> **WIP limit exceeded.** There are now **${count} open pull requests** — the project target is 5 or fewer.`,
+                  '>',
+                  '> Please close or merge an existing PR before continuing with this one.'
+                ].join('\n')
+              });
+            }
+
+  check-issue-limit:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open`
+            });
+            const count = data.total_count;
+
+            if (count > 10) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: [
+                  '> [!WARNING]',
+                  `> **WIP limit exceeded.** There are now **${count} open issues** — the project target is 10 or fewer.`,
+                  '>',
+                  '> Please close or resolve an existing issue before opening new ones.'
+                ].join('\n')
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,26 @@ The Team ID is `G76UP8FNMS` (stored in `.env` as `CAPACITOR_IOS_TEAM_ID`).
 
 ---
 
+## GitHub Workflow
+
+See `CONTRIBUTING.md` for the full contributor guidelines. Key points for Claude sessions:
+
+### WIP limits
+
+The project enforces soft limits: **5 open PRs** and **10 open issues**. A GitHub Actions bot warns (via comment) when these are exceeded — treat the warning as a prompt to close something before continuing. Before opening a new PR, check the current count.
+
+### GitHub Discussions for ambiguous work
+
+Before creating an issue for work where the right approach is not yet obvious, open a [GitHub Discussion](https://github.com/johnpooch/diplicity-react/discussions). Once the approach is agreed, create a focused issue that captures it in the `## Approach` section.
+
+Skip the Discussion if both the goal and the approach are already clear.
+
+### Issue format
+
+Issues follow the three-section format enforced by the `create-issue` skill: **Goal** (always), **Context** (when useful), **Approach** (when discussed). Do not add acceptance criteria, implementation checklists, or sub-issues. If work is too large for one PR, split into two separate issues.
+
+---
+
 # Frontend Development (`/packages/web/`)
 
 ## Architecture Overview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This is a hobby project maintained by two contributors. Keeping the backlog small is deliberate — a small backlog reduces noise, prevents stale work accumulating, and makes it easier to stay focused on what is actually in flight.
+Keeping the backlog small is deliberate — a small backlog reduces noise, prevents stale work accumulating, and makes it easier to stay focused on what is actually in flight.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+This is a hobby project maintained by two contributors. Keeping the backlog small is deliberate — a small backlog reduces noise, prevents stale work accumulating, and makes it easier to stay focused on what is actually in flight.
+
+---
+
+## WIP limits
+
+| Thing | Limit |
+|-------|-------|
+| Open pull requests | 5 |
+| Open issues | 10 |
+
+A bot will warn (via comment) when a new PR or issue pushes the count over the limit. The warning is advisory — it does not block — but treat it as a prompt to close or merge something before continuing.
+
+---
+
+## Stale policy
+
+Issues and pull requests that receive no activity for **7 days** are labelled `stale`. After a further **7 days** of inactivity they are closed automatically.
+
+Any activity (commit, comment, review) resets the timer. Use the `pinned` label to exempt something from the stale bot permanently.
+
+---
+
+## Issues
+
+### When to open a Discussion first
+
+If the right approach to a piece of work is not obvious — if you need to weigh options or explore trade-offs before knowing what to build — open a [GitHub Discussion](https://github.com/johnpooch/diplicity-react/discussions) first. Once the approach is clear, create a focused issue that captures the agreed approach.
+
+Skip the Discussion if both the goal and the approach are already clear.
+
+### Issue format
+
+Issues follow a tight three-section format:
+
+```
+## Goal
+
+What we are doing. (1–2 sentences, always present.)
+
+## Context
+
+Why / background. Include only when genuinely useful — omit the section entirely if the goal is self-explanatory.
+
+## Approach
+
+How we will do it. Include only when an approach was actually discussed. Never invent one.
+```
+
+Keep issues short. A single `## Goal` section is a complete issue.
+
+### What not to include
+
+- Sub-issues or epics. If work is too large for one issue, split it into two or three focused, independent issues.
+- Acceptance criteria checklists.
+- Out of scope sections.
+- Tasks or implementation breakdowns.
+- A list of files to change.
+
+### Scope
+
+Each issue should result in a **single, reviewable PR**. If a change touches both backend and frontend and the pieces are independently deployable, split into two issues: one for the backend, one for the frontend.
+
+---
+
+## Pull requests
+
+### Before opening
+
+Check the current open PR count. If it is already at 5, close or merge something first.
+
+### Checklist
+
+- [ ] This PR does one thing — no unrelated fixes or drive-by cleanups
+- [ ] Tests cover the change
+- [ ] `RELEASE_NOTES.md` updated if the change is user-facing
+- [ ] Screenshots embedded in the PR description for any visual changes
+- [ ] For PRs of any significant complexity: `/review-pr` run in Claude Code and findings addressed
+
+### Screenshots
+
+If a PR changes anything a user can see, include screenshots. See the Playwright screenshot workflow in `CLAUDE.md`.


### PR DESCRIPTION
## What this PR does

Introduces lightweight backlog hygiene tooling and documentation to keep open PRs ≤ 5 and open issues ≤ 10. Motivated by 68 open issues and 16 open PRs creating noise that makes it hard to focus.

## Changes

### `.github/workflows/stale.yml`
Runs daily. Marks issues and PRs stale after **7 days** of inactivity, closes them after **14 days** total. Exempt labels: `pinned`, `no-stale`.

### `.github/workflows/wip-limits.yml`
Fires on every new PR or issue. Posts a warning comment if open PRs exceed 5 or open issues exceed 10. Advisory only — does not block.

### `.github/ISSUE_TEMPLATE/task.yml`
New "Task / Feature" template mirroring the `create-issue` skill format: **Goal** (required), **Context** (optional), **Approach** (optional). Replaces blank issues (which were already disabled).

### `.github/ISSUE_TEMPLATE/config.yml`
Adds a "Start a Discussion first" link to the template chooser, surfaced when the approach to a piece of work isn't obvious yet.

### `.github/PULL_REQUEST_TEMPLATE.md`
Adds a screenshots checklist item and a WIP limit reminder comment.

### `CONTRIBUTING.md`
New file. Documents WIP limits, stale policy, issue format (Goal / Context / Approach), and PR standards in one place.

### `CLAUDE.md`
New "GitHub Workflow" section covering WIP limits, when to open a GitHub Discussion before an issue, and the issue format. Points to `CONTRIBUTING.md` for the full guidelines.

## Notes

- No visual changes.
- The stale bot's 7-day window resets on any activity (commit, comment, review), so active PRs and issues won't be touched.
- The WIP limit warnings are comments only — they do not prevent opening, merging, or closing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCJtkz8BPtGhe55d3XqSse

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCJtkz8BPtGhe55d3XqSse)_