### PR TITLE
Strip unicode-range from embedded map fonts (WebKit Font Embed fix)

### DIFF
--- a/packages/web/src/components/InteractiveMap/dsvgParser.test.ts
+++ b/packages/web/src/components/InteractiveMap/dsvgParser.test.ts
@@ -47,6 +47,17 @@ describe("parseDsvg", () => {
     expect(parsed.defs).toContain("<style");
   });
 
+  test("strips unicode-range from embedded @font-face but keeps the face", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+      <style>@font-face { font-family: 'Italianno'; src: url('data:font/woff2;base64,AAAA') format('woff2'); unicode-range: U+41-57, U+61-7a; }</style>
+      <g id="background"></g>
+    </svg>`;
+    const { defs } = parseDsvg(svg);
+    expect(defs).not.toContain("unicode-range");
+    expect(defs).toContain("font-family: 'Italianno'");
+    expect(defs).toContain("format('woff2')");
+  });
+
   test("returns empty maps when the position layers are absent", () => {
     const withoutPositions = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
       <g id="background"></g>

--- a/packages/web/src/components/InteractiveMap/dsvgParser.ts
+++ b/packages/web/src/components/InteractiveMap/dsvgParser.ts
@@ -77,6 +77,16 @@ const collectPoints = (layer: Element | null): Map<string, Point> => {
 const stripRedundantNamespace = (markup: string): string =>
   markup.split(' xmlns="http://www.w3.org/2000/svg"').join("");
 
+// The variant-creator subsets each embedded font to exactly the glyphs the map
+// uses and emits a matching `unicode-range`. With a single inlined face that
+// gate is redundant in Blink, but WebKit (iOS Safari / WKWebView) mishandles
+// `unicode-range` on `@font-face` applied to SVG <text> and silently falls back
+// to serif. Stripping it makes the font apply to every character that requests
+// it — a no-op in Blink, a fix in WebKit — with no tofu risk, since every used
+// character is covered by the subset by construction.
+const stripUnicodeRange = (markup: string): string =>
+  markup.replace(/\s*unicode-range\s*:[^;}]*;?/gi, "");
+
 const collectDefs = (root: Element): string => {
   let markup = "";
   for (const child of Array.from(root.children)) {
@@ -85,7 +95,7 @@ const collectDefs = (root: Element): string => {
       markup += child.outerHTML;
     }
   }
-  return stripRedundantNamespace(markup);
+  return stripUnicodeRange(stripRedundantNamespace(markup));
 };
 
 const layerMarkup = (root: Element, id: string): string =>


### PR DESCRIPTION
## Problem
On iOS Safari / WKWebView, the small place-name labels on some variants (e.g. **Spice Islands**) render in a serif fallback instead of their intended cursive font. The affected font is **Italianno** — the only one of the map's four embedded faces that carries a `unicode-range` descriptor. Chrome/Android renders it correctly, which is why it only showed on iOS.

## Cause
WebKit mishandles `@font-face` with a `unicode-range` applied to SVG `<text>` and silently falls back. Established by elimination:
- The Italianno woff2 data is valid (correct `wOF2` magic + length).
- In Blink the font applies to every label and removing `unicode-range` changes nothing (measured).
- The Libre Baskerville faces (same data-URI embedding, same injected `<style>`, no `unicode-range`) render fine on the same device.
- ⇒ `unicode-range` is the only differentiator.

This is **not** related to the viewBox refactor — the raw standalone SVG reproduces it identically.

## Fix
The variant-creator subsets each embedded font to exactly the glyphs the map uses and emits a matching `unicode-range`, so for a single inlined face the descriptor is redundant — every used character is covered by construction. Strip it during defs collection (`collectDefs`):
- no-op in Blink (verified by measurement),
- fix in WebKit,
- no tofu risk (no character in use is outside the subset).

## Verification
- `tsc -b` clean, eslint clean, 12 `dsvgParser` tests pass (incl. a new case asserting the range is stripped but the face kept).
- **WebKit confirmation pending on-device** — I couldn't run Playwright WebKit headless locally (missing Linux libs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)