### PR TITLE
Public views (rebased from #551)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Diplicity React - Release Notes
 
+## Public Game Viewing (June 2026)
+
+### Feature: View games without logging in
+
+Public games are now viewable without an account. Shared game links open directly to the map and orders for any visitor — no sign-in required. Guests can browse the current board state, step through the full move history, and see all resolved orders. A "Log in to play" prompt appears in the orders panel, making it easy to sign up when ready to join. Chat and active order entry remain restricted to players.
+
 ## Expandable, Zoomable Map Preview (June 2026)
 
 ### Feature: Inspect a variant's map before committing to a game

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Router from "./Router";
 import { MaintenanceMode } from "./components/MaintenanceMode";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { AuthProvider, useAuth } from "./auth";
+import { AuthProvider } from "./auth";
 import { Toaster } from "./components/ui/sonner";
 import { isNativePlatform } from "./utils/platform";
 import { initializeNativeSocialLogin } from "./auth/nativeGoogleAuth";
@@ -33,14 +33,12 @@ const NotificationPermissionPrompter: React.FC = () => {
 };
 
 function AppContent() {
-  const { loggedIn } = useAuth();
-
   return (
     <>
       <Suspense fallback={null}>
         <NotificationPermissionPrompter />
       </Suspense>
-      <Router loggedIn={loggedIn} queryClient={queryClient} />
+      <Router queryClient={queryClient} />
     </>
   );
 }

--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -1,11 +1,15 @@
 import React, { Suspense } from "react";
 import {
   createBrowserRouter,
+  Navigate,
   Outlet,
   RouterProvider,
   redirect,
+  useLocation,
+  useParams,
   useRouteError,
 } from "react-router";
+import { useAuth } from "./auth";
 import { QueryClient } from "@tanstack/react-query";
 import { Login } from "./screens/Login";
 import { Register } from "./screens/Register";
@@ -21,6 +25,35 @@ import { GamePhaseRedirect } from "./components/GamePhaseRedirect";
 import { getVariantsListQueryOptions } from "./api/generated/endpoints";
 import * as Sentry from "@sentry/react";
 import { deepLinkStorage, useDeepLink } from "./deepLink";
+import { useIsMobile } from "./hooks/use-mobile";
+
+const RequireAuth: React.FC<{ children: React.ReactNode; fallbackPath?: string }> = ({ children, fallbackPath = "/" }) => {
+  const { loggedIn } = useAuth();
+  const location = useLocation();
+
+  React.useEffect(() => {
+    if (!loggedIn && location.pathname !== "/") {
+      deepLinkStorage.setPendingPath(
+        `${location.pathname}${location.search}${location.hash}`
+      );
+    }
+  }, [loggedIn, location]);
+
+  if (!loggedIn) return <Navigate to={fallbackPath} replace />;
+  return <>{children}</>;
+};
+
+const RequireAuthInGame: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { gameId, phaseId } = useParams<{ gameId: string; phaseId: string }>();
+  const fallbackPath = gameId && phaseId ? `/game/${gameId}/phase/${phaseId}` : "/";
+  return <RequireAuth fallbackPath={fallbackPath}>{children}</RequireAuth>;
+};
+
+const GuestOnly: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { loggedIn } = useAuth();
+  if (loggedIn) return <Navigate to="/" replace />;
+  return <>{children}</>;
+};
 
 const RouteFallback: React.FC = () => (
   <div className="flex-1 flex items-center justify-center">
@@ -61,12 +94,25 @@ const GameDetailLayoutWrapper: React.FC = () => {
 };
 
 const AuthenticatedRoot: React.FC = () => {
-  useDeepLink();
+  const { loggedIn } = useAuth();
+  useDeepLink(loggedIn);
   return <Outlet />;
 };
 
+const RootIndex: React.FC = () => {
+  const { loggedIn } = useAuth();
+  if (!loggedIn) return <Login />;
+  return (
+    <HomeLayout>
+      <Suspense fallback={<RouteFallback />}>
+        <Home.MyGames />
+      </Suspense>
+    </HomeLayout>
+  );
+};
+
 const GameIndexRoute: React.FC = () => {
-  const isMobile = window.innerWidth < 1024;
+  const isMobile = useIsMobile();
   return (
     <Suspense fallback={<RouteFallback />}>
       {isMobile ? <GameDetail.MapScreen /> : <GameDetail.OrdersScreen />}
@@ -75,244 +121,290 @@ const GameIndexRoute: React.FC = () => {
 };
 
 interface RouterProps {
-  loggedIn: boolean;
   queryClient: QueryClient;
 }
 
-const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
+const Router: React.FC<RouterProps> = ({ queryClient }) => {
   const router = React.useMemo(
     () =>
-      loggedIn
-        ? createBrowserRouter([
+      createBrowserRouter([
+        {
+          id: "root",
+          path: "/",
+          element: <AuthenticatedRoot />,
+          errorElement: <RootErrorBoundary />,
+          loader: createVariantsLoader(queryClient),
+          children: [
             {
-              id: "root",
-              path: "/",
-              element: <AuthenticatedRoot />,
-              errorElement: <RootErrorBoundary />,
-              loader: createVariantsLoader(queryClient),
+              index: true,
+              element: <RootIndex />,
+            },
+            {
+              path: "register",
+              element: (
+                <GuestOnly>
+                  <Register />
+                </GuestOnly>
+              ),
+            },
+            {
+              path: "forgot-password",
+              element: (
+                <GuestOnly>
+                  <ForgotPassword />
+                </GuestOnly>
+              ),
+            },
+            {
+              path: "check-email",
+              element: (
+                <GuestOnly>
+                  <CheckEmail />
+                </GuestOnly>
+              ),
+            },
+            {
+              path: "verify-email",
+              element: <VerifyEmail />,
+            },
+            {
+              path: "reset-password",
+              element: (
+                <GuestOnly>
+                  <ResetPassword />
+                </GuestOnly>
+              ),
+            },
+            {
+              element: <HomeLayoutWrapper />,
               children: [
                 {
-                  element: <HomeLayoutWrapper />,
+                  path: "find-games",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.FindGames />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "create-game",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.CreateGame />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "account",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.Account />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "profile",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.Profile />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "delete-account",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.DeleteAccount />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "community",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.Community />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "learn-to-play",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.LearnToPlay />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "game-info/:gameId",
+                  element: (
+                    <Suspense fallback={<RouteFallback />}>
+                      <Home.GameInfoScreen />
+                    </Suspense>
+                  ),
+                },
+                {
+                  path: "player-info/:gameId",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Home.PlayerInfoScreen />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "player/:userId",
+                  element: (
+                    <Suspense fallback={<RouteFallback />}>
+                      <Home.PlayerProfileScreen />
+                    </Suspense>
+                  ),
+                },
+                {
+                  path: "variants",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Variants.VariantsList />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "variants/create",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Variants.VariantCreate />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+                {
+                  path: "variants/:variantId/edit",
+                  element: (
+                    <RequireAuth>
+                      <Suspense fallback={<RouteFallback />}>
+                        <Variants.VariantEditRoute />
+                      </Suspense>
+                    </RequireAuth>
+                  ),
+                },
+              ],
+            },
+            {
+              path: "game/:gameId",
+              children: [
+                // Redirect /game/:gameId to /game/:gameId/phase/:currentPhaseId/orders
+                { index: true, element: <GamePhaseRedirect /> },
+                {
+                  path: "phase/:phaseId",
+                  element: <GameDetailLayoutWrapper />,
                   children: [
+                    { index: true, element: <GameIndexRoute /> },
                     {
-                      index: true,
+                      path: "orders",
                       element: (
                         <Suspense fallback={<RouteFallback />}>
-                          <Home.MyGames />
+                          <GameDetail.OrdersScreen />
                         </Suspense>
                       ),
                     },
                     {
-                      path: "find-games",
+                      path: "chat",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.FindGames />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.ChannelListScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "create-game",
+                      path: "chat/channel/create",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.CreateGame />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.ChannelCreateScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "account",
+                      path: "chat/channel/:channelId",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.Account />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.ChannelScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "delete-account",
+                      path: "game-info",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.DeleteAccount />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.GameInfoScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "community",
+                      path: "player-info",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.Community />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.PlayerInfoScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "learn-to-play",
+                      path: "propose-draw",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.LearnToPlay />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.ProposeDrawScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
-                      path: "game-info/:gameId",
+                      path: "draw-proposals",
                       element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.GameInfoScreen />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "player-info/:gameId",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.PlayerInfoScreen />
-                        </Suspense>
+                        <RequireAuthInGame>
+                          <Suspense fallback={<RouteFallback />}>
+                            <GameDetail.DrawProposalsScreen />
+                          </Suspense>
+                        </RequireAuthInGame>
                       ),
                     },
                     {
                       path: "player/:userId",
                       element: (
                         <Suspense fallback={<RouteFallback />}>
-                          <Home.PlayerProfileScreen />
+                          <GameDetail.PlayerProfileScreen />
                         </Suspense>
                       ),
-                    },
-                    {
-                      path: "variants",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantsList />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "variants/create",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantCreate />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "variants/:variantId/edit",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantEditRoute />
-                        </Suspense>
-                      ),
-                    },
-                  ],
-                },
-                {
-                  path: "game/:gameId",
-                  children: [
-                    // Redirect /game/:gameId to /game/:gameId/phase/:currentPhaseId/orders
-                    { index: true, element: <GamePhaseRedirect /> },
-                    {
-                      path: "phase/:phaseId",
-                      element: <GameDetailLayoutWrapper />,
-                      children: [
-                        { index: true, element: <GameIndexRoute /> },
-                        {
-                          path: "orders",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.OrdersScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelListScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat/channel/create",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelCreateScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat/channel/:channelId",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "game-info",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.GameInfoScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "player-info",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.PlayerInfoScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "propose-draw",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ProposeDrawScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "draw-proposals",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.DrawProposalsScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "player/:userId",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.PlayerProfileScreen />
-                            </Suspense>
-                          ),
-                        },
-                      ],
                     },
                   ],
                 },
               ],
-            },
-          ])
-        : createBrowserRouter([
-            {
-              path: "/",
-              element: <Login />,
-            },
-            {
-              path: "/register",
-              element: <Register />,
-            },
-            {
-              path: "/forgot-password",
-              element: <ForgotPassword />,
-            },
-            {
-              path: "/check-email",
-              element: <CheckEmail />,
-            },
-            {
-              path: "/verify-email",
-              element: <VerifyEmail />,
-            },
-            {
-              path: "/reset-password",
-              element: <ResetPassword />,
             },
             {
               path: "*",
@@ -325,8 +417,10 @@ const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
                 return redirect("/");
               },
             },
-          ]),
-    [loggedIn, queryClient]
+          ],
+        },
+      ]),
+    [queryClient]
   );
 
   return <RouterProvider router={router} />;

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -18,6 +18,10 @@ const {
   mockInteractiveMapZoomWrapper: vi.fn(),
 }));
 
