### PR TITLE
Fix My Games crash when member_status is null for sandbox games

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Diplicity React - Release Notes
 
+## My Games No Longer Crashes With Sandbox Games (June 2026)
+
+### Fix: My Games screen could fail to load for players with sandbox games
+
+The My Games screen could show a "Something went wrong" error and fail to load for players
+whose game list included a sandbox game. The game cards now render correctly regardless of a
+game's member status.
+
 ## Player Reliability Requirements on Games (June 2026)
 
 ### Feature: Require a minimum reliability tier to join a game

--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -377,6 +377,11 @@ export interface GameListCurrentPhase {
   readonly remainingTime: number;
 }
 
+/**
+ * * `orders_required` - orders_required
+ * `orders_submitted` - orders_submitted
+ * `no_orders_required` - no_orders_required
+ */
 export type OrderStatusEnum =
   (typeof OrderStatusEnum)[keyof typeof OrderStatusEnum];
 
@@ -440,6 +445,9 @@ export interface GameList {
   readonly currentPhaseId: number | null;
   readonly currentPhase: GameListCurrentPhase | null;
   readonly phaseConfirmed: boolean;
+  readonly orderStatus: OrderStatusEnum | NullEnum | null;
+  /** @nullable */
+  readonly memberStatus: readonly MemberStatusEnum[] | null;
   readonly private: boolean;
   readonly anonymous: boolean;
   /** @nullable */
@@ -466,9 +474,6 @@ export interface GameList {
   readonly pressType: string;
   readonly minReliability: string;
   readonly totalUnreadMessageCount: number;
-  /** @nullable */
-  readonly orderStatus: OrderStatusEnum | null;
-  readonly memberStatus: readonly MemberStatusEnum[];
 }
 
 export interface GameFindSimilar {
@@ -494,6 +499,9 @@ export interface GameRetrieve {
   readonly variantId: string;
   readonly nationAssignment: string;
   readonly phaseConfirmed: boolean;
+  readonly orderStatus: OrderStatusEnum | NullEnum | null;
+  /** @nullable */
+  readonly memberStatus: readonly MemberStatusEnum[] | null;
   /** @nullable */
   readonly movementPhaseDuration: string | null;
   /** @nullable */
@@ -516,9 +524,6 @@ export interface GameRetrieve {
   readonly pressType: string;
   readonly minReliability: string;
   readonly totalUnreadMessageCount: number;
-  /** @nullable */
-  readonly orderStatus: OrderStatusEnum | null;
-  readonly memberStatus: readonly MemberStatusEnum[];
 }
 
 export interface NationFlagUpload {

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -247,6 +247,12 @@ describe("GameCard", () => {
       expect(screen.queryByText("NMR")).not.toBeInTheDocument();
       expect(screen.queryByText("CD")).not.toBeInTheDocument();
     });
+
+    it("renders without crashing when memberStatus is null", () => {
+      renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: null }, ...defaultProps });
+      expect(screen.queryByText("NMR")).not.toBeInTheDocument();
+      expect(screen.queryByText("CD")).not.toBeInTheDocument();
+    });
   });
 
   describe("sandbox visual treatment", () => {

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -145,7 +145,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                       <TooltipContent>No orders are needed from you this phase</TooltipContent>
                     </Tooltip>
                   )}
