### PR TITLE
Add ux-patterns Claude Code skill

### DIFF
--- a/.claude/skills/ux-patterns/SKILL.md
+++ b/.claude/skills/ux-patterns/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ux-patterns
+description: UX design decisions for diplicity-react — which controls to use, how to handle feedback, progressive disclosure, microcopy, accessibility, and interaction patterns. Load when building or reviewing any UI, making design decisions, or choosing between controls.
+allowed-tools: Task, Read, Glob, Grep, Write, Edit, Bash, TodoWrite
+---
+
+# UX Patterns Skill
+
+This skill encodes the design decisions for the diplicity-react application. These are not suggestions — they are resolved decisions to apply consistently across the codebase.
+
+The stack is **React 19 + Tailwind v4 + Radix UI (shadcn/ui style) + react-hook-form + Zod**. No Chakra, no Semantic UI.
+
+## Quick Reference: Which file to consult?
+
+- Choosing a form control (select vs radio vs slider)? → [./form-controls.md](./form-controls.md)
+- Loading states, errors, toasts, confirmations? → [./feedback-patterns.md](./feedback-patterns.md)
+- Sheets vs dialogs, screen structure, navigation? → [./navigation-layout.md](./navigation-layout.md)
+- When and how to explain things to users? → [./progressive-disclosure.md](./progressive-disclosure.md)
+- Button labels, error copy, help text, tone? → [./microcopy.md](./microcopy.md)
+- Optimistic updates, undo, live data, mobile? → [./interaction-patterns.md](./interaction-patterns.md)
+
+## Non-Negotiable Principles
+
+1. **Tabs are navigation only.** Never use `<Tabs>` to drive form selection or binary choices — use radio buttons instead.
+2. **Dialogs are for interruptions only.** A `<Dialog>` or `<AlertDialog>` appears only for destructive confirmations or unexpected required information. Secondary content, player profiles, and settings go in a `<Sheet>`.
+3. **Dropdowns are a last resort for form fields.** 2–4 short-label options use segmented control or radio group. `<Select>` is for 5+ options or long lists.
+4. **No adaptive UI.** The interface is identical for new and experienced players. It does not hide or alter content based on usage history.
+5. **Rare features are deprioritized, not hidden.** Sandbox mode and Game Master controls are always accessible but visually subordinate.
+
+## Suspense Fallbacks
+
+All screens that fetch data must use a skeleton fallback — not `<Suspense fallback={<div></div>}>`. See [./feedback-patterns.md](./feedback-patterns.md) for the correct pattern.
+
+Apply this to every new screen you build and to any existing screen you touch as part of the current issue. Do not fix screens the current PR is not already touching — boy scout rule.
+
+## Detailed Guidance
+
+- **[./form-controls.md](./form-controls.md)** — Decision tree for every input type: select, radio, segmented control, slider, stepper, combobox, checkbox, switch
+- **[./feedback-patterns.md](./feedback-patterns.md)** — Loading skeletons, toast rules, inline errors, confirmation dialogs, button loading states
+- **[./navigation-layout.md](./navigation-layout.md)** — Screen structure, sheet vs dialog, action placement, stepper navigation, focus management
+- **[./progressive-disclosure.md](./progressive-disclosure.md)** — Two-tier explanation model, first-time UX, conditional fields, complexity escalation, the (i) tooltip pattern
+- **[./microcopy.md](./microcopy.md)** — Tone, button labels, placeholder text, help text, error copy, confirm dialog copy
+- **[./interaction-patterns.md](./interaction-patterns.md)** — Optimistic updates, undo, live updates, inline editing, empty states, pagination

--- a/.claude/skills/ux-patterns/SKILL.md
+++ b/.claude/skills/ux-patterns/SKILL.md
@@ -29,7 +29,7 @@ The stack is **React 19 + Tailwind v4 + Radix UI (shadcn/ui style) + react-hook-
 
 ## Suspense Fallbacks
 
-All screens that fetch data must use a skeleton fallback — not `<Suspense fallback={<div></div>}>`. See [./feedback-patterns.md](./feedback-patterns.md) for the correct pattern.
+Keep the Suspense wrapper — it is the correct pattern. Only the fallback changes: replace the empty-div fallback (`<Suspense fallback={<div></div>}>`) with a skeleton that matches the loaded content's dimensions exactly, so the swap causes no layout shift. See [./feedback-patterns.md](./feedback-patterns.md) for the full pattern.
 
 Apply this to every new screen you build and to any existing screen you touch as part of the current issue. Do not fix screens the current PR is not already touching — boy scout rule.
 

--- a/.claude/skills/ux-patterns/feedback-patterns.md
+++ b/.claude/skills/ux-patterns/feedback-patterns.md
@@ -1,0 +1,127 @@
+# Feedback Patterns
+
+## Loading States
+
+**Always use skeleton screens.** When data is loading, render placeholder shapes that match the layout of the content that will appear. Do not use centered spinners. Do not render a blank `<div>`.
+
+The current pattern `<Suspense fallback={<div></div>}>` is an anti-pattern. Replace with a skeleton that mirrors the screen structure.
+
+---
+
+## Toast Notifications (Sonner)
+
+### When to use a toast
+
+- Transient mutations: join game, leave lobby, send message, copy link
+- Network errors mid-session (with a Retry action)
+- Success confirmation for game orders (see special rule below)
+- Undo opportunity after a reversible destructive action
+
+### When NOT to use a toast
+
+- Form submission errors → use inline error banner instead
+- State changes the UI already makes obvious (toggling a checkbox, inline edit save)
+
+### Toast duration
+
+Calculate based on message length. A person reads ~200 words per minute, ~3–4 words per second. Formula: `max(3000, wordCount * 300)` ms. A 5-word message stays for 3s. A 15-word message stays for ~4.5s. Never hard-code a single duration for all toasts.
+
+### Undo toasts
+
+For reversible destructive actions (e.g. leaving a lobby that you can rejoin), execute immediately and show: `"You left the lobby" [Undo]`. The Undo window is ~5 seconds.
+
+---
+
+## Form Errors
+
+### Field-level errors
+
+Show below the field AND apply a destructive-colored border to the input. Both signals together — the border draws the eye, the message explains.
+
+```tsx
+<FormItem>
+  <FormLabel>Game Name</FormLabel>
+  <FormControl>
+    <Input className={cn(fieldState.error && "border-destructive")} {...field} />
+  </FormControl>
+  <FormMessage /> {/* appears below */}
+</FormItem>
+```
+
+### Submission errors
+
+When a form submission fails (server error), show an inline error banner inside the form — not a toast. Place the banner just above the submit/next button so the user sees it without scrolling up to find which field is highlighted.
+
+```tsx
+{submitError && (
+  <Alert variant="destructive">
+    <AlertDescription>{submitError}</AlertDescription>
+  </Alert>
+)}
+<Button type="submit">Create Game</Button>
+```
+
+---
+
+## Confirmation Dialogs
+
+Use `<AlertDialog>` only for:
+
+1. **Destructive/irreversible actions**: Delete account, concede game, end game
+2. **Unexpected required information**: Something the user must acknowledge before proceeding that could not have been anticipated
+
+Do not use `<AlertDialog>` for: secondary information, player profiles, settings, or anything that could be a `<Sheet>`.
+
+### Copy format
+
+**Title**: Verb-first, names the action exactly. No "Are you sure?"
+
+**Description**: States the specific consequence. No vague "This cannot be undone."
+
+```
+Title:       "Delete account"
+Description: "Your profile, game history, and all associated data will be permanently deleted."
+
+Title:       "Concede game"
+Description: "You will be eliminated. Your units are disbanded and your supply centers become neutral."
+```
+
+---
+
+## Button Loading State
+
+When an action is in progress, replace the button label with a spinner icon. The button remains disabled and its width does not change (use a fixed-width container if needed).
+
+```tsx
+<Button disabled={isPending}>
+  {isPending ? <Loader2 className="size-4 animate-spin" /> : "Create Game"}
+</Button>
+```
+
+Do not show "Creating..." text. Do not show a spinner alongside text.
+
+---
+
+## Urgency Signals
+
+For approaching deadlines, change the color of the time display:
+
+- Normal: default text color
+- ~6 hours remaining: amber/warning color
+- ~2 hours remaining: red/destructive color
+
+Do not add pulsing animations or banner alerts. Push notifications handle proactive alerting — the in-app UI signals urgency through color only.
+
+---
+
+## Network Errors (Mid-Session)
+
+When a request fails while the user is using the app (not initial load), show an error toast with a Retry action:
+
+```
+"Failed to load games"  [Retry]
+```
+
+TanStack Query retries automatically with backoff. Only surface the error to the user after all automatic retries are exhausted.
+
+For initial-load failures (data the screen requires to render at all), use `<QueryErrorBoundary>` which handles the error state inline in the content area, keeping the `<ScreenHeader>` visible.

