### PR TITLE
Harden active-member queries to exclude retired members

### DIFF
--- a/service/channel/models.py
+++ b/service/channel/models.py
@@ -11,7 +11,7 @@ class ChannelQuerySet(models.QuerySet):
     def accessible_to_user(self, user, game):
         queryset = self.filter(game=game)
         try:
-            member = game.members.get(user=user)
+            member = game.members.get(user=user, replaced_by__isnull=True)
             return queryset.filter(Q(private=False) | Q(members=member)).distinct()
         except:
             return queryset.filter(private=False)
@@ -55,7 +55,7 @@ class ChannelManager(models.Manager):
         return ChannelQuerySet(self.model, using=self._db)
 
     def create_from_member_ids(self, user, member_ids, game):
-        member_ids = member_ids + [game.members.get(user=user).id]
+        member_ids = member_ids + [game.members.get(user=user, replaced_by__isnull=True).id]
         channel_members = game.members.filter(id__in=member_ids)
         nations = sorted([m.nation.name for m in channel_members])
         channel_name = ", ".join(nations)

--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -32,7 +32,7 @@ class IsGameMember(BasePermission):
 
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
-        return game.members.filter(user=request.user).exists()
+        return game.members.filter(user=request.user, replaced_by__isnull=True).exists()
 
 
 class IsGameMemberOrGameMaster(BasePermission):
@@ -42,7 +42,7 @@ class IsGameMemberOrGameMaster(BasePermission):
         game = resolve_game(request, view.kwargs.get("game_id"))
         if game.game_master_id is not None and game.game_master_id == request.user.id:
             return True
-        return game.members.filter(user=request.user).exists()
+        return game.members.filter(user=request.user, replaced_by__isnull=True).exists()
 
 
 class IsActiveGameMember(BasePermission):
@@ -51,7 +51,7 @@ class IsActiveGameMember(BasePermission):
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
 
-        member = game.members.filter(user=request.user).first()
+        member = game.members.filter(user=request.user, replaced_by__isnull=True).first()
         if not member:
             self.message = "User is not a member of the game."
             return False
@@ -92,7 +92,7 @@ class IsNotGameMember(BasePermission):
 
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
-        return not game.members.filter(user=request.user).exists()
+        return not game.members.filter(user=request.user, replaced_by__isnull=True).exists()
 
 
 class IsSpaceAvailable(BasePermission):
@@ -175,7 +175,7 @@ class IsGameManager(BasePermission):
         if game.game_master_id is not None:
             self.message = "Only the game master can perform this action."
             return game.game_master_id == request.user.id
-        if not game.members.filter(user=request.user).exists():
+        if not game.members.filter(user=request.user, replaced_by__isnull=True).exists():
             self.message = "User is not a member of the game."
             return False
         if game.created_by_id is None or game.created_by_id != request.user.id:
@@ -205,7 +205,7 @@ class IsInCivilDisorder(BasePermission):
 
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
-        member = game.members.filter(user=request.user).first()
+        member = game.members.filter(user=request.user, replaced_by__isnull=True).first()
         if not member:
             self.message = "User is not a member of the game."
             return False

