### PR TITLE
Add implement-issue skill

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,20 @@
+---
+description: Autonomously implement a ready issue and open a pull request for it
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash, Bash(gh:*), Bash(git:*)
+---
+
+Autonomously pick up one ready issue in `johnpooch/diplicity-react`, implement it, and open a pull request.
+
+All project context — architecture, conventions, tooling, how to run tests/lint/codegen, branch and git rules — lives in @CLAUDE.md. Follow it; do not restate it here.
+
+## Steps
+
+1. **Find a candidate issue.** Query open issues labelled `workflow: ready-for-implementation` that do **not** also carry `workflow: in-progress`. If several qualify, pick one (oldest is a reasonable default). If none qualify, stop and report that there is no ready work — do nothing else.
+
+2. **Claim it before anything else.** Your very first action after selecting the issue is to add the `workflow: in-progress` label to it. This is the lock that stops a concurrent or scheduled run from grabbing the same issue. Only after the label is applied, read the issue in full — including the **entire** comment thread. Earlier attempts and human notes recorded there must inform your implementation.
+
+3. **Implement.** Create a new branch and make the change, following the conventions in CLAUDE.md. Run the relevant tests, lint, and (if the API shape changed) codegen as CLAUDE.md describes.
+
+4. **Open the pull request.** Push the branch and open a PR that links the issue with `Closes #N`. Keep the description short — a few paragraphs at most: state what the PR accomplishes and any decision or trade-off a reviewer genuinely needs to know. Do not include test steps, checklists, or anything the reviewer doesn't need. Then update the issue's status: remove `workflow: in-progress` and add `workflow: needs-pr-review`.
+
+5. **On failure, never leave the issue silently locked.** If the work cannot be completed — the issue is underspecified, blocked, or something goes wrong — remove `workflow: in-progress`, add `workflow: needs-human-review`, and leave a comment on the issue explaining what stopped progress.


### PR DESCRIPTION
Adds a new `implement-issue` workflow skill at `.claude/commands/implement-issue.md`. Its job is to autonomously pick up a ready issue, implement it, and open a PR.

The skill is intentionally thin — it defers all architecture, tooling, and git conventions to `CLAUDE.md` and only spells out the workflow that's unique to it: querying for issues labelled `workflow: ready-for-implementation` (minus `workflow: in-progress`), claiming an issue by applying `workflow: in-progress` as the very first action (a lock against concurrent runs), reading the full comment thread before implementing, and the status transitions on completion (`in-progress` → `needs-pr-review`) and on failure (`in-progress` → `needs-human-review` plus an explanatory comment, so an issue is never left silently locked).

Worth a reviewer's attention: these `workflow: *` labels differ from the scheme documented in the existing `create-issue` skill (`bug`/`feature` + `needs-context`/`ready`/`in-progress`). If they're meant to be the same board, the label vocabularies should be reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDpuKRJT86XXPB33J2PgaZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDpuKRJT86XXPB33J2PgaZ)_