--- a/.claude/skills/ux-patterns/feedback-patterns.md
+++ b/.claude/skills/ux-patterns/feedback-patterns.md
@@ -2,9 +2,11 @@
 
 ## Loading States
 
-**Always use skeleton screens.** When data is loading, render placeholder shapes that match the layout of the content that will appear. Do not use centered spinners. Do not render a blank `<div>`.
+**Always use skeleton screens.** When data is loading, render placeholder shapes that match the layout of the content that will appear. Do not use centered spinners.
 
-The current pattern `<Suspense fallback={<div></div>}>` is an anti-pattern. Replace with a skeleton that mirrors the screen structure.
+Keep the Suspense wrapper — it is good practice. Only the fallback changes: replace `<Suspense fallback={<div></div>}>` with a skeleton that mirrors the screen structure.
+
+**The skeleton must match the loaded content's dimensions exactly** so the swap causes no vertical shift ("hiccup"). Where content has a variable height (game cards, player cards), give the component a fixed height so the skeleton and the loaded content occupy the same space.
 
 ---
 
@@ -26,9 +28,20 @@ The current pattern `<Suspense fallback={<div></div>}>` is an anti-pattern. Repl
 
 Calculate based on message length. A person reads ~200 words per minute, ~3–4 words per second. Formula: `max(3000, wordCount * 300)` ms. A 5-word message stays for 3s. A 15-word message stays for ~4.5s. Never hard-code a single duration for all toasts.
 
+A toast that carries an action (Undo, Retry) must stay long enough to use that action. Its duration is **whichever is longer** — the formula above or the action's window (see Undo toasts). An action toast must never disappear before its action can be used.
+
 ### Undo toasts
 
-For reversible destructive actions (e.g. leaving a lobby that you can rejoin), execute immediately and show: `"You left the lobby" [Undo]`. The Undo window is ~5 seconds.
+This is the canonical Undo pattern; other files reference it rather than restating it.
+
+For reversible destructive actions (e.g. leaving a lobby you can rejoin):
+
+1. Execute the action immediately — it is a real mutation, the user has left.
+2. Show a toast with an Undo action: `"You left the lobby" [Undo]`.
+3. The undo window is ~5 seconds. The toast stays for whichever is longer: the duration formula or the undo window.
+4. Tapping Undo issues a *separate* reversing request (e.g. rejoin). That request can itself fail — if it does, show an error toast and leave the original action committed.
+
+For irreversible actions, use a confirmation dialog instead (see Confirmation Dialogs below).
 
 ---
 
@@ -36,17 +49,7 @@ For reversible destructive actions (e.g. leaving a lobby that you can rejoin), e
 
 ### Field-level errors
 
-Show below the field AND apply a destructive-colored border to the input. Both signals together — the border draws the eye, the message explains.
-
-```tsx
-<FormItem>
-  <FormLabel>Game Name</FormLabel>
-  <FormControl>
-    <Input className={cn(fieldState.error && "border-destructive")} {...field} />
-  </FormControl>
-  <FormMessage /> {/* appears below */}
-</FormItem>
-```
+The message appears below the field and the input shows a destructive border — both signals together. **This is automatic in the standard `FormField` pattern**: `FormControl` sets `aria-invalid` when the field has an error, `Input` styles its border destructive on `aria-invalid`, and `FormMessage` renders the message. Do not add a manual `border-destructive` class.
 
 ### Submission errors
 
@@ -65,12 +68,7 @@ When a form submission fails (server error), show an inline error banner inside 
 
 ## Confirmation Dialogs
 
-Use `<AlertDialog>` only for:
-
-1. **Destructive/irreversible actions**: Delete account, concede game, end game
-2. **Unexpected required information**: Something the user must acknowledge before proceeding that could not have been anticipated
-
-Do not use `<AlertDialog>` for: secondary information, player profiles, settings, or anything that could be a `<Sheet>`.
+See [./navigation-layout.md](./navigation-layout.md) for when a confirmation belongs in an `<AlertDialog>` versus a `<Sheet>`. When you do use an `<AlertDialog>`, the copy follows this format:
 
 ### Copy format
 
@@ -90,27 +88,26 @@ Description: "You will be eliminated. Your units are disbanded and your supply c
 
 ## Button Loading State
 
-When an action is in progress, replace the button label with a spinner icon. The button remains disabled and its width does not change (use a fixed-width container if needed).
+When an action is in progress, show a spinner before the button's label and disable the button. Keep the label — do not change it to "Creating..." or "Loading...".
 
 ```tsx
 <Button disabled={isPending}>
-  {isPending ? <Loader2 className="size-4 animate-spin" /> : "Create Game"}
+  {isPending && <Loader2 className="size-4 animate-spin" />}
+  Create Game
 </Button>
 ```
-
-Do not show "Creating..." text. Do not show a spinner alongside text.
 
 ---
 
 ## Urgency Signals
 
-For approaching deadlines, change the color of the time display:
+Signal urgency through color escalation only. Do not add pulsing animations or banner alerts — push notifications handle proactive alerting; the in-app UI escalates color as the situation becomes more urgent.
+
+Example — an approaching deadline, by colouring the time display:
 
 - Normal: default text color
 - ~6 hours remaining: amber/warning color
 - ~2 hours remaining: red/destructive color
-
-Do not add pulsing animations or banner alerts. Push notifications handle proactive alerting — the in-app UI signals urgency through color only.
 
 ---
 