--- a/service/draw_proposal/models.py
+++ b/service/draw_proposal/models.py
@@ -48,7 +48,7 @@ class DrawProposalManager(models.Manager):
         phase = game.current_phase
 
         all_active_members = list(game.members.filter(
-            eliminated=False, kicked=False
+            eliminated=False, kicked=False, replaced_by__isnull=True
         ))
 
         proposal = self.create(

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -804,3 +804,98 @@ def test_join_game_reliability_requirement(
         assert response.status_code == status.HTTP_201_CREATED
     else:
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestRetiredMemberHardening:
+    """
+    Verifies that replaced (retired) members are excluded from active-member
+    queries and permission checks.  Each test constructs a synthetic
+    retired + active pair on the same nation.
+    """
+
+    def _make_game_with_retired_pair(
+        self,
+        classical_variant,
+        classical_england_nation,
+        primary_user,
+        secondary_user,
+    ):
+        game = Game.objects.create(
+            name="Hardening Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        active_member = game.members.create(
+            user=secondary_user, nation=classical_england_nation
+        )
+        retired_member = game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            replaced_by=active_member,
+        )
+        return game, retired_member, active_member
+
+    @pytest.mark.django_db
+    def test_is_game_member_ignores_retired_member(
+        self,
+        classical_variant,
+        classical_england_nation,
+        primary_user,
+        secondary_user,
+    ):
+        game, retired_member, active_member = self._make_game_with_retired_pair(
+            classical_variant, classical_england_nation, primary_user, secondary_user
+        )
+        from common.permissions import IsGameMember
+        perm = IsGameMember()
+        assert game.members.filter(user=secondary_user, replaced_by__isnull=True).exists() is True
+        assert game.members.filter(user=primary_user, replaced_by__isnull=True).exists() is False
+
+    @pytest.mark.django_db
+    def test_is_not_game_member_treats_retired_member_as_non_member(
+        self,
+        authenticated_client,
+        classical_variant,
+        classical_england_nation,
+        primary_user,
+        secondary_user,
+    ):
+        game = Game.objects.create(
+            name="Hardening Pending Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        active_member = game.members.create(user=secondary_user, nation=classical_england_nation)
+        game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            replaced_by=active_member,
+        )
+        join_url = reverse(join_viewname, args=[game.id])
+        response = authenticated_client.post(join_url)
+        assert response.status_code == status.HTTP_201_CREATED
+
+    @pytest.mark.django_db
+    def test_is_in_civil_disorder_ignores_retired_member(
+        self,
+        authenticated_client,
+        classical_variant,
+        classical_england_nation,
+        primary_user,
+        secondary_user,
+    ):
+        game = Game.objects.create(
+            name="Hardening CD Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        active_member = game.members.create(user=secondary_user, nation=classical_england_nation)
+        game.members.create(
+            user=primary_user,
+            nation=classical_england_nation,
+            civil_disorder=True,
+            replaced_by=active_member,
+        )
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -807,11 +807,6 @@ def test_join_game_reliability_requirement(
 
 
 class TestRetiredMemberHardening:
-    """
-    Verifies that replaced (retired) members are excluded from active-member
-    queries and permission checks.  Each test constructs a synthetic
-    retired + active pair on the same nation.
-    """
 
     def _make_game_with_retired_pair(
         self,
@@ -846,8 +841,6 @@ class TestRetiredMemberHardening:
         game, retired_member, active_member = self._make_game_with_retired_pair(
             classical_variant, classical_england_nation, primary_user, secondary_user
         )
-        from common.permissions import IsGameMember
-        perm = IsGameMember()
         assert game.members.filter(user=secondary_user, replaced_by__isnull=True).exists() is True
         assert game.members.filter(user=primary_user, replaced_by__isnull=True).exists() is False
 

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -534,7 +534,7 @@ class PhaseManager(models.Manager):
 
         candidates = list(
             previous_phase.game.members.filter(
-                eliminated=False, kicked=False, nation__isnull=False
+                eliminated=False, kicked=False, replaced_by__isnull=True, nation__isnull=False
             ).select_related("user", "nation")
         )
 
@@ -568,7 +568,7 @@ class PhaseManager(models.Manager):
         if game.sandbox:
             return False
 
-        active_members = list(game.members.filter(eliminated=False, kicked=False))
+        active_members = list(game.members.filter(eliminated=False, kicked=False, replaced_by__isnull=True))
         if not active_members:
             return False
 
@@ -786,7 +786,7 @@ class PhaseManager(models.Manager):
                     nations_with_orders = new_phase.nations_with_possible_orders
 
                     # Prefetch member nations to avoid N+1
-                    members = list(new_phase.game.members.select_related("nation").all())
+                    members = list(new_phase.game.members.filter(replaced_by__isnull=True).select_related("nation"))
 
                     phase_states_to_create = []
                     for member in members:

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -680,3 +680,54 @@ class TestTierAllowsMinReliability:
         from user_profile.utils import tier_allows_min_reliability
 
         assert tier_allows_min_reliability(None, "something_else") is True
+
+
+class TestRetiredMemberStats:
+
+    @pytest.mark.django_db
+    def test_retired_member_excluded_from_total_games(
+        self,
+        authenticated_client,
+        classical_variant,
+        classical_england_nation,
+        classical_france_nation,
+    ):
+        user = User.objects.create_user(
+            username="retiredstatsuser", email="retiredstats@example.com", password="testpass123"
+        )
+        UserProfile.objects.create(user=user, name="Retired Stats User")
+
+        other_user = User.objects.create_user(
+            username="takeover_user", email="takeover@example.com", password="testpass123"
+        )
+        UserProfile.objects.create(user=other_user, name="Takeover User")
+
+        retired_game = Game.objects.create(
+            name="Retired Game",
+            variant=classical_variant,
+            status=GameStatus.COMPLETED,
+            finished_at=timezone.now(),
+        )
+        active_replacement = retired_game.members.create(
+            user=other_user, nation=classical_england_nation
+        )
+        retired_game.members.create(
+            user=user,
+            nation=classical_england_nation,
+            replaced_by=active_replacement,
+        )
+
+        normal_game = Game.objects.create(
+            name="Normal Game",
+            variant=classical_variant,
+            status=GameStatus.COMPLETED,
+            finished_at=timezone.now(),
+        )
+        normal_game.members.create(user=user, nation=classical_france_nation)
+
+        url = reverse("public-user-profile", kwargs={"user_id": user.id})
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total_games"] == 1
+        assert response.data["losses"] == 1

--- a/service/user_profile/utils.py
+++ b/service/user_profile/utils.py
@@ -24,13 +24,15 @@ def get_player_stats(user):
         .order_by("-game__finished_at")
     )
 
-    total_games = completed_members.count()
+    active_completed_members = completed_members.filter(replaced_by__isnull=True)
+
+    total_games = active_completed_members.count()
     solo_wins = (
         Victory.objects.solo_victories()
-        .filter(members__in=completed_members.filter(drew=False))
+        .filter(members__in=active_completed_members.filter(drew=False))
         .count()
     )
-    draws = completed_members.filter(drew=True).count()
+    draws = active_completed_members.filter(drew=True).count()
     losses = total_games - solo_wins - draws
 
     last_n_members = list(completed_members[:RELIABILITY_GAME_WINDOW])


### PR DESCRIPTION
Closes #692
Part of #690
Builds on #691

## Summary

- Added `replaced_by__isnull=True` filter to every place in the codebase that queries for a game's active members, so retired members (players who handed off their nation to a replacement via the seeking-replacement flow introduced in #691) are never mistakenly treated as active participants.
- **Permissions** (`common/permissions.py`): `IsGameMember`, `IsActiveGameMember`, `IsNotGameMember`, `IsGameManager`, and `IsInCivilDisorder` all now ignore retired members. A retired user is not a current member, can rejoin as a spectator/new player, and cannot be in civil disorder.
- **Phase resolution** (`phase/models.py`): Elimination checks, abandonment checks, and phase-state creation now filter out retired members so resolution logic operates only on current players.
- **Draw proposals** (`draw_proposal/models.py`): Vote rows are only created for non-retired active members.
- **Channels** (`channel/models.py`): `accessible_to_user` and `create_from_member_ids` look up only the active (non-retired) membership.
- **Player stats** (`user_profile/utils.py`): Win/loss/draw tallies use only active memberships; NMR/CD rates include retired memberships (to preserve those historical signals in the reliability window).

## Test plan

- [ ] `pytest service/common/tests.py service/member/tests.py --create-db` — `TestRetiredMemberHardening` covers permission behaviour for retired members
- [ ] `pytest service/user_profile/tests.py --create-db` — `TestRetiredMemberStats` verifies retired memberships are excluded from total_games/wins/losses
- [ ] `pytest service/draw_proposal/tests.py service/phase/tests.py service/channel/tests.py --create-db` — existing tests continue to pass
- [ ] Full suite: `cd service && pytest -n auto --create-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnQHpXrL5Suwvb21w257oz