-                  {game.memberStatus.includes("nmr") && (
+                  {game.memberStatus?.includes("nmr") && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Badge variant="destructive" className="gap-1">
@@ -156,7 +156,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                       <TooltipContent>No Move Received — you did not submit orders in the previous phase</TooltipContent>
                     </Tooltip>
                   )}
-                  {game.memberStatus.includes("civil_disorder") && (
+                  {game.memberStatus?.includes("civil_disorder") && (
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Badge variant="destructive" className="gap-1">

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2185,6 +2185,18 @@ components:
         phaseConfirmed:
           type: boolean
           readOnly: true
+        orderStatus:
+          nullable: true
+          readOnly: true
+          oneOf:
+          - $ref: '#/components/schemas/OrderStatusEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        memberStatus:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemberStatusEnum'
+          nullable: true
+          readOnly: true
         private:
           type: boolean
           readOnly: true
@@ -2271,6 +2283,7 @@ components:
       - gameMaster
       - id
       - isPaused
+      - memberStatus
       - members
       - minReliability
       - movementFrequency
@@ -2278,6 +2291,7 @@ components:
       - name
       - nationAssignment
       - nmrExtensionsAllowed
+      - orderStatus
       - pausedAt
       - phaseConfirmed
       - phases
@@ -2413,6 +2427,18 @@ components:
         phaseConfirmed:
           type: boolean
           readOnly: true
+        orderStatus:
+          nullable: true
+          readOnly: true
+          oneOf:
+          - $ref: '#/components/schemas/OrderStatusEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        memberStatus:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemberStatusEnum'
+          nullable: true
+          readOnly: true
         movementPhaseDuration:
           type: string
           readOnly: true
@@ -2481,6 +2507,7 @@ components:
       - gameMaster
       - id
       - isPaused
+      - memberStatus
       - members
       - minReliability
       - movementFrequency
@@ -2488,6 +2515,7 @@ components:
       - name
       - nationAssignment
       - nmrExtensionsAllowed
+      - orderStatus
       - pausedAt
       - phaseConfirmed
       - phases
@@ -2559,6 +2587,14 @@ components:
       - replaceable
       - seekingReplacement
       - userId
+    MemberStatusEnum:
+      enum:
+      - nmr
+      - civil_disorder
+      type: string
+      description: |-
+        * `nmr` - nmr
+        * `civil_disorder` - civil_disorder
     MinReliabilityEnum:
       enum:
       - open
@@ -2758,6 +2794,16 @@ components:
       required:
       - by
       - status
+    OrderStatusEnum:
+      enum:
+      - orders_required
+      - orders_submitted
+      - no_orders_required
+      type: string
+      description: |-
+        * `orders_required` - orders_required
+        * `orders_submitted` - orders_submitted
+        * `no_orders_required` - no_orders_required
     OrderTypeEnum:
       enum:
       - Move


### PR DESCRIPTION
## Problem

The My Games screen crashed in production with:

```
TypeError: Cannot read properties of null (reading 'includes')
    at GameCard (GameCard.tsx)
```

(In production the chunk is named `useInfiniteScroll-*.js` because Vite bundles `GameCard` into that chunk.)

I reproduced it locally by serving a game with `memberStatus: null` — the screen renders the "Something went wrong" boundary with the identical error.

| Before (crash) | After (fixed) |
|---|---|
| ![before](https://raw.githubusercontent.com/johnpooch/diplicity-react/c4ef06c09bdcf5fccd3545403b0ec3ece673cdeb/shots/before-crash.png) | ![after](https://raw.githubusercontent.com/johnpooch/diplicity-react/c4ef06c09bdcf5fccd3545403b0ec3ece673cdeb/shots/after-fixed.png) |

## Root cause

A two-commit chain introduced the regression:

1. **`8ad6e61`** ("Add order status and member status badges to game cards") added `member_status` to the game serializers, always returning an array, and generated `endpoints.ts` with a non-nullable `memberStatus` type. It never committed the matching `openapi-schema.yaml`, so the schema went stale.
2. **`acec164`** ("Suppress order_status and member_status for sandbox games") added `if obj.sandbox: return None` plus `allow_null=True` to the serializer — making the field genuinely nullable in production — **but did not regenerate the client types**. So `endpoints.ts` still declared `memberStatus` as a non-null array.

Because the type was wrong, TypeScript never flagged `GameCard`'s unguarded `game.memberStatus.includes(...)`, and it threw at runtime for any player whose game list contained a sandbox game (which returns `member_status: null`).

## Fix

Both the type contract and the call site are corrected:

- **Schema / generated types:** Brought the stale `openapi-schema.yaml` back in sync by adding the missing `order_status` / `member_status` fields (with `member_status` nullable, matching the serializer) and their enum schemas, then regenerated `endpoints.ts`. `memberStatus` is now typed `readonly MemberStatusEnum[] | null`, so the type system catches this class of bug going forward. (`orderStatus` also picks up the standard `OrderStatusEnum | NullEnum | null` form already used by other nullable enum fields in the file.)

  Only the two fields and their enums were added to the schema — `/devices`, `/api/test-sentry/`, and `FCMDevice` were deliberately left untouched (they are environmental and unrelated to this fix).
- **Call site:** Guarded both `memberStatus` accesses in `GameCard` with optional chaining.
- **Test:** Added a regression test asserting `GameCard` renders without crashing when `memberStatus` is `null`.

## Verification

- `npx tsc -b --noEmit` — passes
- `npm run lint` on changed files — passes
- `npm run test GameCard` — 28 passing (incl. new null-memberStatus test)
- Manual repro: My Games renders correctly with `memberStatus: null` (after screenshot above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmhG2DW6e1bBS85HbqTjf3)_