--- a/.claude/skills/ux-patterns/form-controls.md
+++ b/.claude/skills/ux-patterns/form-controls.md
@@ -1,0 +1,105 @@
+# Form Controls
+
+## The Decision Tree
+
+### Single-select fields
+
+Start with the number of options and their label length:
+
+| Options | Label length | Control |
+|---------|-------------|---------|
+| 2 | Any | Segmented control (horizontal equal-weight pills) |
+| 3–4 | Short (1–2 words) | Segmented control |
+| 3–4 | Long (3+ words) | Vertical radio group |
+| 3–4 | Each has a description | Radio group with description under each label — OR slider if options form a spectrum (see below) |
+| 5+ | Any | `<Select>` dropdown |
+| 10+ | Predictable/searchable names | Combobox (typeahead) |
+
+**Spectrum options → Slider.** When options represent a continuum from permissive to restrictive (e.g. player reliability: Open → Reliable+New → Reliable Only), use a slider. Left = most open, right = most restrictive. Label the endpoints and current value.
+
+**CRITICAL: `<Tabs>` is never a form control.** It is navigation only. The current codebase incorrectly uses `<Tabs>` for `deadlineMode` and `variantCategory` — those are anti-patterns to fix, not to follow.
+
+---
+
+### Binary toggles (exactly 2 options)
+
+- **On/off semantics** (enabling a feature): `<Switch>`. Example: Private game, Push notifications.
+- **Two named alternatives** (neither is obviously "on"): Radio buttons. Example: Fixed Time vs Duration deadlines, Random vs Ordered nation assignment.
+
+Never use `<Tabs>` for binary form choices.
+
+---
+
+### Boolean fields
+
+Use `<Checkbox>` with `FormLabel` to the right. For settings rows (Account screen), use `<Switch>` with the label to the right of the toggle.
+
+---
+
+### Number inputs
+
+| Range / context | Control |
+|----------------|---------|
+| Small integers, ≤5 options | Stepper (− display +) |
+| Spectrum with visual meaning | Slider |
+| Large, precise, or open-ended | Plain numeric `<Input type="number">` |
+
+---
+
+### Multi-select fields
+
+Use a vertical checkbox list (`<Checkbox>` group). This applies when ≤8 options are available. For longer lists that need search, use a Popover-based combobox with checkboxes inside.
+
+---
+
+### Searchable selects
+
+Use a Combobox (typeahead input + filtered dropdown) when the list has 10+ options with predictable names that benefit from typing. Do not use a Combobox just because the list is long — only when searching is genuinely useful.
+
+The timezone selector currently has enough options for a Combobox, but the options are too similar (all "City (Region)" format) to benefit from search — keep it as a `<Select>`. A community variant selector with hundreds of variants would warrant a Combobox.
+
+---
+
+### Paired fields
+
+When two fields logically belong together (e.g. time + timezone, movement duration + retreat duration), place them in a 2-column grid on the same row:
+
+```tsx
+<div className="grid grid-cols-2 gap-4">
+  <FormField name="fixedDeadlineTime" ... />
+  <FormField name="fixedDeadlineTimezone" ... />
+</div>
+```
+
+This is the only case where form fields share a row. All other fields are full-width stacked.
+
+---
+
+### Option label overflow
+
+Truncate long labels with ellipsis after 1 line. Always add a tooltip that shows the full label on hover (desktop) or long press (mobile). Never wrap labels across 2 lines in a segmented control.
+
+---
+
+## Component Reference
+
+| Control | Radix/shadcn component |
+|---------|----------------------|
+| Segmented control | `<Tabs>` used as a UI primitive (not for navigation) — or custom button group |
+| Radio group | `@radix-ui/react-radio-group` — not yet in `components/ui/`, add if needed |
+| Slider | `@radix-ui/react-slider` — not yet in `components/ui/`, add if needed |
+| Select/dropdown | `<Select>` from `@/components/ui/select` |
+| Combobox | `<Popover>` + `<Command>` (cmdk) — add if needed |
+| Checkbox | `<Checkbox>` from `@/components/ui/checkbox` |
+| Switch | `<Switch>` from `@/components/ui/switch` |
+| Stepper | Custom: two `<Button size="icon">` flanking a display span |
+
+---
+
+## Anti-patterns in the current codebase (do not follow)
+
+- `mode` field (Standard/Gunboat/Sandbox): currently `<Select>` with 3 options → should be radio group (labels are short-ish but options have meaningfully different descriptions)
+- `nmrExtensionsAllowed` (None/1 per player/2 per player): currently `<Select>` with 3 short options → should be segmented control
+- `minReliability` (Open/Reliable+New/Reliable Only): currently `<Select>` with descriptions → should be slider (spectrum)
+- `deadlineMode` (Fixed Time/Duration): currently `<Tabs>` used as form selector → should be radio buttons
+- Theme selector (Light/Dark/System): currently `<Select>` with 3 options → should be segmented control

--- a/.claude/skills/ux-patterns/form-controls.md
+++ b/.claude/skills/ux-patterns/form-controls.md
@@ -15,9 +15,11 @@ Start with the number of options and their label length:
 | 5+ | Any | `<Select>` dropdown |
 | 10+ | Predictable/searchable names | Combobox (typeahead) |
 
+Examples: three short-label options (Light / Dark / System, or None / 1 / 2) → segmented control; three options that each need a description (game mode: Standard / Gunboat / Sandbox) → radio group with descriptions.
+
 **Spectrum options → Slider.** When options represent a continuum from permissive to restrictive (e.g. player reliability: Open → Reliable+New → Reliable Only), use a slider. Left = most open, right = most restrictive. Label the endpoints and current value.
 
-**CRITICAL: `<Tabs>` is never a form control.** It is navigation only. The current codebase incorrectly uses `<Tabs>` for `deadlineMode` and `variantCategory` — those are anti-patterns to fix, not to follow.
+**CRITICAL: `<Tabs>` is never a form control.** It is navigation only — never use it to drive form field selection or binary choices. Use a segmented control or radio group instead.
 
 ---
 
@@ -81,25 +83,11 @@ Truncate long labels with ellipsis after 1 line. Always add a tooltip that shows
 
 ---
 
-## Component Reference
+## Lists: Cards vs Rows
 
-| Control | Radix/shadcn component |
-|---------|----------------------|
-| Segmented control | `<Tabs>` used as a UI primitive (not for navigation) — or custom button group |
-| Radio group | `@radix-ui/react-radio-group` — not yet in `components/ui/`, add if needed |
-| Slider | `@radix-ui/react-slider` — not yet in `components/ui/`, add if needed |
-| Select/dropdown | `<Select>` from `@/components/ui/select` |
-| Combobox | `<Popover>` + `<Command>` (cmdk) — add if needed |
-| Checkbox | `<Checkbox>` from `@/components/ui/checkbox` |
-| Switch | `<Switch>` from `@/components/ui/switch` |
-| Stepper | Custom: two `<Button size="icon">` flanking a display span |
+| Content type | Component |
+|-------------|-----------|
+| Rich items with preview (games, variants with map) | `<Card>` or `<ScreenCard>` |
+| Simple items (players, account settings, nav items) | `<Item>` / `<ItemGroup>` from `@/components/ui/item` |
 
----
-
-## Anti-patterns in the current codebase (do not follow)
-
-- `mode` field (Standard/Gunboat/Sandbox): currently `<Select>` with 3 options → should be radio group (labels are short-ish but options have meaningfully different descriptions)
-- `nmrExtensionsAllowed` (None/1 per player/2 per player): currently `<Select>` with 3 short options → should be segmented control
-- `minReliability` (Open/Reliable+New/Reliable Only): currently `<Select>` with descriptions → should be slider (spectrum)
-- `deadlineMode` (Fixed Time/Duration): currently `<Tabs>` used as form selector → should be radio buttons
-- Theme selector (Light/Dark/System): currently `<Select>` with 3 options → should be segmented control
+Within a list, all items must use the same component. Never mix cards and rows. (Players are rows today; this may shift toward cards as more player data — reliability, rating — is surfaced.)