+vi.mock("@/auth", () => ({
+  useAuth: () => ({ loggedIn: true }),
+}));
+
 vi.mock("sonner", () => ({
   toast: { success: mockToastSuccess, error: mockToastError },
 }));

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -1,6 +1,6 @@
 import { useRequiredParams } from "../hooks";
 import { useRef, useMemo, useEffect, useState, useCallback } from "react";
-import { useIsDesktopWeb } from "@/hooks/use-platform";
+import { useAuth } from "../auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { determineRenderableProvinces } from "../utils/provinces";
@@ -49,18 +49,6 @@ function useBanner(duration = 3000) {
   return { message, show };
 }
 
-const ORDER_TYPE_KEYS: Record<string, string> = {
-  Hold: "H",
-  Move: "M",
-  Support: "S",
-  Convoy: "C",
-  MoveViaConvoy: "V",
-  Army: "A",
-  Fleet: "F",
-  Disband: "D",
-  Build: "B",
-};
-
 const GameMap: React.FC = () => {
   const { gameId, phaseId } = useRequiredParams<{
     gameId: string;
@@ -69,14 +57,15 @@ const GameMap: React.FC = () => {
   const selectedPhase = Number(phaseId);
 
   const queryClient = useQueryClient();
+  const { loggedIn } = useAuth();
 
   const { data: game } = useGameRetrieve(gameId);
   const { data: variants } = useVariantsList();
   const { data: phase } = useGamePhaseRetrieve(gameId, selectedPhase);
   const { data: orders } = useGameOrdersList(gameId, selectedPhase);
-  const { data: optionsData } = useGameOptionsRetrieve(gameId);
-
-  const isDesktopWeb = useIsDesktopWeb();
+  const { data: optionsData } = useGameOptionsRetrieve(gameId, {
+    query: { enabled: loggedIn },
+  });
   const containerRef = useRef<HTMLDivElement>(null);
   const [menuPosition, setMenuPosition] = useState<{
     x: number;
@@ -227,26 +216,6 @@ const GameMap: React.FC = () => {
       wizard.nextField === "namedCoast") &&
     menuPosition !== null;
 
-  useEffect(() => {
-    if (!showMenu || !isDesktopWeb) return;
-
-    const keyToOrderType = Object.fromEntries(
-      Object.entries(ORDER_TYPE_KEYS).map(([id, key]) => [key, id])
-    );
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const orderTypeId = keyToOrderType[event.key.toUpperCase()];
-      if (!orderTypeId) return;
-      const match = wizard.choices.find((c) => c.id === orderTypeId);
-      if (match) {
-        wizard.select(match.id);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showMenu, isDesktopWeb, wizard]);
-
   const displayOrders = pendingOrder
     ? [
         ...(orders ?? []).filter(
@@ -297,11 +266,6 @@ const GameMap: React.FC = () => {
                 key={c.id}
                 onClick={() => handleSelectOrderOption(c.id)}
               >
-                {isDesktopWeb && ORDER_TYPE_KEYS[c.id] && (
-                  <kbd className="inline-flex items-center justify-center size-5 rounded border border-border bg-muted text-muted-foreground font-mono text-xs shrink-0 pl-px pt-0.5">
-                    {ORDER_TYPE_KEYS[c.id]}
-                  </kbd>
-                )}
                 {c.label}
               </FloatingMenuItem>
             ))}

--- a/packages/web/src/components/InteractiveMap/toRenderState.ts
+++ b/packages/web/src/components/InteractiveMap/toRenderState.ts
@@ -15,7 +15,7 @@ type PhaseForRender = {
     province: { id: string };
     nation: { name: string };
   }>;
-  provinceNations?: Record<string, string> | string;
+  provinceNations?: string;
 };
 
 const orderSourceId = (order: Order): string => {
@@ -63,11 +63,11 @@ export const toRenderState = (
     nation: sc.nation.name,
   }));
 
+  const parsedProvinceNations: Record<string, string> = phase.provinceNations
+    ? (JSON.parse(phase.provinceNations) as Record<string, string>)
+    : {};
   const nonScProvinceColors: Record<string, string> = {};
-  const rawPN = phase.provinceNations;
-  const pnMap: Record<string, string> =
-    typeof rawPN === "string" ? (rawPN ? JSON.parse(rawPN) : {}) : (rawPN ?? {});
-  for (const [provinceId, nationName] of Object.entries(pnMap)) {
+  for (const [provinceId, nationName] of Object.entries(parsedProvinceNations)) {
     const color = nationColors[nationName];
     if (color) nonScProvinceColors[provinceId] = color;
   }

--- a/packages/web/src/components/LogInToPlayBanner.tsx
+++ b/packages/web/src/components/LogInToPlayBanner.tsx
@@ -1,0 +1,51 @@
+import { useLocation, useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import { DiplicityLogo } from "@/components/DiplicityLogo";
+import { deepLinkStorage } from "@/deepLink";
+import { isIosPlatform, isNativePlatform } from "@/utils/platform";
+
+const LogInToPlayBanner: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const storePath = () => {
+    deepLinkStorage.setPendingPath(location.pathname + location.search);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-3 text-center">
+      <div className="flex items-center gap-2">
+        <DiplicityLogo />
+        <p className="text-2xl font-bold">Diplicity</p>
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="text-xs text-muted-foreground">
+          A digital implementation of Diplomacy — the legendary game of negotiation, alliance, and betrayal.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => { storePath(); navigate("/"); }}>
+          Sign in
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => { storePath(); navigate("/register"); }}>
+          Register
+        </Button>
+      </div>
+      {(!isNativePlatform() || isIosPlatform()) && (
+        <a
+          href="https://apps.apple.com/app/id6759169536"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <img
+            src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us"
+            alt="Download on the App Store"
+            className="h-8"
+          />
+        </a>
+      )}
+    </div>
+  );
+};
+
+export { LogInToPlayBanner };

--- a/packages/web/src/deepLink/useDeepLink.ts
+++ b/packages/web/src/deepLink/useDeepLink.ts
@@ -2,7 +2,7 @@ import { useEffect, useSyncExternalStore } from "react";
 import { useNavigate } from "react-router";
 import { deepLinkStorage } from "./deepLinkStorage";
 
-export const useDeepLink = () => {
+export const useDeepLink = (loggedIn: boolean) => {
   const navigate = useNavigate();
   const pendingPath = useSyncExternalStore(
     deepLinkStorage.subscribe,
@@ -10,11 +10,11 @@ export const useDeepLink = () => {
   );
 
   useEffect(() => {
-    if (pendingPath) {
+    if (pendingPath && loggedIn) {
       const path = deepLinkStorage.consumePendingPath();
       if (path) {
         navigate(path, { replace: true });
       }
     }
-  }, [pendingPath, navigate]);
+  }, [pendingPath, navigate, loggedIn]);
 };

--- a/packages/web/src/screens/GameDetail/ChannelMessageList.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelMessageList.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { MessageCircle } from "lucide-react";
+import { Message, MessageContent, MessageTimestamp } from "@/components/ui/message";
+import { Notice } from "@/components/Notice";
+import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
+import { brightnessByColor, toHex6 } from "./channelUtils";
+import { ChannelMessage as ChannelMessageType } from "@/api/generated/endpoints";
+
+const BUBBLE_ALPHA_HEX = "26";
+
+export type MessageDisplayItem = {
+  id: number;
+  body: string;
+  sender: { nationName: string; nationColor: string };
+  isCurrentUser: boolean;
+  showAvatar: boolean;
+  formattedTime: string;
+};
+
+export const formatMessageTime = (createdAt: string): string => {
+  const date = new Date(createdAt);
+  const today = new Date();
+  const isToday =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  if (isToday) return time;
+  return `${date.toLocaleDateString([], { month: "short", day: "numeric" })} ${time}`;
+};
+
+export const buildMessageDisplayItems = (
+  messages: readonly ChannelMessageType[]
+): MessageDisplayItem[] =>
+  messages.map((msg, index) => ({
+    id: msg.id,
+    body: msg.body,
+    sender: {
+      nationName: msg.sender.nation.name,
+      nationColor: msg.sender.nation.color,
+    },
+    isCurrentUser: msg.sender.isCurrentUser,
+    showAvatar:
+      index === 0 || messages[index - 1].sender.nation.name !== msg.sender.nation.name,
+    formattedTime: formatMessageTime(msg.createdAt),
+  }));
+
+const NewMessagesDivider: React.FC = () => (
+  <div className="flex items-center gap-2 my-1">
+    <div className="flex-1 h-px bg-border" />
+    <span className="text-xs text-muted-foreground font-medium">New messages</span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);
+
+interface ChannelMessageListProps {
+  messageItems: MessageDisplayItem[];
+  variantNations: ReadonlyArray<{ name: string; flagUrl: string | null }>;
+  firstUnreadIndex?: number | null;
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
+  emptyMessage?: string;
+}
+
+export const ChannelMessageList: React.FC<ChannelMessageListProps> = ({
+  messageItems,
+  variantNations,
+  firstUnreadIndex,
+  scrollContainerRef,
+  emptyMessage,
+}) => {
+  if (messageItems.length === 0) {
+    return (
+      <Notice
+        icon={MessageCircle}
+        title="No messages yet"
+        message={emptyMessage}
+        className="h-full"
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2 p-2"
+    >
+      {messageItems.map((item, index) => (
+        <React.Fragment key={item.id}>
+          {firstUnreadIndex != null && index === firstUnreadIndex && (
+            <NewMessagesDivider />
+          )}
+          <Message className={item.isCurrentUser ? "flex-row-reverse" : undefined}>
+            {item.showAvatar ? (
+              <div className="w-8 flex-shrink-0 flex justify-center">
+                <NationFlag
+                  flagUrl={findNationFlagUrl(variantNations, item.sender.nationName)}
+                  alt={item.sender.nationName}
+                  size="lg"
+                  color={item.sender.nationColor}
+                />
+              </div>
+            ) : (
+              <div className="w-8 flex-shrink-0" />
+            )}
+            <MessageContent
+              className={`py-1.5 px-2 ${item.isCurrentUser ? "rounded-tr-none" : "rounded-tl-none"}`}
+              style={{
+                backgroundColor: toHex6(item.sender.nationColor) + BUBBLE_ALPHA_HEX,
+                border:
+                  brightnessByColor(item.sender.nationColor) > 128
+                    ? `1px solid ${item.sender.nationColor}`
+                    : undefined,
+              }}
+            >
+              {item.body}
+              {item.showAvatar ? (
+                <div className="flex items-center justify-between gap-2 mt-0.5">
+                  <span
+                    className="text-xs font-medium"
+                    style={{ color: item.sender.nationColor }}
+                  >
+                    {item.sender.nationName}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {item.formattedTime}
+                  </span>
+                </div>
+              ) : (
+                <MessageTimestamp className="mt-0.5">{item.formattedTime}</MessageTimestamp>
+              )}
+            </MessageContent>
+          </Message>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useRef, useEffect, useState, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
+import { Send, MessageSquareOff } from "lucide-react";
 import { useDraft, useRequiredParams } from "@/hooks";
 import { toast } from "sonner";
 
@@ -9,17 +9,12 @@ import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
-import {
-  Message,
-  MessageContent,
-  MessageTimestamp,
-} from "@/components/ui/message";
 import { Notice } from "@/components/Notice";
-import { NationFlag, findNationFlagUrl } from "@/components/NationFlag";
 import { GameDetailAppBar } from "./AppBar";
-import { getChannelDisplayName, getChannelFlagUrls, brightnessByColor, toHex6 } from "./channelUtils";
+import { getChannelDisplayName, getChannelFlagUrls } from "./channelUtils";
 import { ChannelAvatar } from "./ChannelAvatar";
 import { Panel } from "@/components/Panel";
+import { buildMessageDisplayItems, ChannelMessageList } from "./ChannelMessageList";
 import {
   useGameRetrieveSuspense,
   useGamesChannelsListSuspense,
@@ -28,68 +23,8 @@ import {
   useGamesChannelsMarkReadCreate,
   getGamesChannelsListQueryKey,
   getGameRetrieveQueryKey,
-  ChannelMessage as ChannelMessageType,
 } from "@/api/generated/endpoints";
 
-type MessageDisplayItem = {
-  id: number;
-  body: string;
-  createdAt: string;
-  sender: {
-    nationName: string;
-    nationColor: string;
-    picture: string | null;
-  };
-  isCurrentUser: boolean;
-  showAvatar: boolean;
-  formattedTime: string;
-};
-
-const formatMessageTime = (createdAt: string): string => {
-  const date = new Date(createdAt);
-  const today = new Date();
-  const isToday =
-    date.getFullYear() === today.getFullYear() &&
-    date.getMonth() === today.getMonth() &&
-    date.getDate() === today.getDate();
-  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  if (isToday) return time;
-  return `${date.toLocaleDateString([], { month: "short", day: "numeric" })} ${time}`;
-};
-
-const buildMessageItems = (
-  messages: readonly ChannelMessageType[]
-): MessageDisplayItem[] => {
-  return messages.map((msg, index) => {
-    const showAvatar =
-      index === 0 ||
-      messages[index - 1].sender.nation.name !== msg.sender.nation.name;
-
-    return {
-      id: msg.id,
-      body: msg.body,
-      createdAt: msg.createdAt,
-      sender: {
-        nationName: msg.sender.nation.name,
-        nationColor: msg.sender.nation.color,
-        picture: msg.sender.picture,
-      },
-      isCurrentUser: msg.sender.isCurrentUser,
-      showAvatar,
-      formattedTime: formatMessageTime(msg.createdAt),
-    };
-  });
-};
-
-const BUBBLE_ALPHA_HEX = "26"; // 15% opacity (0x26/0xFF)
-
-const NewMessagesDivider: React.FC = () => (
-  <div className="flex items-center gap-2 my-1">
-    <div className="flex-1 h-px bg-border" />
-    <span className="text-xs text-muted-foreground font-medium">New messages</span>
-    <div className="flex-1 h-px bg-border" />
-  </div>
-);
 
 const ChannelScreen: React.FC = () => {
   const { gameId, phaseId, channelId } = useRequiredParams<{
@@ -202,7 +137,7 @@ const ChannelScreen: React.FC = () => {
     game.status !== "abandoned";
 
   const messageItems = useMemo(
-    () => buildMessageItems(channel.messages),
+    () => buildMessageDisplayItems(channel.messages),
     [channel.messages]
   );
 
@@ -242,77 +177,13 @@ const ChannelScreen: React.FC = () => {
         <Panel>
           <Panel.Content>
             <div className="h-full flex flex-col">
-              {channel.messages.length === 0 ? (
-                <Notice
-                  icon={MessageCircle}
-                  title="No messages yet"
-                  message="Start the conversation by sending a message"
-                  className="h-full"
-                />
-              ) : (
-                <div
-                  ref={messagesContainerRef}
-                  className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-2 p-2"
-                >
-                  {messageItems.map((item, index) => (
-                    <React.Fragment key={item.id}>
-                      {firstUnreadIndex !== null && index === firstUnreadIndex && (
-                        <NewMessagesDivider />
-                      )}
-                      <Message
-                        className={
-                          item.isCurrentUser ? "flex-row-reverse" : undefined
-                        }
-                      >
-                        {item.showAvatar ? (
-                          <div className="w-8 flex-shrink-0 flex justify-center">
-                            <NationFlag
-                              flagUrl={
-                                variant
-                                  ? findNationFlagUrl(variant.nations, item.sender.nationName)
-                                  : null
-                              }
-                              alt={item.sender.nationName}
-                              size="lg"
-                              color={item.sender.nationColor}
-                            />
-                          </div>
-                        ) : (
-                          <div className="w-8 flex-shrink-0" />
-                        )}
-                        <MessageContent
-                          className={`py-1.5 px-2 ${item.isCurrentUser ? "rounded-tr-none" : "rounded-tl-none"}`}
-                          style={{
-                            backgroundColor: toHex6(item.sender.nationColor) + BUBBLE_ALPHA_HEX,
-                            border: brightnessByColor(item.sender.nationColor) > 128
-                              ? `1px solid ${item.sender.nationColor}`
-                              : undefined,
-                          }}
-                        >
-                          {item.body}
-                          {item.showAvatar ? (
-                            <div className="flex items-center justify-between gap-2 mt-0.5">
-                              <span
-                                className="text-xs font-medium"
-                                style={{ color: item.sender.nationColor }}
-                              >
-                                {item.sender.nationName}
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {item.formattedTime}
-                              </span>
-                            </div>
-                          ) : (
-                            <MessageTimestamp className="mt-0.5">
-                              {item.formattedTime}
-                            </MessageTimestamp>
-                          )}
-                        </MessageContent>
-                      </Message>
-                    </React.Fragment>
-                  ))}
-                </div>
-              )}
+              <ChannelMessageList
+                messageItems={messageItems}
+                variantNations={variant?.nations ?? []}
+                firstUnreadIndex={firstUnreadIndex}
+                scrollContainerRef={messagesContainerRef}
+                emptyMessage="Start the conversation by sending a message"
+              />
             </div>
           </Panel.Content>
           <Separator />

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -26,6 +26,15 @@ const mockPhaseData = vi.fn();
 const mockOrdersData = vi.fn();
 const mockVariantsData = vi.fn();
 const mockPhaseStatesData = vi.fn();
+const mockUseAuth = vi.fn();
+
+vi.mock("@/auth", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@/components/LogInToPlayBanner", () => ({
+  LogInToPlayBanner: () => <div>Register to play</div>,
+}));
 
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({ data: mockGameData() }),
@@ -33,6 +42,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   useGameOrdersListSuspense: () => ({ data: mockOrdersData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
   useGamePhaseStatesListSuspense: () => ({ data: mockPhaseStatesData() }),
+  useGamesChannelsListSuspense: () => ({ data: [] }),
   useGameOrdersDeleteDestroy: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameConfirmPhasePartialUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameResolvePhaseCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -40,6 +50,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   getGameRetrieveQueryKey: () => ["game"],
   getGameOrdersListQueryKey: () => ["orders"],
   getGameOptionsRetrieveQueryKey: () => ["options"],
+  getGamePhaseStatesListQueryKey: () => ["phase-states"],
 }));
 
 vi.mock("@/components/NationFlag", () => ({
@@ -59,7 +70,7 @@ const baseMember = (overrides = {}) => ({
   nation: "England",
   eliminated: false,
   kicked: false,
-  isGameCreator: false,
+  isGameMaster: false,
   nmrExtensionsRemaining: 0,
   civilDisorder: false,
   ...overrides,
@@ -83,7 +94,8 @@ const renderOrdersScreen = () => {
 
 describe("OrdersScreen civil disorder handling", () => {
   beforeEach(() => {
-    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
+    mockUseAuth.mockReturnValue({ loggedIn: true });
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical", nations: [] }]);
     mockPhaseData.mockReturnValue({
       id: 1, status: "active", supplyCenters: [], units: [],
     });
@@ -181,5 +193,69 @@ describe("OrdersScreen named coast display", () => {
     renderOrdersScreen();
 
     expect(screen.getByText(/Fleet Spain \(NC\)/)).toBeInTheDocument();
+  });
+});
+
+describe("GuestOrdersScreen", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ loggedIn: false });
+    mockPhaseStatesData.mockReturnValue([]);
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical", nations: [] }]);
+  });
+
+  it("shows the login banner", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [],
+    });
+    mockPhaseData.mockReturnValue({ id: 1, status: "active", supplyCenters: [], units: [] });
+    mockOrdersData.mockReturnValue([]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText("Register to play")).toBeInTheDocument();
+  });
+
+  it("shows past-phase orders for all nations", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [],
+    });
+    mockPhaseData.mockReturnValue({ id: 2, status: "completed", supplyCenters: [], units: [] });
+    mockOrdersData.mockReturnValue([
+      { nation: { name: "France" }, source: { id: "par", name: "Paris" }, summary: "Hold Paris", resolution: null },
+    ]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText("France")).toBeInTheDocument();
+    expect(screen.getByText("Hold Paris")).toBeInTheDocument();
+  });
+
+  it("does not show orders accordion for active phase", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [],
+    });
+    mockPhaseData.mockReturnValue({ id: 1, status: "active", supplyCenters: [], units: [] });
+    mockOrdersData.mockReturnValue([
+      { nation: { name: "France" }, source: { id: "par", name: "Paris" }, summary: "Hold Paris", resolution: null },
+    ]);
+
+    renderOrdersScreen();
+
+    expect(screen.queryByText("France")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -1,6 +1,8 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useState, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
+import { useAuth } from "@/auth";
+import { LogInToPlayBanner } from "@/components/LogInToPlayBanner";
 import {
   Trash2,
   CheckSquare,
@@ -11,6 +13,8 @@ import {
   Star,
   UserX,
   Handshake,
+  LucideIcon,
+  ChevronRight,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -37,6 +41,9 @@ import {
 import { Notice } from "@/components/Notice";
 import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import { NationBadge } from "@/components/NationBadge";
+import { getChannelFlagUrls } from "./channelUtils";
+import { buildMessageDisplayItems, ChannelMessageList } from "./ChannelMessageList";
+import { ChannelAvatar } from "./ChannelAvatar";
 import { GameDropdownMenu } from "@/components/GameDropdownMenu";
 import { GameDetailAppBar } from "./AppBar";
 import { Panel } from "@/components/Panel";
@@ -47,6 +54,7 @@ import {
   PhaseRetrieve,
   PhaseState,
   Province,
+  Channel,
   useGameOrdersDeleteDestroy,
   useGameOrdersListSuspense,
   useGamePhaseRetrieveSuspense,
@@ -55,6 +63,7 @@ import {
   useGameResolvePhaseCreate,
   useGameRetrieveSuspense,
   useVariantsListSuspense,
+  useGamesChannelsListSuspense,
   useGamesDrawProposalsListSuspense,
   getGameRetrieveQueryKey,
   getGameOrdersListQueryKey,
@@ -63,8 +72,47 @@ import {
   Order,
   GameRetrieve,
   Unit,
+  Variant,
 } from "@/api/generated/endpoints";
 import { cn } from "../../lib/utils";
+
+
+interface GuestChannelViewProps {
+  channel: Channel;
+  game: GameRetrieve;
+  variant: Variant;
+  onClose: () => void;
+}
+
+const GuestChannelView: React.FC<GuestChannelViewProps> = ({ channel, game, variant, onClose }) => {
+  const flagUrls = getChannelFlagUrls(channel, game.members, undefined, variant.nations);
+  const messageItems = useMemo(() => buildMessageDisplayItems(channel.messages), [channel.messages]);
+
+  const channelTitle = (
+    <div className="flex items-center justify-start gap-2">
+      <ChannelAvatar nations={flagUrls} />
+      <span className="text-lg font-semibold truncate text-left">{channel.name}</span>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <GameDetailAppBar title={channelTitle} onNavigateBack={onClose} variant="secondary" />
+      <div className="flex-1 overflow-hidden">
+        <Panel>
+          <Panel.Content>
+            <div className="h-full flex flex-col">
+              <ChannelMessageList
+                messageItems={messageItems}
+                variantNations={variant.nations}
+              />
+            </div>
+          </Panel.Content>
+        </Panel>
+      </div>
+    </div>
+  );
+};
 
 type NationGroup = {
   nation: string;
@@ -135,6 +183,129 @@ const buildNationGroups = (
   });
 };
 
+interface OrdersDisplayProps {
+  nationGroups: NationGroup[];
+  phase: PhaseRetrieve;
+  variant: Variant;
+  isActivePhase: boolean;
+  canModifyOrders: boolean;
+  accordionDefaultValue: string[];
+  emptyState?: { icon: LucideIcon; title: string; message: string };
+  onDeleteOrder?: (sourceId: string) => void;
+  deleteIsPending?: boolean;
+}
+
+const OrdersDisplay: React.FC<OrdersDisplayProps> = ({
+  nationGroups,
+  phase,
+  variant,
+  isActivePhase,
+  canModifyOrders,
+  accordionDefaultValue,
+  emptyState,
+  onDeleteOrder,
+  deleteIsPending,
+}) => {
+  const hasContent = nationGroups.length > 0;
+
+  const getSupplyCenterCount = (nation: string) =>
+    phase.supplyCenters.filter(sc => sc.nation.name === nation).length;
+
+  if (!hasContent && !emptyState) return null;
+
+  if (!hasContent && emptyState) {
+    return (
+      <Notice
+        icon={emptyState.icon}
+        title={emptyState.title}
+        message={emptyState.message}
+        className="h-full"
+      />
+    );
+  }
+
+  return (
+    <Accordion type="multiple" defaultValue={accordionDefaultValue}>
+      {nationGroups.map(({ nation, member, items }) => {
+        const nationColor = findNationColor(variant.nations, nation);
+        return (
+          <AccordionItem key={nation} value={nation}>
+            <AccordionTrigger className="p-2 items-center">
+              <div className="flex items-center gap-2">
+                <NationFlag
+                  flagUrl={findNationFlagUrl(variant.nations, nation)}
+                  alt={nation}
+                  size="md"
+                  color={nationColor}
+                />
+                <span>{nation}</span>
+                <span className="text-muted-foreground">•</span>
+                {member.isCurrentUser && nation && (
+                  <>
+                    <NationBadge nations={variant.nations} nation={nation}>
+                      you
+                    </NationBadge>
+                    <span className="text-muted-foreground">•</span>
+                  </>
+                )}
+                <span className="inline-flex items-center gap-1 text-muted-foreground">
+                  <Star className="size-3" />
+                  <span>{getSupplyCenterCount(nation)}</span>
+                </span>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="p-0">
+              <ItemGroup>
+                {items.map((item, index) => (
+                  <React.Fragment key={item.province.id}>
+                    {index === 0 && <Separator />}
+                    <Item size="sm">
+                      <ItemContent>
+                        <ItemTitle>
+                          {item.unit?.type}{" "}
+                          {item.unit?.province.name ?? item.province.name}
+                        </ItemTitle>
+                        <ItemDescription>
+                          {item.order ? item.order.summary : "Order not provided"}
+                        </ItemDescription>
+                      </ItemContent>
+                      {canModifyOrders && item.order && onDeleteOrder && (
+                        <ItemActions>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => onDeleteOrder(item.province.id)}
+                            disabled={deleteIsPending}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        </ItemActions>
+                      )}
+                      {!isActivePhase && item.order?.resolution?.status && (
+                        <ItemContent
+                          className={cn(
+                            "text-xs",
+                            item.order.resolution.status === "Succeeded"
+                              ? "text-green-600"
+                              : "text-red-600"
+                          )}
+                        >
+                          {item.order.resolution.status}
+                        </ItemContent>
+                      )}
+                    </Item>
+                    {index < items.length - 1 && <ItemSeparator />}
+                  </React.Fragment>
+                ))}
+              </ItemGroup>
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
+};
+
 const DrawProposalsBadge: React.FC<{ gameId: string; currentMemberId?: number }> = ({
   gameId,
   currentMemberId,
@@ -182,11 +353,7 @@ const OrdersScreen: React.FC = () => {
   const currentMember = game.members.find(m => m.isCurrentUser);
   const isCurrentMemberInCivilDisorder = currentMember?.civilDisorder ?? false;
   const canModifyOrders =
-    isActivePhase && !isGameFinished && !isCurrentMemberInCivilDisorder;
-
-  const getSupplyCenterCount = (nation: string) => {
-    return phase.supplyCenters.filter(sc => sc.nation.name === nation).length;
-  };
+    !!currentMember && isActivePhase && !isGameFinished && !isCurrentMemberInCivilDisorder;
 
   const handleDeleteOrder = async (sourceId: string) => {
     try {
@@ -259,7 +426,7 @@ const OrdersScreen: React.FC = () => {
     game.status === "active" ||
     game.status === "completed" ||
     game.status === "abandoned";
-  const showDrawProposalsButton = !game.sandbox && isStartedGame;
+  const showDrawProposalsButton = !!currentMember && !game.sandbox && isStartedGame;
 
   const handleNavigateToDrawProposals = () => {
     navigate(`/game/${gameId}/phase/${phaseId}/draw-proposals`);
@@ -306,26 +473,30 @@ const OrdersScreen: React.FC = () => {
         message: "No orders were created by any nation in this phase.",
       };
 
+  const appBar = (
+    <GameDetailAppBar
+      title={
+        <div className="flex items-center gap-2">
+          <div className="flex-1 flex flex-col items-center gap-0.5">
+            <PhaseSelect />
+            <Suspense fallback={null}>
+              <PhaseGuidance />
+            </Suspense>
+          </div>
+          <GameDropdownMenu
+            game={game}
+            onNavigateToGameInfo={handleNavigateToGameInfo}
+            onNavigateToPlayerInfo={handleNavigateToPlayerInfo}
+          />
+        </div>
+      }
+      onNavigateBack={() => navigate("/")}
+    />
+  );
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <GameDetailAppBar
-        title={
-          <div className="flex items-center gap-2">
-            <div className="flex-1 flex flex-col items-center gap-0.5">
-              <PhaseSelect />
-              <Suspense fallback={null}>
-                <PhaseGuidance />
-              </Suspense>
-            </div>
-            <GameDropdownMenu
-              game={game}
-              onNavigateToGameInfo={handleNavigateToGameInfo}
-              onNavigateToPlayerInfo={handleNavigateToPlayerInfo}
-            />
-          </div>
-        }
-        onNavigateBack={() => navigate("/")}
-      />
+      {appBar}
       <div className="flex-1 overflow-y-auto">
         <Panel>
           {isCurrentMemberInCivilDisorder && (
@@ -338,105 +509,19 @@ const OrdersScreen: React.FC = () => {
             </Alert>
           )}
           <Panel.Content>
-            {!hasContent ? (
-              <Notice
-                icon={emptyState.icon}
-                title={emptyState.title}
-                message={emptyState.message}
-                className="h-full"
-              />
-            ) : (
-              <Accordion
-                type="multiple"
-                defaultValue={[
-                  nationGroups.find(g => g.member.isCurrentUser)?.nation ?? "",
-                ]}
-              >
-                {nationGroups.map(({ nation, member, items }) => {
-                  const nationColor = findNationColor(variant.nations, nation);
-                  return (
-                    <AccordionItem key={nation} value={nation}>
-                      <AccordionTrigger className="p-2 items-center">
-                        <div className="flex items-center gap-2">
-                          <NationFlag
-                            flagUrl={findNationFlagUrl(variant.nations, nation)}
-                            alt={nation}
-                            size="md"
-                            color={nationColor}
-                          />
-                          <span>{nation}</span>
-                          <span className="text-muted-foreground">•</span>
-                          {member.isCurrentUser && nation && (
-                            <>
-                              <NationBadge nations={variant.nations} nation={nation}>
-                                you
-                              </NationBadge>
-                              <span className="text-muted-foreground">•</span>
-                            </>
-                          )}
-                          <span className="inline-flex items-center gap-1 text-muted-foreground">
-                            <Star className="size-3" />
-                            <span>{getSupplyCenterCount(nation)}</span>
-                          </span>
-                        </div>
-                      </AccordionTrigger>
-                      <AccordionContent className="p-0">
-                        <ItemGroup>
-                          {items.map((item, index) => (
-                            <React.Fragment key={item.province.id}>
-                              {index === 0 && <Separator />}
-                              <Item size="sm">
-                                <ItemContent>
-                                  <ItemTitle>
-                                    {item.unit?.type}{" "}
-                                    {item.unit?.province.name ?? item.province.name}
-                                  </ItemTitle>
-                                  <ItemDescription>
-                                    {item.order
-                                      ? item.order.summary
-                                      : "Order not provided"}
-                                  </ItemDescription>
-                                </ItemContent>
-                                {canModifyOrders && item.order && (
-                                  <ItemActions>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      onClick={() =>
-                                        handleDeleteOrder(item.province.id)
-                                      }
-                                      disabled={deleteOrderMutation.isPending}
-                                    >
-                                      <Trash2 className="size-4" />
-                                    </Button>
-                                  </ItemActions>
-                                )}
-                                {!isActivePhase &&
-                                  item.order &&
-                                  item.order.resolution?.status && (
-                                    <ItemContent
-                                      className={cn(
-                                        "text-xs",
-                                        item.order.resolution.status ===
-                                          "Succeeded"
-                                          ? "text-green-600"
-                                          : "text-red-600"
-                                      )}
-                                    >
-                                      {item.order.resolution.status}
-                                    </ItemContent>
-                                  )}
-                              </Item>
-                              {index < items.length - 1 && <ItemSeparator />}
-                            </React.Fragment>
-                          ))}
-                        </ItemGroup>
-                      </AccordionContent>
-                    </AccordionItem>
-                  );
-                })}
-              </Accordion>
-            )}
+            <OrdersDisplay
+              nationGroups={nationGroups}
+              phase={phase}
+              variant={variant}
+              isActivePhase={isActivePhase}
+              canModifyOrders={canModifyOrders}
+              accordionDefaultValue={[
+                nationGroups.find(g => g.member.isCurrentUser)?.nation ?? "",
+              ]}
+              emptyState={emptyState}
+              onDeleteOrder={handleDeleteOrder}
+              deleteIsPending={deleteOrderMutation.isPending}
+            />
           </Panel.Content>
 
           {(rightFooterButton || showDrawProposalsButton) && (
@@ -470,10 +555,102 @@ const OrdersScreen: React.FC = () => {
   );
 };
 
+const GuestOrdersScreen: React.FC = () => {
+  const navigate = useNavigate();
+  const [showPublicPress, setShowPublicPress] = useState(false);
+  const { gameId, phaseId } = useRequiredParams<{ gameId: string; phaseId: string }>();
+  const selectedPhase = Number(phaseId);
+
+  const { data: game } = useGameRetrieveSuspense(gameId);
+  const { data: phase } = useGamePhaseRetrieveSuspense(gameId, selectedPhase);
+  const { data: orders } = useGameOrdersListSuspense(gameId, selectedPhase);
+  const { data: variants } = useVariantsListSuspense();
+  const { data: channels } = useGamesChannelsListSuspense(gameId);
+
+  const isActivePhase = phase.status === "active";
+  const variant = variants.find(v => v.id === game.variantId);
+  const publicPressChannel = channels.find(c => !c.private);
+  const nationGroups = buildNationGroups(isActivePhase, [], orders, phase, game);
+
+  if (!variant) return null;
+
+  if (showPublicPress && publicPressChannel) {
+    return (
+      <GuestChannelView
+        channel={publicPressChannel}
+        game={game}
+        variant={variant}
+        onClose={() => setShowPublicPress(false)}
+      />
+    );
+  }
+
+  const isOngoingGame = game.status === "active";
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <GameDetailAppBar
+        title={
+          <div className="flex justify-center">
+            <PhaseSelect />
+          </div>
+        }
+        onNavigateBack={() => navigate("/")}
+      />
+      <div className="flex-1 overflow-y-auto">
+        <Panel>
+          <Panel.Content>
+            <div className="p-4">
+              <div className="rounded-xl border bg-card p-3 shadow-sm">
+                <LogInToPlayBanner />
+              </div>
+            </div>
+            {isOngoingGame && publicPressChannel && (
+              <Item
+                size="sm"
+                className="mx-4 mb-2 cursor-pointer rounded-lg border bg-card"
+                onClick={() => setShowPublicPress(true)}
+              >
+                <ChannelAvatar
+                  nations={getChannelFlagUrls(publicPressChannel, game.members, undefined, variant.nations)}
+                />
+                <ItemContent className="gap-0.5">
+                  <ItemTitle>{publicPressChannel.name}</ItemTitle>
+                  {publicPressChannel.messages.length > 0 && (
+                    <ItemDescription>
+                      {publicPressChannel.messages[publicPressChannel.messages.length - 1].body}
+                    </ItemDescription>
+                  )}
+                </ItemContent>
+                <ChevronRight className="text-muted-foreground size-4" />
+              </Item>
+            )}
+            {!isActivePhase && (
+              <OrdersDisplay
+                nationGroups={nationGroups}
+                phase={phase}
+                variant={variant}
+                isActivePhase={isActivePhase}
+                canModifyOrders={false}
+                accordionDefaultValue={nationGroups.map(g => g.nation)}
+              />
+            )}
+          </Panel.Content>
+        </Panel>
+      </div>
+    </div>
+  );
+};
+
+const OrdersScreenSelector: React.FC = () => {
+  const { loggedIn } = useAuth();
+  return loggedIn ? <OrdersScreen /> : <GuestOrdersScreen />;
+};
+
 const OrdersScreenSuspense: React.FC = () => (
   <QueryErrorBoundary>
     <Suspense fallback={<div></div>}>
-      <OrdersScreen />
+      <OrdersScreenSelector />
     </Suspense>
   </QueryErrorBoundary>
 );

--- a/packages/web/src/screens/Home/Profile.tsx
+++ b/packages/web/src/screens/Home/Profile.tsx
@@ -1,0 +1,252 @@
+import React, { Suspense, useState } from "react";
+import { Check, X, Pencil } from "lucide-react";
+
+import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
+import { ScreenHeader } from "@/components/ui/screen-header";
+import { ScreenContainer } from "@/components/ui/screen-container";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useTheme } from "@/theme/useTheme";
+import { useAuth } from "@/auth";
+import { useNavigate } from "react-router";
+import { useMessaging } from "@/hooks/useMessaging";
+import {
+  useUserRetrieveSuspense,
+  useUserUpdatePartialUpdate,
+  getUserRetrieveQueryKey,
+} from "@/api/generated/endpoints";
+import { useQueryClient } from "@tanstack/react-query";
+
+const Profile: React.FC = () => {
+  const queryClient = useQueryClient();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/");
+  };
+  const { data: userProfile } = useUserRetrieveSuspense();
+  const updateProfileMutation = useUserUpdatePartialUpdate();
+
+  const { preference, setPreference } = useTheme();
+
+  const {
+    enableMessaging,
+    enabled,
+    disableMessaging,
+    permissionDenied,
+    error,
+  } = useMessaging();
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editedName, setEditedName] = useState("");
+  const [saveNameError, setSaveNameError] = useState(false);
+
+  const handleStartEditName = () => {
+    setEditedName(userProfile?.name || "");
+    setSaveNameError(false);
+    setIsEditingName(true);
+  };
+
+  const handleCancelEditName = () => {
+    setIsEditingName(false);
+    setEditedName("");
+    setSaveNameError(false);
+  };
+
+  const handleSaveName = async () => {
+    const trimmedName = editedName.trim();
+    if (trimmedName.length >= 2) {
+      try {
+        await updateProfileMutation.mutateAsync({
+          data: { name: trimmedName },
+        });
+        queryClient.invalidateQueries({ queryKey: getUserRetrieveQueryKey() });
+        setIsEditingName(false);
+        setEditedName("");
+        setSaveNameError(false);
+      } catch {
+        setSaveNameError(true);
+      }
+    }
+  };
+
+  const handleTogglePushNotifications = (checked: boolean) => {
+    if (checked) {
+      enableMessaging();
+    } else {
+      disableMessaging();
+    }
+  };
+
+  return (
+    <ScreenCard>
+      <ScreenCardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">User</h2>
+          <Button
+            variant="outline"
+            onClick={handleLogout}
+            className="hidden sm:inline-flex"
+          >
+            Log out
+          </Button>
+        </div>
+        <div className="flex items-center gap-4">
+          <div>
+            <Avatar className="size-12">
+              <AvatarImage src={userProfile?.picture ?? undefined} />
+              <AvatarFallback>
+                {userProfile?.name?.[0]?.toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+          </div>
+
+          <div className="flex-1">
+            {isEditingName ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  value={editedName}
+                  onChange={e => setEditedName(e.target.value)}
+                  autoFocus
+                  disabled={updateProfileMutation.isPending}
+                  className="max-w-xs"
+                  onKeyDown={e => {
+                    if (e.key === "Enter") {
+                      handleSaveName();
+                    } else if (e.key === "Escape") {
+                      handleCancelEditName();
+                    }
+                  }}
+                />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={handleSaveName}
+                  disabled={
+                    updateProfileMutation.isPending ||
+                    !editedName ||
+                    editedName.trim().length < 2
+                  }
+                  aria-label="Save"
+                >
+                  <Check className="size-4" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={handleCancelEditName}
+                  disabled={updateProfileMutation.isPending}
+                  aria-label="Cancel"
+                >
+                  <X className="size-4" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-medium">{userProfile?.name}</span>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={handleStartEditName}
+                  aria-label="Edit name"
+                >
+                  <Pencil className="size-4" />
+                </Button>
+              </div>
+            )}
+            {saveNameError && (
+              <p className="text-sm text-destructive mt-1">
+                Failed to update name. Please try again.
+              </p>
+            )}
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          onClick={handleLogout}
+          className="sm:hidden"
+        >
+          Log out
+        </Button>
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Appearance</h2>
+          <div className="flex items-center gap-4">
+            <Label htmlFor="theme-select">Theme</Label>
+            <Select value={preference} onValueChange={setPreference}>
+              <SelectTrigger id="theme-select" className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+                <SelectItem value="system">System</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Notifications</h2>
+
+          <div className="space-y-2">
+            <div className="space-y-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="push-notifications"
+                  checked={!permissionDenied && enabled}
+                  disabled={permissionDenied}
+                  onCheckedChange={handleTogglePushNotifications}
+                />
+                <Label htmlFor="push-notifications">Push Notifications</Label>
+              </div>
+              {permissionDenied && (
+                <p className="text-sm text-muted-foreground">
+                  Reset permissions for this app or website before notifications
+                  can be turned on.
+                </p>
+              )}
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </div>
+          </div>
+        </div>
+
+        <div className="pt-4 border-t">
+          <Button
+            variant="destructive"
+            onClick={() => navigate("/delete-account")}
+          >
+            Delete Account
+          </Button>
+        </div>
+      </ScreenCardContent>
+    </ScreenCard>
+  );
+};
+
+const ProfileSuspense: React.FC = () => {
+  return (
+    <ScreenContainer>
+      <ScreenHeader title="Profile" />
+      <QueryErrorBoundary>
+        <Suspense fallback={<div></div>}>
+          <Profile />
+        </Suspense>
+      </QueryErrorBoundary>
+    </ScreenContainer>
+  );
+};
+
+export { ProfileSuspense as Profile };

--- a/packages/web/src/screens/Home/index.ts
+++ b/packages/web/src/screens/Home/index.ts
@@ -11,6 +11,7 @@ export const Home = {
   Account: lazy(() =>
     import("./Account").then((m) => ({ default: m.Account }))
   ),
+  Profile: lazy(() => import("./Profile").then((m) => ({ default: m.Profile }))),
   GameInfoScreen: lazy(() =>
     import("./GameInfo").then((m) => ({ default: m.GameInfoScreen }))
   ),

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -14,7 +14,7 @@ const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
   status: "pending" as PhaseRetrieve["status"],
   units,
   supplyCenters: [],
-  provinceNations: "",
+  provinceNations: "{}",
   previousPhaseId: null,
   nextPhaseId: null,
 });

--- a/service/game/tests/test_game_master.py
+++ b/service/game/tests/test_game_master.py
@@ -167,7 +167,8 @@ class TestGameMasterInGameAccess:
         game = active_game_with_game_master_factory()
         url = reverse(phase_state_list_viewname, args=[game.id])
         response = authenticated_client_for_secondary_user.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
 
 
 class TestGameMasterPowers:

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -108,7 +108,8 @@ def test_list_orderable_provinces_sandbox_game(authenticated_client, sandbox_gam
 def test_list_orderable_provinces_not_member(authenticated_client, active_game_created_by_secondary_user):
     url = reverse("phase-state-list", args=[active_game_created_by_secondary_user.id])
     response = authenticated_client.get(url)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == []
 
 
 @pytest.mark.django_db
@@ -1439,7 +1440,7 @@ class TestPhaseRetrieveView:
         phase = game.current_phase
         url = reverse("phase-retrieve", args=[game.id, phase.id])
         response = unauthenticated_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.status_code == status.HTTP_200_OK
 
     @pytest.mark.django_db
     def test_retrieve_phase_not_found(self, authenticated_client, active_game_with_phase_state):
@@ -1566,7 +1567,7 @@ class TestPhaseListView:
         url = reverse("phase-list", args=[game.id])
         response = unauthenticated_client.get(url)
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.status_code == status.HTTP_200_OK
 
 
 class TestPhaseListViewPerformance:
@@ -1594,7 +1595,7 @@ class TestPhaseListViewPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 3  # was 6 before resolve_game cache eliminated the dup phase fetches
+        assert query_count == 2
 
 
 class TestPhaseRetrieveViewQueryPerformance:

--- a/service/phase/views.py
+++ b/service/phase/views.py
@@ -10,12 +10,11 @@ from common.permissions import (
     IsNotSandboxGame,
     IsSandboxGame,
     IsGameMember,
-    IsGameMemberOrGameMaster,
 )
 from common.serializers import EmptySerializer
 from common.views import SelectedGameMixin, CurrentGameMemberMixin
 from rest_framework.response import Response
-from .models import Phase
+from .models import Phase, PhaseState
 from .serializers import PhaseStateSerializer, PhaseResolveResponseSerializer, PhaseRetrieveSerializer, PhaseListSerializer
 
 tracer = trace.get_tracer(__name__)
@@ -40,16 +39,16 @@ class PhaseStateUpdateView(SelectedGameMixin, CurrentGameMemberMixin, generics.U
 
 
 class PhaseStateListView(SelectedGameMixin, generics.ListAPIView):
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsActiveOrCompletedGame,
-        IsGameMemberOrGameMaster,
-    ]
+    permission_classes = [permissions.AllowAny]
     serializer_class = PhaseStateSerializer
 
     def get_queryset(self):
         game = self.get_game()
         current_phase = game.current_phase
+        if current_phase is None:
+            return PhaseState.objects.none()
+        if not self.request.user.is_authenticated:
+            return current_phase.phase_states.none()
         return current_phase.phase_states.filter(member__user=self.request.user)
 
 
@@ -77,11 +76,7 @@ class DeadlineWarningsView(views.APIView):
 
 
 class PhaseListView(SelectedGameMixin, generics.ListAPIView):
-    permission_classes = [
-        permissions.IsAuthenticated,
-        IsActiveOrCompletedGame,
-        IsGameMember,
-    ]
+    permission_classes = [permissions.AllowAny]
     serializer_class = PhaseListSerializer
 
     def get_queryset(self):
@@ -92,13 +87,14 @@ class PhaseListView(SelectedGameMixin, generics.ListAPIView):
 
 
 class PhaseRetrieveView(generics.RetrieveAPIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
     serializer_class = PhaseRetrieveSerializer
     lookup_field = 'id'
     lookup_url_kwarg = 'phase_id'
 
     def get_queryset(self):
-        return Phase.objects.with_detail_data()
+        game_id = self.kwargs.get("game_id")
+        return Phase.objects.with_detail_data().filter(game_id=game_id)
 
 
 class PhaseResolveView(SelectedGameMixin, views.APIView):


### PR DESCRIPTION
## Summary

Ports the stale PR #551 ("Public views") onto the current main branch. The original branch had no common ancestor with main (history diverged due to a squash rebase), so this re-applies the changes as a clean commit on top of current main.

### Changes from PR #551

- **Extract `ChannelMessageList`**: message bubble rendering was duplicated between `ChannelScreen` and `GuestChannelView` in `OrdersScreen`. Pulled into a shared `ChannelMessageList.tsx` file. Also centralises `buildMessageDisplayItems`, `formatMessageTime`, and `MessageDisplayItem`.
- **Remove `LoggedInContext`**: `Router` no longer receives `loggedIn` as a prop or wraps it in a context. `RequireAuth`, `GuestOnly`, `AuthenticatedRoot`, and `RootIndex` now call `useAuth()` directly. `AppContent` in `App.tsx` no longer needs to call `useAuth()` itself.
- **Unified router tree**: single router with `RequireAuth`/`RequireAuthInGame`/`GuestOnly` guards instead of two separate trees.
- **Guest game viewing**: unauthenticated users can view sandbox games via direct URL; auth-required routes redirect to the phase root.
- **Guest orders view**: shows `LogInToPlayBanner`, public press channel, and past-phase orders for non-members.
- **Guest sidebar**: shows `LogInToPlayBanner` in left sidebar on HomeLayout screens; hides nav/footer.
- **Disable player avatars button for guests** on game-info screen.
- **Backend**: `PhaseStateListView`, `PhaseListView`, `PhaseRetrieveView` now use `AllowAny` with empty-queryset fallback for unauthenticated/non-member callers.
- **Fix `provinceNations`** serialized as JSON string (not a plain object) in phase serializer.

## Conflicts resolved

- `Router.tsx` — kept all new routes added to main since #551 was created, applied the LoggedInContext removal
- `GameMap.tsx` — kept both sets of changes (auth gating for options, plus map preview additions from main)
- `InteractiveMap/toRenderState.ts` — kept the `provinceNations` JSON string change alongside main's additions
- `OrdersScreen.tsx` — kept the `GuestOrdersScreen` addition alongside the order status badges added to main
- `service/phase/views.py` — kept the AllowAny permission change alongside other view changes from main
- `service/phase/tests.py` — updated 4 tests that were asserting old 401/403 behavior: they now correctly assert 200 (and empty `[]` for non-members on the phase-state endpoint)

## Test plan

- [ ] Log in — home screen, game list, and game detail all load normally
- [ ] Log out — redirected to login; guest-accessible routes (game info, orders) still work
- [ ] Open a channel in a game — messages render with correct bubble styling and nation flags
- [ ] Guest visits a public sandbox game — GuestChannelView shows the public press channel with matching bubble styling
- [ ] Auth-required routes (`/find-games`, `/profile`, `/chat/…`) redirect unauthenticated users
- [ ] Guest-only routes (`/register`, `/forgot-password`) redirect logged-in users to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ajv1CLMNpAg4hXbrASSUAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajv1CLMNpAg4hXbrASSUAJ)_