### PR TITLE
Add NationFlag entry to the Django admin

### DIFF
--- a/service/nation/admin.py
+++ b/service/nation/admin.py
@@ -1,5 +1,9 @@
+from django import forms
 from django.contrib import admin
-from .models import Nation
+from lxml import etree
+
+from .models import Nation, NationFlag
+from .views import FLAG_MAX_BYTES
 
 
 @admin.register(Nation)
@@ -11,3 +15,49 @@ class NationAdmin(admin.ModelAdmin):
 
     def variant_name(self, obj):
         return obj.variant.name if obj.variant else "-"
+
+
+class NationFlagAdminForm(forms.ModelForm):
+    svg_file = forms.FileField(required=False, help_text="Upload an SVG flag file.")
+
+    class Meta:
+        model = NationFlag
+        fields = ["nation"]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        upload = cleaned_data.get("svg_file")
+
+        if not upload:
+            if not self.instance.pk:
+                raise forms.ValidationError("Upload an SVG flag file.")
+            return cleaned_data
+
+        if upload.size > FLAG_MAX_BYTES:
+            raise forms.ValidationError(f"Flag is too large (max {FLAG_MAX_BYTES} bytes).")
+
+        try:
+            svg = upload.read().decode("utf-8")
+        except UnicodeDecodeError:
+            raise forms.ValidationError("Uploaded file is not valid UTF-8 text.")
+
+        try:
+            etree.fromstring(svg.encode())
+        except etree.XMLSyntaxError as exc:
+            raise forms.ValidationError(f"Could not parse SVG: {exc}.")
+
+        self.instance.svg = svg
+        return cleaned_data
+
+
+@admin.register(NationFlag)
+class NationFlagAdmin(admin.ModelAdmin):
+    form = NationFlagAdminForm
+    list_display = ("nation", "variant_name", "content_hash", "updated_at")
+    list_filter = ("nation__variant",)
+    search_fields = ("nation__name",)
+    autocomplete_fields = ("nation",)
+    readonly_fields = ("content_hash",)
+
+    def variant_name(self, obj):
+        return obj.nation.variant.name if obj.nation else "-"

--- a/service/nation/tests/test_nation_flag_admin.py
+++ b/service/nation/tests/test_nation_flag_admin.py
@@ -1,0 +1,75 @@
+import hashlib
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from nation.admin import NationFlagAdminForm
+from nation.models import NationFlag
+from nation.views import FLAG_MAX_BYTES
+
+
+def _upload(svg, name="flag.svg"):
+    return SimpleUploadedFile(name, svg.encode(), content_type="image/svg+xml")
+
+
+@pytest.mark.django_db
+def test_admin_form_accepts_valid_upload(draft_variant_for_primary, minimal_flag_svg):
+    nation = draft_variant_for_primary.nations.first()
+
+    form = NationFlagAdminForm(
+        data={"nation": nation.pk}, files={"svg_file": _upload(minimal_flag_svg)}
+    )
+
+    assert form.is_valid(), form.errors
+    instance = form.save()
+    assert instance.nation == nation
+    assert instance.content_hash == hashlib.sha256(instance.svg.encode()).hexdigest()
+
+
+@pytest.mark.django_db
+def test_admin_form_replaces_existing_flag(draft_variant_for_primary, minimal_flag_svg):
+    nation = draft_variant_for_primary.nations.first()
+    existing = NationFlag.objects.create(nation=nation, svg="<svg/>")
+    original_hash = existing.content_hash
+
+    form = NationFlagAdminForm(
+        data={"nation": nation.pk},
+        files={"svg_file": _upload(minimal_flag_svg)},
+        instance=existing,
+    )
+
+    assert form.is_valid(), form.errors
+    instance = form.save()
+    assert instance.content_hash != original_hash
+
+
+@pytest.mark.django_db
+def test_admin_form_rejects_malformed_xml(draft_variant_for_primary):
+    nation = draft_variant_for_primary.nations.first()
+
+    form = NationFlagAdminForm(
+        data={"nation": nation.pk}, files={"svg_file": _upload("<svg><g></svg>")}
+    )
+
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_admin_form_requires_a_file_on_add(draft_variant_for_primary):
+    nation = draft_variant_for_primary.nations.first()
+
+    form = NationFlagAdminForm(data={"nation": nation.pk}, files={})
+
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_admin_form_rejects_oversized_flag(draft_variant_for_primary):
+    nation = draft_variant_for_primary.nations.first()
+    oversized = "<svg>" + "a" * (FLAG_MAX_BYTES + 1) + "</svg>"
+
+    form = NationFlagAdminForm(
+        data={"nation": nation.pk}, files={"svg_file": _upload(oversized)}
+    )
+
+    assert not form.is_valid()


### PR DESCRIPTION
## Goal

Closes #625 — add a way to create and replace variant nation flags from the Django admin.

## Changes

- Register `NationFlag` in the Django admin (`service/nation/admin.py`).
- Add a `NationFlagAdminForm` with an `svg_file` upload field, mirroring the existing `VariantSvgAdmin` pattern. The form:
  - requires a file when adding a new flag, but allows leaving it blank when editing an existing one,
  - rejects oversized uploads using the existing `FLAG_MAX_BYTES` limit,
  - validates the upload is UTF-8 and parseable SVG,
  - sets `instance.svg`, letting the model's `save()` handle SVG sanitisation and `content_hash` computation.
- The `NationFlagAdmin` lists the nation, its variant, `content_hash`, and `updated_at`, filters by variant, searches by nation name, and uses autocomplete for the nation FK (`content_hash` is read-only).
- Add `service/nation/tests/test_nation_flag_admin.py` covering valid upload, replacing an existing flag, malformed XML, missing file on add, and oversized uploads.

## Testing

- `python -m pytest nation/tests/test_nation_flag_admin.py` — 5 passed.
- `python manage.py check` — no issues.

No visual changes (Django admin / backend only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ef5pvTemojhHukRYY6YYpg)_