--- a/.claude/skills/ux-patterns/interaction-patterns.md
+++ b/.claude/skills/ux-patterns/interaction-patterns.md
@@ -1,0 +1,173 @@
+# Interaction Patterns
+
+## Optimistic Updates
+
+Three tiers based on action stakes:
+
+### Standard optimistic (messaging, non-critical actions)
+Update the UI immediately. If the server rejects, revert silently and show an error toast. No success toast — the UI state change is the confirmation.
+
+### Orders: optimistic + success confirmation
+Game orders are the exception. Update the UI immediately (optimistic), then show a success toast when the server confirms. This is non-negotiable: a missed order can lose a game. The player needs to know their order was received.
+
+```tsx
+// After mutateAsync resolves:
+toast.success("Orders submitted")
+```
+
+Do not apply this pattern elsewhere — it would create noise. Only game orders warrant explicit server confirmation.
+
+### Pessimistic (one-shot actions: join game, create game)
+Wait for the server before updating the UI. Show a spinner on the button. No optimistic state change. If it fails, the user is still in the same state they started from.
+
+---
+
+## Undo
+
+For reversible destructive actions (actions the user can redo without consequence, e.g. leaving a lobby they can rejoin):
+
+1. Execute the action immediately
+2. Show a toast: `"You left the lobby" [Undo]`
+3. Undo window: ~5 seconds
+4. If the user doesn't undo, the action is committed
+
+For irreversible actions, use a confirmation dialog instead (see [./feedback-patterns.md](./feedback-patterns.md)).
+
+---
+
+## Live Updates
+
+When new data arrives while the user is viewing a screen (e.g. a new game phase starts):
+
+- Show a toast describing what changed
+- Automatically refresh the relevant list/screen
+
+Do not use "New content available — tap to refresh" banners. The toast + auto-refresh handles it.
+
+---
+
+## Infinite Scroll
+
+For lists that can grow unboundedly (game history, message history), load more content as the user scrolls to the bottom. No "Load more" button. No pagination controls.
+
+Use TanStack Query's `useInfiniteQuery` with an intersection observer on the last item.
+
+---
+
+## Pull to Refresh
+
+Support pull-to-refresh only on screens where real-time state matters:
+
+- My Games list
+- Active game phase screen
+
+Other screens (profile, settings, variants) do not need pull-to-refresh — data there changes infrequently.
+
+---
+
+## Inline Editing
+
+See [./navigation-layout.md](./navigation-layout.md) for the full pattern. Summary: tap edit icon → Input appears in-place → Save/Cancel icon buttons appear inline → success returns to display state → failure shows inline error.
+
+---
+
+## Empty States
+
+All empty states include: icon + title + description + primary CTA (action to resolve the empty state).
+
+```tsx
+<Notice
+  icon={Users}
+  title="No games found"
+  message="Try a different filter or create your own game."
+  action={<Button>Create Game</Button>}
+/>
+```
+
+**No-results state** (search/filter returned nothing): "No results" title + "Clear filters" CTA. No icon needed — keep it lightweight.
+
+---
+
+## Multi-Select with Checkboxes
+
+In a vertical checkbox list, when the user has applied selections and the state is "nothing found":
+
+Show the empty state with a "Clear filters" button that resets all selections to their default (unselected) state.
+
+---
+
+## Notification Badges
+
+| Situation | Component |
+|-----------|-----------|
+| "Your turn" on a nav item | Dot indicator (colored dot, no count) |
+| Unread message count | Numeric badge |
+| Phase or game status | Semantic `<Badge>` (colored pill) |
+| Metadata count (3/7 players) | Muted text — no badge |
+
+---
+
+## Game Order Submission Flow
+
+Direct manipulation on the map — tapping a unit shows order options contextually, inline on or near the map. No separate wizard panel. No sheet for order type selection.
+
+This is the existing pattern in the codebase. Do not change it to a side-panel form.
+
+---
+
+## Accordion: Orders Display
+
+When showing resolved orders for a completed phase:
+
+- Collapsed by default (one row per nation)
+- Individual rows expand/collapse on tap
+- Always include "Expand all" / "Collapse all" controls above the accordion
+
+```tsx
+<div className="flex justify-end gap-3 text-sm mb-2">
+  <button
+    className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+    onClick={() => setExpandedItems(allNationIds)}
+  >
+    Expand all
+  </button>
+  <button
+    className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+    onClick={() => setExpandedItems([])}
+  >
+    Collapse all
+  </button>
+</div>
+```
+
+---
+
+## First-Time Feature Encounter
+
+When a user encounters a feature for the first time (not covered in the new-player introduction):
+
+Show a subtle muted text block below the relevant UI element. It disappears after the user takes their first action. It does not reappear.
+
+This is the only contextual help mechanism for first encounters. Do not use highlighted "New" badges, modal announcements, or coach marks.
+
+---
+
+## App Updates
+
+Non-breaking updates: distribute automatically through the app store. No in-app prompt, no banner, no notification. Users receive the update silently.
+
+Breaking updates (if ever required): blocking `<AlertDialog>` that prevents use until updated. This should be extremely rare.
+
+---
+
+## Animations
+
+Minimal. Only animate when the animation communicates a state change:
+
+- Sheet slides in from bottom/right when opening
+- Fields fade in/slide in when conditionally appearing
+- Fields fade out when conditionally removed
+
+Do not animate: page transitions, hover states, data loading, list item appearance. The game context does not call for decorative motion — players are focused on the board.
+
+Use Tailwind's `animate-in`, `fade-in`, `slide-in-from-top-1`, `duration-150` for conditional field appearance/disappearance. Use the default Radix animation for Sheet/Dialog (already built in).

--- a/.claude/skills/ux-patterns/interaction-patterns.md
+++ b/.claude/skills/ux-patterns/interaction-patterns.md
@@ -10,11 +10,6 @@ Update the UI immediately. If the server rejects, revert silently and show an er
 ### Orders: optimistic + success confirmation
 Game orders are the exception. Update the UI immediately (optimistic), then show a success toast when the server confirms. This is non-negotiable: a missed order can lose a game. The player needs to know their order was received.
 
-```tsx
-// After mutateAsync resolves:
-toast.success("Orders submitted")
-```
-
 Do not apply this pattern elsewhere — it would create noise. Only game orders warrant explicit server confirmation.
 
 ### Pessimistic (one-shot actions: join game, create game)
@@ -24,14 +19,7 @@ Wait for the server before updating the UI. Show a spinner on the button. No opt
 
 ## Undo
 
-For reversible destructive actions (actions the user can redo without consequence, e.g. leaving a lobby they can rejoin):
-
-1. Execute the action immediately
-2. Show a toast: `"You left the lobby" [Undo]`
-3. Undo window: ~5 seconds
-4. If the user doesn't undo, the action is committed
-
-For irreversible actions, use a confirmation dialog instead (see [./feedback-patterns.md](./feedback-patterns.md)).
+See [./feedback-patterns.md](./feedback-patterns.md) for the canonical Undo pattern: execute immediately, show a toast with an Undo action, and reverse via a separate request on undo. For irreversible actions, use a confirmation dialog instead.
 
 ---
 
