### PR TITLE
[Quick Bug Fix] Make desktop sidebar Chat icon return to channel list

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -76,11 +76,26 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
     });
   }, [gameId, phaseId, searchParams, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
 
-  // Filter out Map for desktop sidebar since map is already visible in right panel
-  const sidebarNavItems = useMemo(
-    () => navItems.filter(item => item.label !== "Map"),
-    [navItems]
-  );
+  // Filter out Map for desktop sidebar since map is already visible in right
+  // panel. Unlike the bottom nav, the sidebar Chat icon should return to the
+  // channel list rather than resuming the last channel, since the map is
+  // always visible alongside the chat in the desktop layout.
+  const sidebarNavItems = useMemo(() => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("channelId");
+    const paramsStr = params.toString();
+    const chatBasePath = `/game/${gameId}/phase/${phaseId}/chat`;
+    return navItems
+      .filter(item => item.label !== "Map")
+      .map(item =>
+        item.label === "Chat"
+          ? {
+              ...item,
+              path: paramsStr ? `${chatBasePath}?${paramsStr}` : chatBasePath,
+            }
+          : item
+      );
+  }, [navItems, searchParams, gameId, phaseId]);
 
   const bottomClasses = cn("border-t bg-background", "block md:hidden");
 


### PR DESCRIPTION
## Summary

On desktop, the left sidebar **Chat** icon now returns to the channel list instead of resuming the last-opened channel.

The chat "resume" behavior works via a `channelId` search param: `ChannelScreen` writes the current `channelId` into the URL, and `ChannelListScreen` redirects to that channel when the param is present. On mobile this is desirable — tapping Chat in the bottom nav jumps you back to where you were. On desktop the map is always visible in the right panel alongside chat, so the more useful behavior is to land on the channel list.

This change builds a dedicated `sidebarNavItems` whose Chat entry strips `channelId` from the search params, so the desktop sidebar Chat icon navigates to the bare chat route and `ChannelListScreen` renders the list. The mobile bottom nav (`navItems`) is unchanged and still resumes the last channel.

## Changes

- `packages/web/src/components/GameDetailLayout.tsx`: `sidebarNavItems` now maps the Chat item to a path with `channelId` removed from the query string (previously it only filtered out the Map item).

## Review

Self-reviewed via `/code-review` (high effort) against `main`:

- **Line-by-line:** `channelId` is correctly stripped from a copy of `searchParams`; `isActive`/`badge` are preserved via the spread of `navItems`.
- **Removed behavior:** the prior `filter(item => item.label !== "Map")` is fully retained — nothing dropped.
- **Cross-file:** `ChannelListScreen` redirects only when `channelId` is present, so stripping it reliably forces the channel list; `ChannelScreen` only re-adds the param while mounted, so navigating away doesn't re-trigger the resume. Mobile bottom nav still carries `channelId`, preserving the intended platform difference.
- Typecheck (`tsc -b --noEmit`) and ESLint pass clean.

No findings.

## Testing

- `npx tsc -b --noEmit` — clean
- `npx eslint src/components/GameDetailLayout.tsx` — clean

No visual changes screenshots included (behavior/navigation change; visually identical icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
