### PR TITLE
Fix Enter key inserting no newline in chat on mobile

### DIFF
--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
 import { useDraft, useRequiredParams } from "@/hooks";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
@@ -100,6 +101,7 @@ const ChannelScreen: React.FC = () => {
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
   const [message, setMessage] = useDraft(gameId, channelId);
   const [, setSearchParams] = useSearchParams();
 
@@ -190,6 +192,7 @@ const ChannelScreen: React.FC = () => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isMobile) return;
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit();
@@ -322,6 +325,7 @@ const ChannelScreen: React.FC = () => {
                 placeholder="Type a message"
                 value={message}
                 rows={1}
+                enterKeyHint="enter"
                 onChange={e => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
                 disabled={createMessageMutation.isPending}

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { Send, MessageCircle, MessageSquareOff } from "lucide-react";
 import { useDraft, useRequiredParams } from "@/hooks";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsDesktopWeb } from "@/hooks/use-platform";
 import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
@@ -101,7 +101,7 @@ const ChannelScreen: React.FC = () => {
 
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const isMobile = useIsMobile();
+  const isDesktopWeb = useIsDesktopWeb();
   const [message, setMessage] = useDraft(gameId, channelId);
   const [, setSearchParams] = useSearchParams();
 
@@ -192,7 +192,7 @@ const ChannelScreen: React.FC = () => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (isMobile) return;
+    if (!isDesktopWeb) return;
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit();


### PR DESCRIPTION
## Problem

On the channel screen, the chat message textarea's soft-keyboard return key showed the **enter/newline glyph** but pressing it did nothing — no newline, no send. The only way to send was the on-screen Send button.

## Root cause

`handleKeyDown` applied the desktop "Enter sends, Shift+Enter newlines" rule on **every** device. On a mobile soft keyboard the return key fires `keydown` with `key === "Enter"` and `shiftKey === false`, so the handler ran `e.preventDefault()` — suppressing the textarea's native newline — and then attempted to submit (unreliable on mobile due to composing/IME and the empty-trim guard). Net effect: the key did nothing visible.

## Fix

Gate the Enter-to-send behaviour on **pointer type**, not viewport width. `handleKeyDown` now returns early unless the device is a mouse-driven desktop, letting the keystroke fall through to the textarea's native newline on touch devices. Also add `enterKeyHint="enter"` so the soft-keyboard action key explicitly advertises newline.

The discriminator is the existing `useIsDesktopWeb` hook, which is `false` on native/Capacitor platforms and otherwise matches `(hover: hover) and (pointer: fine)`. This is the correct signal because:

- **Mobile in landscape** — a phone rotated to landscape is wider than the 768px mobile breakpoint, so a viewport-width check (`useIsMobile`) would mis-classify it as desktop and send on Enter. Pointer type is orientation-independent: a touch device stays touch, so Enter inserts a newline in both orientations.
- **Narrow desktop window** — a desktop browser shrunk below 768px still has a fine pointer (mouse), so it keeps Enter-to-send (and Shift+Enter for newline). A viewport-width check would have wrongly dropped Enter-to-send here.

Desktop is unchanged: Enter sends, Shift+Enter newlines. On touch devices, Enter newlines and sending goes through the Send button.

## Verification

- `npx eslint src/screens/GameDetail/ChannelScreen.tsx` — clean
- `npx tsc -b --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