@@ -40,9 +28,11 @@ For irreversible actions, use a confirmation dialog instead (see [./feedback-pat
 When new data arrives while the user is viewing a screen (e.g. a new game phase starts):
 
 - Show a toast describing what changed
-- Automatically refresh the relevant list/screen
+- Automatically reload the relevant screen content
 
-Do not use "New content available — tap to refresh" banners. The toast + auto-refresh handles it.
+Do not use "New content available — tap to refresh" banners. The toast + auto-reload handles it.
+
+When the current phase resolves while the user is viewing an older phase, shift them to the newest phase anyway, and show a toast telling them it updated. One consistent rule (always show the latest) is worth more than the rare moment of being moved off a phase they were reviewing — and the toast explains why.
 
 ---
 
@@ -65,9 +55,22 @@ Other screens (profile, settings, variants) do not need pull-to-refresh — data
 
 ---
 
+## Touch Targets
+
+Minimum 48×48dp for all interactive elements on mobile. If a visual element is smaller (e.g. a 16×16 icon), expand the hit area with padding. The `size="icon"` variant on `<Button>` handles this for icon buttons — do not reduce it.
+
+---
+
 ## Inline Editing
 
-See [./navigation-layout.md](./navigation-layout.md) for the full pattern. Summary: tap edit icon → Input appears in-place → Save/Cancel icon buttons appear inline → success returns to display state → failure shows inline error.
+For editable fields on non-form screens (e.g. username on the Account screen):
+
+1. Show value + edit icon (`<Pencil>` button with `aria-label`)
+2. Tap edit: the value is replaced with an `<Input>` pre-filled with the current value
+3. Show Save (`<Check>`) and Cancel (`<X>`) icon buttons to the right
+4. Save/Cancel appear immediately — never below the field
+5. On save success: return to display state
+6. On save failure: show the error message inline below the input (not a toast)
 
 ---
 
@@ -80,30 +83,11 @@ All empty states include: icon + title + description + primary CTA (action to re
   icon={Users}
   title="No games found"
   message="Try a different filter or create your own game."
-  action={<Button>Create Game</Button>}
+  actions={<Button>Create Game</Button>}
 />
 ```
 
 **No-results state** (search/filter returned nothing): "No results" title + "Clear filters" CTA. No icon needed — keep it lightweight.
-
----
-
-## Multi-Select with Checkboxes
-
-In a vertical checkbox list, when the user has applied selections and the state is "nothing found":
-
-Show the empty state with a "Clear filters" button that resets all selections to their default (unselected) state.
-
----
-
-## Notification Badges
-
-| Situation | Component |
-|-----------|-----------|
-| "Your turn" on a nav item | Dot indicator (colored dot, no count) |
-| Unread message count | Numeric badge |
-| Phase or game status | Semantic `<Badge>` (colored pill) |
-| Metadata count (3/7 players) | Muted text — no badge |
 
 ---
 
@@ -112,51 +96,6 @@ Show the empty state with a "Clear filters" button that resets all selections to
 Direct manipulation on the map — tapping a unit shows order options contextually, inline on or near the map. No separate wizard panel. No sheet for order type selection.
 
 This is the existing pattern in the codebase. Do not change it to a side-panel form.
-
----
-
-## Accordion: Orders Display
-
-When showing resolved orders for a completed phase:
-
-- Collapsed by default (one row per nation)
-- Individual rows expand/collapse on tap
-- Always include "Expand all" / "Collapse all" controls above the accordion
-
-```tsx
-<div className="flex justify-end gap-3 text-sm mb-2">
-  <button
-    className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
-    onClick={() => setExpandedItems(allNationIds)}
-  >
-    Expand all
-  </button>
-  <button
-    className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
-    onClick={() => setExpandedItems([])}
-  >
-    Collapse all
-  </button>
-</div>
-```
-
----
-
-## First-Time Feature Encounter
-
-When a user encounters a feature for the first time (not covered in the new-player introduction):
-
-Show a subtle muted text block below the relevant UI element. It disappears after the user takes their first action. It does not reappear.
-
-This is the only contextual help mechanism for first encounters. Do not use highlighted "New" badges, modal announcements, or coach marks.
-
----
-
-## App Updates
-
-Non-breaking updates: distribute automatically through the app store. No in-app prompt, no banner, no notification. Users receive the update silently.
-
-Breaking updates (if ever required): blocking `<AlertDialog>` that prevents use until updated. This should be extremely rare.
 
 ---
 

--- a/.claude/skills/ux-patterns/microcopy.md
+++ b/.claude/skills/ux-patterns/microcopy.md
@@ -8,6 +8,7 @@
 - No thematic language ("dispatches", "nations" in button labels)
 - No exclamation marks
 - No first-person from the app ("We couldn't find that game")
+- No em-dashes, no marketing or LLM-flavored phrasing ("seamless", "effortless", "unlock"). UI copy should read like a human wrote it tersely.
 - Short sentences. Active voice.
 
 ---
@@ -28,7 +29,22 @@
 
 In a multi-step form, the final submit button names the outcome ("Create Game"), not the action ("Submit"). All other buttons: Next, Back — no label needed beyond that.
 
-When an action is in progress, the button shows a spinner (no text). Never "Creating...", never "Loading...".
+When an action is in progress, the button shows a spinner before its label and the label stays. Never change it to "Creating..." or "Loading...".
+
+### Icon-only buttons
+
+Any button whose only content is an icon (no visible text label) must have both an `aria-label` and a visible tooltip — the `aria-label` for screen readers, the tooltip for sighted users.
+
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button size="icon" variant="ghost" aria-label="Edit name" onClick={handleEdit}>
+      <Pencil className="size-4" />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>Edit name</TooltipContent>
+</Tooltip>
+```
 
 ---
 
@@ -128,18 +144,7 @@ Do not add a third sentence suggesting the next step. The implication makes it c
 
 ## Empty States
 
-Every empty state has: icon + title + description + primary CTA.
-
-```tsx
-<Notice
-  icon={Map}
-  title="No games yet"
-  message="Join an existing game or create your own."
-  action={<Button>Find a Game</Button>}
-/>
-```
-
-When the empty state results from a search or filter with no results, the CTA is "Clear filters" instead of a creation action. Title: "No results". No description needed — the filter state is already visible.
+See [./interaction-patterns.md](./interaction-patterns.md) for the empty-state pattern (structure and the no-results variant). For the copy: the title names what's missing ("No games yet"), the message is one short sentence pointing to the resolving action ("Join an existing game or create your own."), and the CTA verb names that action ("Find a Game"). A no-results state uses the title "No results" and a "Clear filters" CTA, with no description.
 
 ---
 

--- a/.claude/skills/ux-patterns/microcopy.md
+++ b/.claude/skills/ux-patterns/microcopy.md
@@ -1,0 +1,159 @@
+# Microcopy
+
+## Tone of Voice
+
+**Serious and direct.** This is a strategy game. Players are focused. They want efficiency, not charm.
+
+- No personality, warmth, or wit in UI copy
+- No thematic language ("dispatches", "nations" in button labels)
+- No exclamation marks
+- No first-person from the app ("We couldn't find that game")
+- Short sentences. Active voice.
+
+---
+
+## Button Labels
+
+**Title Case imperative verb phrase.** Always specific — name the object being acted on.
+
+| Do | Don't |
+|----|-------|
+| Create Game | Create |
+| Join Game | Join |
+| Save Changes | Save |
+| Delete Account | Delete |
+| Submit Orders | Submit |
+| Leave Game | Leave |
+| View Profile | View |
+
+In a multi-step form, the final submit button names the outcome ("Create Game"), not the action ("Submit"). All other buttons: Next, Back — no label needed beyond that.
+
+When an action is in progress, the button shows a spinner (no text). Never "Creating...", never "Loading...".
+
+---
+
+## Placeholder Text
+
+Placeholders are for **example values only**. They are never a substitute for a label.
+
+```
+Good:  placeholder="e.g. Summer 1901"
+Good:  placeholder="HH:MM"
+Bad:   placeholder="Enter game name"   ← that's the label's job
+Bad:   placeholder="Select a timezone" ← use the FormLabel
+```
+
+If the field has no useful example to show, leave the placeholder empty. Do not add ghost text that describes the field — the `<FormLabel>` does that.
+
+---
+
+## Help Text (FormDescription)
+
+Show only when **the field purpose is non-obvious** or **there is a constraint with real consequences**.
+
+Simple fields (Name, Email, Time) need no description. If a user would understand the field from its label alone, omit the description.
+
+When description is needed, describe **consequences**, not the field:
+
+```
+Good:  "Only players with a history of completing games can join."
+Bad:   "Set the minimum reliability level for players who can join this game."
+
+Good:  "Player names and messaging are disabled."
+Bad:   "Gunboat mode hides player identities."
+```
+
+After the inline description, add a `(i)` tooltip only if misunderstanding has meaningful consequences. See [./progressive-disclosure.md](./progressive-disclosure.md) for the full (i) pattern.
+
+---
+
+## Error Copy
+
+**Short and specific.** State the violated constraint, nothing more.
+
+| Good | Bad |
+|------|-----|
+| Name required | Please enter a game name |
+| Too long | Game name must be less than 100 characters |
+| Must be at least 2 characters | Your name is too short |
+| Invalid email | Please enter a valid email address |
+
+No "Please". No full sentences. No apologies. No suggestions for what to do — the label and field make the fix obvious.
+
+---
+
+## Explanatory Errors (Complex Situations)
+
+When an error requires the user to understand *why* something failed before they can proceed:
+
+**Pattern: reason + implication. No next action.**
+
+```
+"The movement phase has ended. Your orders were not submitted."
+"This game is full. You cannot join."
+"Your session has expired. Log in again to continue."
+```
+
+Do not add a third sentence suggesting the next step. The implication makes it clear. The UI around the error provides the path forward.
+
+---
+
+## Confirmation Dialog Copy
+
+**Title**: Verb-first, names the action. No question. No "Are you sure?"
+
+**Description**: Specific consequence. What exactly is lost or changed. No "This cannot be undone."
+
+```tsx
+// Good
+<AlertDialogTitle>Delete account</AlertDialogTitle>
+<AlertDialogDescription>
+  Your profile, game history, and all associated data will be permanently deleted.
+</AlertDialogDescription>
+
+// Good
+<AlertDialogTitle>Leave game</AlertDialogTitle>
+<AlertDialogDescription>
+  You will be removed from the game and cannot rejoin.
+</AlertDialogDescription>
+
+// Bad
+<AlertDialogTitle>Are you sure?</AlertDialogTitle>
+<AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+```
+
+**Action buttons**: Primary = the destructive action (verb-only: "Delete", "Leave", "Concede"). Secondary = "Cancel".
+
+---
+
+## Empty States
+
+Every empty state has: icon + title + description + primary CTA.
+
+```tsx
+<Notice
+  icon={Map}
+  title="No games yet"
+  message="Join an existing game or create your own."
+  action={<Button>Find a Game</Button>}
+/>
+```
+
+When the empty state results from a search or filter with no results, the CTA is "Clear filters" instead of a creation action. Title: "No results". No description needed — the filter state is already visible.
+
+---
+
+## Section Headings in Forms
+
+Section headings use `<h2 className="text-lg font-semibold">` followed by `space-y-4` around the fields. Use a `<hr className="border-t">` to separate logically distinct groups within a single form step (e.g. separating variant selection from the mode fields above it).
+
+Do not wrap sections in separate cards within a single form step. The step itself is the container.
+
+---
+
+## Dates and Times
+
+- **Near future/past** (within ~7 days): relative — "in 3h", "2 days ago", "in 5 min"
+- **Distant**: absolute — "Mon 15 Jun, 21:00" using the user's locale
+- **Deadlines**: always relative when within 7 days (urgency is what matters)
+- **Phase history**: absolute (historical record)

--- a/.claude/skills/ux-patterns/navigation-layout.md
+++ b/.claude/skills/ux-patterns/navigation-layout.md
@@ -87,73 +87,21 @@ The wizard exists because all steps require conscious decisions. Do not skip ste
 
 ---
 
-## Inline Editing
+## Settings
 
-For editable fields on non-form screens (e.g. username on Account screen):
+Group settings by topic — what they control (e.g. Profile, Notifications, Appearance) — not by where their value is stored. Users reason about the thing being configured, not whether it lives on the device or the account.
 
-1. Show value + edit icon (`<Pencil>` button with `aria-label`)
-2. Tap edit: value is replaced with `<Input>` pre-filled with current value
-3. Show Save (`<Check>`) and Cancel (`<X>`) icon buttons to the right
-4. Save/Cancel appear immediately — never below the field
-5. On save success: return to display state
-6. On save failure: show error message inline below the input (not a toast)
-
----
-
-## Settings: Local vs Global
-
-The Account screen contains both device-local settings (e.g. Push Notifications) and global account settings (e.g. username, theme preference). These must be visually separated with distinct section headings:
-
-- "This device" or "Notifications" — settings that apply to this device only
-- "Account" — profile settings that apply everywhere
-
-Never mix the two groups in the same section.
-
----
-
-## Icon-Only Buttons
-
-Both `aria-label` and a visible tooltip are required. No exceptions.
-
-```tsx
-<Tooltip>
-  <TooltipTrigger asChild>
-    <Button size="icon" variant="ghost" aria-label="Edit name" onClick={handleEdit}>
-      <Pencil className="size-4" />
-    </Button>
-  </TooltipTrigger>
-  <TooltipContent>Edit name</TooltipContent>
-</Tooltip>
-```
-
----
-
-## Touch Targets
-
-Minimum 48×48dp for all interactive elements on mobile. If a visual element is smaller (e.g. a 16×16 icon), expand the hit area with padding. The `size="icon"` variant on `<Button>` handles this for icon buttons — do not reduce it.
-
----
-
-## Lists: Cards vs Rows
-
-| Content type | Component |
-|-------------|-----------|
-| Rich items with preview (games, variants with map) | `<Card>` or `<ScreenCard>` |
-| Simple items (players, account settings, nav items) | `<Item>` / `<ItemGroup>` from `@/components/ui/item` |
-
-Within a list, all items must use the same component. Never mix cards and rows.
+Some settings apply only to the current device (e.g. push notifications). Where that scope isn't obvious, add a small muted indicator on the individual setting ("This device") rather than splitting the screen by storage location.
 
 ---
 
 ## Notification Badges
 
-| Signal | Style |
-|--------|-------|
-| "Your turn" (binary) | Dot indicator — colored dot, no count |
-| Unread messages (quantitative) | Numeric badge count |
-| Phase status, game status | Colored `<Badge>` with semantic color |
-| Metadata (3/7 players) | Muted text, no badge |
+Match the badge to the *kind* of signal it carries:
 
-Semantic badge colors: red = urgent/requires action, yellow = warning/approaching deadline, green = success/complete, blue = informational.
+- **Binary** ("your turn", something needs attention) → a dot indicator, no count
+- **Quantitative** (unread messages) → a numeric badge count
+- **Status** (phase status, game status) → a `<Badge>` whose color carries meaning: red = urgent/requires action, yellow = warning/approaching deadline, green = success/complete, blue = informational
+- **Passive metadata** (3/7 players) → muted text, never a badge
 
-In the game map and board context, color alone may convey nation identity — a visible legend must accompany any color-only encoding.
+Color is never the only carrier of meaning. Where color encodes something — a semantic badge, or nation identity on the map/board — a label or visible legend must accompany it.

--- a/.claude/skills/ux-patterns/navigation-layout.md
+++ b/.claude/skills/ux-patterns/navigation-layout.md
@@ -1,0 +1,159 @@
+# Navigation & Layout
+
+## Screen Structure
+
+Every screen follows this hierarchy:
+
+```
+ScreenContainer
+  ScreenHeader (title, optional back button, optional header action)
+  QueryErrorBoundary
+    Suspense (with skeleton fallback)
+      ScreenCard / ScreenCard / ...
+        ScreenCardContent
+          [screen content]
+```
+
+Never put layout wrappers inside a screen component. Layouts (`HomeLayout`, `GameDetailLayout`) are applied at the router level via `<Outlet />`. Screens return content only.
+
+---
+
+## Typography Hierarchy
+
+Maximum 3 levels per screen:
+
+- `<ScreenHeader title="...">` → renders as `h1`
+- Section headings inside cards → `<h2 className="text-lg font-semibold">`
+- Sub-section headings → `<h3 className="text-sm font-medium">`
+
+Never go deeper than h3. Never use bold text to substitute for a heading level.
+
+---
+
+## Sheet vs Dialog: The Rule
+
+**`<Sheet>`** (drawer/bottom sheet): for secondary content and quick-peek panels.
+
+Use for: player profiles, game info detail, settings that don't require a decision, any content the user might want to reference while staying in context.
+
+**`<AlertDialog>`**: for interruptions only.
+
+Use for:
+1. Destructive/irreversible action confirmation
+2. Unexpected information the user must acknowledge before continuing
+
+Do not use Dialog or AlertDialog for information, navigation, or secondary content. If there's no decision to make, it's a Sheet.
+
+When a Sheet or Dialog opens, focus moves to the first interactive element (Radix default behavior — do not override).
+
+---
+
+## Navigation Patterns
+
+### Multi-mode screens (My Games / Find Games)
+
+- **Desktop**: sidebar navigation
+- **Mobile**: bottom tab bar
+
+### Tabs (reminder)
+
+`<Tabs>` is a navigation primitive only. It renders peer-level views the user switches between, like "My Games" and "Find Games". It is never used for form field selection.
+
+### Action placement
+
+- **Screen header (top right)**: global or screen-level actions — Add, Filter, Settings icon
+- **Bottom of content**: primary form submission — Next, Create Game, Save Changes
+- **Inline with content**: contextual row-level actions — Edit pencil, join button on a game card
+
+### Button layout by context
+
+| Context | Layout |
+|---------|--------|
+| Mobile, single action | Full-width button |
+| Mobile, primary + secondary | Full-width primary, secondary as ghost/text link below |
+| Desktop, form with Back/Next | Side-by-side equal-width buttons in a flex row |
+| Mobile, form with Back/Next | Full-width stack (Back above Next), or full-width Next only with Back as text link |
+
+---
+
+## Multi-Step Forms (Stepper)
+
+- Back on step 1 = native navigation (exit the flow)
+- Back on step 2+ = previous step
+- If the form has been modified and user attempts to exit from step 1, prompt before discarding
+- Stepper does not allow skipping steps — each step must be validated before advancing
+
+The wizard exists because all steps require conscious decisions. Do not skip steps programmatically or pre-validate on behalf of the user.
+
+---
+
+## Inline Editing
+
+For editable fields on non-form screens (e.g. username on Account screen):
+
+1. Show value + edit icon (`<Pencil>` button with `aria-label`)
+2. Tap edit: value is replaced with `<Input>` pre-filled with current value
+3. Show Save (`<Check>`) and Cancel (`<X>`) icon buttons to the right
+4. Save/Cancel appear immediately — never below the field
+5. On save success: return to display state
+6. On save failure: show error message inline below the input (not a toast)
+
+---
+
+## Settings: Local vs Global
+
+The Account screen contains both device-local settings (e.g. Push Notifications) and global account settings (e.g. username, theme preference). These must be visually separated with distinct section headings:
+
+- "This device" or "Notifications" — settings that apply to this device only
+- "Account" — profile settings that apply everywhere
+
+Never mix the two groups in the same section.
+
+---
+
+## Icon-Only Buttons
+
+Both `aria-label` and a visible tooltip are required. No exceptions.
+
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button size="icon" variant="ghost" aria-label="Edit name" onClick={handleEdit}>
+      <Pencil className="size-4" />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>Edit name</TooltipContent>
+</Tooltip>
+```
+
+---
+
+## Touch Targets
+
+Minimum 48×48dp for all interactive elements on mobile. If a visual element is smaller (e.g. a 16×16 icon), expand the hit area with padding. The `size="icon"` variant on `<Button>` handles this for icon buttons — do not reduce it.
+
+---
+
+## Lists: Cards vs Rows
+
+| Content type | Component |
+|-------------|-----------|
+| Rich items with preview (games, variants with map) | `<Card>` or `<ScreenCard>` |
+| Simple items (players, account settings, nav items) | `<Item>` / `<ItemGroup>` from `@/components/ui/item` |
+
+Within a list, all items must use the same component. Never mix cards and rows.
+
+---
+
+## Notification Badges
+
+| Signal | Style |
+|--------|-------|
+| "Your turn" (binary) | Dot indicator — colored dot, no count |
+| Unread messages (quantitative) | Numeric badge count |
+| Phase status, game status | Colored `<Badge>` with semantic color |
+| Metadata (3/7 players) | Muted text, no badge |
+
+Semantic badge colors: red = urgent/requires action, yellow = warning/approaching deadline, green = success/complete, blue = informational.
+
+In the game map and board context, color alone may convey nation identity — a visible legend must accompany any color-only encoding.

--- a/.claude/skills/ux-patterns/progressive-disclosure.md
+++ b/.claude/skills/ux-patterns/progressive-disclosure.md
@@ -1,0 +1,166 @@
+# Progressive Disclosure
+
+Progressive disclosure is about when and how to surface complexity. The guiding principle: show what users need to act, hide what they don't — but never hide it forever.
+
+---
+
+## Two-Tier Explanation Model
+
+The app has two categories of knowledge:
+
+**Tier 1 — App features**: How to use this application. What a deadline mode is, how NMR extensions work, what Game Master controls do. These are explained **inline** using `FormDescription`, `Notice`, or the (i) tooltip pattern.
+
+**Tier 2 — Game rules**: What a convoy is, how supply centers work, what civil disorder means. These are **never explained in the UI** unless the user explicitly asks. Gate them behind a (i) tooltip or a link to the guide. Assume the player knows the game.
+
+---
+
+## The (i) Info Icon Pattern
+
+Use `(i)` when: a feature is **non-obvious** AND misunderstanding it has **meaningful consequences**.
+
+Examples that qualify: deadline mode differences, NMR extension effects, accelerated retreat phases, Game Master implications.
+
+Examples that do not qualify: the Game Name field, whether to make a game private.
+
+**Implementation**: inline `FormDescription` handles the basic explanation. Add an `(i)` icon with a `<Tooltip>` immediately after the description for the fuller explanation. Never use an external link — keep all explanation in-app.
+
+```tsx
+<FormDescription>
+  Automatically extends the deadline when a player hasn't submitted orders.
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Info className="ml-1 inline size-3.5 cursor-help text-muted-foreground" />
+    </TooltipTrigger>
+    <TooltipContent className="max-w-xs">
+      Each player receives this many extensions per game. Extensions are granted
+      automatically 1 hour before the deadline if orders are incomplete. Once
+      exhausted, the player NMRs normally.
+    </TooltipContent>
+  </Tooltip>
+</FormDescription>
+```
+
+---
+
+## First-Time Users
+
+New users encounter an onboarding flow before reaching the main UI. This flow explains what Diplomacy is and what the app does — context before action.
+
+The new-player introduction covers most feature types. If a feature is covered in the introduction, the UI adds no additional explanation.
+
+If a feature is NOT covered in the introduction: show a **subtle muted text block below the relevant UI element** until the user takes their first action with it. After the first action, the text does not reappear.
+
+```tsx
+{!hasSubmittedOrders && (
+  <p className="text-sm text-muted-foreground">
+    Select a unit on the map to begin entering orders.
+  </p>
+)}
+```
+
+---
+
+## Situational Features (First Encounter)
+
+For features that only appear in certain game states (retreat phase, build phase, draw proposals):
+
+- If covered in new-player intro → feature appears without any explanation
+- If not covered → subtle muted inline help visible until first action
+
+Never add "New" badges or one-time announcements. The app is the same for everyone.
+
+---
+
+## Conditional Fields
+
+When a selection makes other fields irrelevant (e.g. "Sandbox" mode removes deadline fields):
+
+- **Immediately remove** the irrelevant fields with a CSS transition (`animate-in fade-in slide-in-from-top-1`)
+- Do not leave disabled ghost fields in the layout
+- Do not explain what disappeared — the removed fields are self-evidently inapplicable to the chosen mode
+
+---
+
+## Gated Options
+
+When an option is available only if another field is set first (e.g. Game Master requires Private game):
+
+- Keep the option **visible but disabled**
+- Use `FormDescription` to explain the condition: "Only available in private games"
+- Do not hide the option — the user needs to know it exists to understand they should first enable the prerequisite
+
+---
+
+## Multi-Step Forms: Conscious Decisions by Design
+
+The Create Game stepper hides deadline and advanced settings behind "Next" — but this is intentional. Deadline mode and game mode are decisions all users must consciously make. The stepper forces attention on each step.
+
+Do not pre-validate or skip steps on behalf of the user. The defaults may be good, but users must see and consciously pass through each step.
+
+---
+
+## Decision Support: Just-in-Time
+
+Show context at the moment of the decision, not before. When the user is on the variant selector, show variant details (map preview, nation count, description). When they're on the deadlines step, show a live summary of what their settings mean.
+
+Do not front-load information. Do not summarize all consequences at the end — each step handles its own context.
+
+---
+
+## Competing Attention
+
+When the user has multiple things to act on (orders to submit, a draw vote open, unread messages), show all of them simultaneously in a dashboard-style view. Do not funnel the user through one task at a time. The user decides their own priority.
+
+---
+
+## Read-Only Complexity (Completed Phases)
+
+When displaying information the user doesn't need to act on (e.g. resolved orders from a completed phase):
+
+- **Collapse by default** using an accordion
+- Each nation's orders are one collapsible row
+- Provide **"Expand all" and "Collapse all"** controls above the accordion — essential for players who want to review the full phase at once
+
+```tsx
+<div className="flex justify-end gap-2 text-sm">
+  <button onClick={expandAll} className="text-muted-foreground hover:text-foreground">
+    Expand all
+  </button>
+  <button onClick={collapseAll} className="text-muted-foreground hover:text-foreground">
+    Collapse all
+  </button>
+</div>
+<Accordion type="multiple" ...>
+  {nations.map(nation => (
+    <AccordionItem key={nation.id} value={nation.id}>
+      <AccordionTrigger>{nation.name}</AccordionTrigger>
+      <AccordionContent>
+        {/* nation's orders */}
+      </AccordionContent>
+    </AccordionItem>
+  ))}
+</Accordion>
+```
+
+---
+
+## Complexity Escalation
+
+When a situation is complex enough to require understanding before acting (e.g. why the user is in civil disorder):
+
+Use the two-layer pattern:
+1. **Brief inline explanation** in a `Notice` or `Alert` on the screen where the situation is encountered
+2. **`(i)` tooltip** for users who want the full picture
+
+Never link to an external guide. Never open a Dialog to explain a situation — that interrupts the flow.
+
+---
+
+## Rare Features
+
+Game Master controls and Sandbox mode are features most users will never use. They are:
+
+- **Always present** in the UI — never behind an "Advanced" toggle
+- **Visually subordinate**: listed after common options, styled at the same weight as other options but not promoted
+
+The visual hierarchy communicates priority naturally. Users who need rare features can find them; users who don't can ignore them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,7 @@ const MyScreen: React.FC = () => {
 const MyScreenSuspense: React.FC = () => (
   <ScreenContainer>
     <ScreenHeader title="My Screen" />
-    <Suspense fallback={<div></div>}>
+    <Suspense fallback={<MyScreenSkeleton />}>
       <MyScreen />
     </Suspense>
   </ScreenContainer>
@@ -434,7 +434,7 @@ The outer wrapper should also include `QueryErrorBoundary` wrapping `Suspense` (
 - Does the inner component use `useXxxSuspense` hooks (not `useXxx`)?
 - Is the outer wrapper present with `ScreenContainer`, `ScreenHeader`, `QueryErrorBoundary`, and `Suspense`?
 - Is the wrapper exported with the screen name?
-- Is the `Suspense` fallback an empty div (not a spinner or skeleton — keep it minimal)?
+- Is the `Suspense` fallback a skeleton that mirrors the screen's content and matches its dimensions (not an empty div or a centered spinner)? The skeleton-to-content swap must not shift layout — see the UX skill's loading-states guidance.
 - Is `QueryErrorBoundary` wrapping `Suspense` (not inside it)? Without it, query errors crash the whole page instead of showing the "Try Again" UI in the content area.
 
 ### Inline Over Extract
@@ -692,7 +692,7 @@ const MyScreenSuspense: React.FC = () => (
   <ScreenContainer>
     <ScreenHeader title="My Screen" />
     <QueryErrorBoundary>
-      <Suspense fallback={<div></div>}>
+      <Suspense fallback={<MyScreenSkeleton />}>
         <MyScreen />
       </Suspense>
     </QueryErrorBoundary>


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/ux-patterns/` — a loadable Claude Code skill that encodes resolved UX design decisions for this codebase
- Covers: form controls, feedback patterns, navigation/layout, progressive disclosure, microcopy, and interaction patterns
- Closes #748

## No visual changes

This is a developer tooling change only — no production code was modified.