### PR TITLE
Suppress order_status and member_status for sandbox games

### DIFF
--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -149,6 +149,8 @@ class GameListSerializer(serializers.Serializer):
         allow_null=True,
     ))
     def get_order_status(self, obj):
+        if obj.sandbox:
+            return None
         user = self.context["request"].user
         if not user.is_authenticated or obj.status != "active":
             return None
@@ -166,8 +168,11 @@ class GameListSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.ListField(
         child=serializers.ChoiceField(choices=["nmr", "civil_disorder"]),
+        allow_null=True,
     ))
     def get_member_status(self, obj):
+        if obj.sandbox:
+            return None
         user = self.context["request"].user
         if not user.is_authenticated:
             return []
@@ -303,6 +308,8 @@ class GameRetrieveSerializer(serializers.Serializer):
         allow_null=True,
     ))
     def get_order_status(self, obj):
+        if obj.sandbox:
+            return None
         user = self.context["request"].user
         if not user.is_authenticated or obj.status != "active":
             return None
@@ -320,8 +327,11 @@ class GameRetrieveSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.ListField(
         child=serializers.ChoiceField(choices=["nmr", "civil_disorder"]),
+        allow_null=True,
     ))
     def get_member_status(self, obj):
+        if obj.sandbox:
+            return None
         user = self.context["request"].user
         if not user.is_authenticated:
             return []

--- a/service/game/tests/test_game_list_status_fields.py
+++ b/service/game/tests/test_game_list_status_fields.py
@@ -246,3 +246,73 @@ def test_member_status_empty_when_no_flags(
     data = _get_game_data(response, game.id)
     assert data is not None
     assert data["member_status"] == []
+
+
+@pytest.mark.django_db
+def test_order_status_null_for_sandbox_game(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Sandbox Order Status Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+        sandbox=True,
+        private=True,
+    )
+    member = game.members.create(user=primary_user, nation=classical_england_nation)
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase.phase_states.create(member=member, has_possible_orders=True, orders_confirmed=False)
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["order_status"] is None
+
+
+@pytest.mark.django_db
+def test_member_status_null_for_sandbox_game(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Sandbox Member Status Test Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+        sandbox=True,
+        private=True,
+    )
+    member = game.members.create(
+        user=primary_user,
+        nation=classical_england_nation,
+        civil_disorder=True,
+    )
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase.phase_states.create(member=member, has_possible_orders=True)
+
+    response = authenticated_client.get(LIST_URL + "?mine=1")
+    assert response.status_code == status.HTTP_200_OK
+    data = _get_game_data(response, game.id)
+    assert data is not None
+    assert data["member_status"] is None


### PR DESCRIPTION
## Summary

- `get_order_status` now returns `null` when `game.sandbox` is `True`
- `get_member_status` now returns `null` when `game.sandbox` is `True`
- Updated `@extend_schema_field` on `get_member_status` to declare `allow_null=True` so the OpenAPI schema reflects the nullable type
- Two new tests cover the sandbox cases in `test_game_list_status_fields.py`

Both changes apply to `GameListSerializer` and `GameRetrieveSerializer`.

Closes #752

## No visual changes

This is a backend-only change. The frontend already handles `null` for `order_status`; once `member_status` can also be `null`, any frontend badge logic consuming it should guard accordingly (no frontend changes were needed for the suppression behaviour itself).

---
_Generated by [Claude Code](https://claude.ai/code/session_015RpmZuUrBurWT1yCDYsrXo)_