### PR TITLE
[Frontend] Civil disorder recovery — "I'm back" button

### DIFF
--- a/packages/web/src/components/PlayerInfoContent.test.tsx
+++ b/packages/web/src/components/PlayerInfoContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, it, expect, vi } from "vitest";
 
@@ -7,11 +7,15 @@ import { PlayerInfoContent } from "./PlayerInfoContent";
 const mockGameData = vi.fn();
 const mockVariantsData = vi.fn();
 const mockCurrentPhaseData = vi.fn();
+const mockMutateAsync = vi.fn().mockResolvedValue({});
+const mockInvalidateQueries = vi.fn();
 
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({ data: mockGameData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
   useGamePhaseRetrieve: () => ({ data: mockCurrentPhaseData() }),
+  useGameRecoverFromCivilDisorderCreate: () => ({ mutateAsync: mockMutateAsync }),
+  getGameRetrieveQueryKey: (gameId: string) => ["game", gameId],
 }));
 
 vi.mock("@/components/NationFlag", () => ({
@@ -19,6 +23,14 @@ vi.mock("@/components/NationFlag", () => ({
   findNationFlagUrl: () => null,
   findNationColor: () => null,
 }));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  };
+});
 
 const renderPlayerInfo = () =>
   render(
@@ -48,6 +60,8 @@ describe("PlayerInfoContent", () => {
       { id: "classical", name: "Classical" },
     ]);
     mockCurrentPhaseData.mockReturnValue({ supplyCenters: [] });
+    mockMutateAsync.mockResolvedValue({});
+    mockInvalidateQueries.mockReset();
   });
 
   it("shows the civil disorder badge for members in civil disorder", () => {
@@ -115,5 +129,67 @@ describe("PlayerInfoContent", () => {
     renderPlayerInfo();
 
     expect(screen.queryByText("Game Master")).not.toBeInTheDocument();
+  });
+
+  it("shows I'm back button for current user in civil disorder", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      nmrExtensionsAllowed: 0,
+      victory: null,
+      phases: [{ id: 1, status: "active" }],
+      members: [{ ...baseMember, isCurrentUser: true, civilDisorder: true }],
+    });
+
+    renderPlayerInfo();
+
+    expect(screen.getByRole("button", { name: "I'm back" })).toBeInTheDocument();
+  });
+
+  it("does not show I'm back button for other users in civil disorder", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      nmrExtensionsAllowed: 0,
+      victory: null,
+      phases: [{ id: 1, status: "active" }],
+      members: [{ ...baseMember, isCurrentUser: false, civilDisorder: true }],
+    });
+
+    renderPlayerInfo();
+
+    expect(screen.queryByRole("button", { name: "I'm back" })).not.toBeInTheDocument();
+  });
+
+  it("does not show I'm back button for current user not in civil disorder", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      nmrExtensionsAllowed: 0,
+      victory: null,
+      phases: [{ id: 1, status: "active" }],
+      members: [{ ...baseMember, isCurrentUser: true, civilDisorder: false }],
+    });
+
+    renderPlayerInfo();
+
+    expect(screen.queryByRole("button", { name: "I'm back" })).not.toBeInTheDocument();
+  });
+
+  it("calls the recovery mutation when I'm back button is clicked", async () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      nmrExtensionsAllowed: 0,
+      victory: null,
+      phases: [{ id: 1, status: "active" }],
+      members: [{ ...baseMember, isCurrentUser: true, civilDisorder: true }],
+    });
+
+    renderPlayerInfo();
+
+    fireEvent.click(screen.getByRole("button", { name: "I'm back" }));
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({ gameId: "game-1" });
   });
 });

--- a/packages/web/src/components/PlayerInfoContent.tsx
+++ b/packages/web/src/components/PlayerInfoContent.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { Shield, Star, Trophy } from "lucide-react";
 import { Link, useParams } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { CivilDisorderBadge } from "@/components/CivilDisorderBadge";
 import { GameStatusAlerts } from "@/components/GameStatusAlerts";
 import { NationFlag, findNationFlagUrl, findNationColor } from "@/components/NationFlag";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
@@ -13,6 +16,8 @@ import {
   useGameRetrieveSuspense,
   useGamePhaseRetrieve,
   useVariantsListSuspense,
+  useGameRecoverFromCivilDisorderCreate,
+  getGameRetrieveQueryKey,
   Member,
 } from "@/api/generated/endpoints";
 import { getCurrentPhaseId } from "@/util";
@@ -21,9 +26,22 @@ import { useRequiredParams } from "@/hooks";
 export const PlayerInfoContent: React.FC = () => {
   const { gameId } = useRequiredParams<{ gameId: string }>();
   const { phaseId } = useParams<{ phaseId: string }>();
+  const queryClient = useQueryClient();
 
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: variants } = useVariantsListSuspense();
+
+  const recoverMutation = useGameRecoverFromCivilDisorderCreate();
+
+  const handleRecoverFromCivilDisorder = async () => {
+    try {
+      await recoverMutation.mutateAsync({ gameId });
+      toast.success("Welcome back!");
+      queryClient.invalidateQueries({ queryKey: getGameRetrieveQueryKey(gameId) });
+    } catch {
+      toast.error("Failed to recover from civil disorder");
+    }
+  };
 
   const currentPhaseId = getCurrentPhaseId(game);
   const { data: currentPhase } = useGamePhaseRetrieve(
@@ -119,6 +137,15 @@ export const PlayerInfoContent: React.FC = () => {
                       </Badge>
                     )}
                     {member.civilDisorder && <CivilDisorderBadge />}
+                    {member.isCurrentUser && member.civilDisorder && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleRecoverFromCivilDisorder}
+                      >
+                        I&apos;m back
+                      </Button>
+                    )}
                   </div>
 
                   {member.nation && (

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -202,6 +202,9 @@ export const handlers = [
   ),
   http.delete("*/game/:gameId/leave/", () => new HttpResponse(null, { status: 204 })),
   http.delete("*/game/:gameId/delete/", () => new HttpResponse(null, { status: 204 })),
+  http.post("*/game/:gameId/recover-from-civil-disorder/", () =>
+    HttpResponse.json({})
+  ),
   http.patch("*/game/:gameId/confirm-phase/", () => HttpResponse.json({})),
   http.post("*/game/:gameId/resolve-phase/", () => HttpResponse.json({})),
   http.put("*/game/:gameId/pause/", () => HttpResponse.json({})),


### PR DESCRIPTION
Closes #587

## Summary

- Adds an "I'm back" button to the player list row for the current user when they are in civil disorder
- Clicking the button calls `POST /game/:gameId/recover-from-civil-disorder/` via the `useGameRecoverFromCivilDisorderCreate` mutation hook
- On success, shows a "Welcome back!" toast and invalidates the game query; on failure, shows an error toast
- Adds an MSW handler for the endpoint in mock mode
- Adds 4 new unit tests covering: button visibility for own/other players, civil disorder on/off states, and mutation call on click

## Test plan

- [ ] All 8 tests in `PlayerInfoContent.test.tsx` pass (`npm run test -- --run PlayerInfoContent`)
- [ ] `npm run lint` passes with no warnings
- [ ] `npx tsc -b --noEmit` passes
- [ ] In mock mode, navigate to an active game's player info page as a user in civil disorder — "I'm back" button appears
- [ ] Button does not appear for other players in civil disorder
- [ ] Button does not appear when the current user is not in civil disorder
- [ ] Clicking the button shows the "Welcome back!" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxp8BzeAi5bCY4cPwDTQxU