### PR TITLE
Remove CD Rate from player profile display

### DIFF
--- a/packages/web/src/components/PlayerProfileContent.tsx
+++ b/packages/web/src/components/PlayerProfileContent.tsx
@@ -99,11 +99,6 @@ export const PlayerProfileContent: React.FC<PlayerProfileContentProps> = ({
               value={formatPercent(profile.nmrRate)}
               info="The percentage of movement phases where this player submitted no orders, based on their last 10 games."
             />
-            <StatRow
-              label="CD Rate"
-              value={formatPercent(profile.cdRate)}
-              info="The percentage of games where this player entered civil disorder (abandoned the game), based on their last 10 games."
-            />
           </div>
         </ScreenCardContent>
       </ScreenCard>

--- a/packages/web/src/mocks/fixtures/users.ts
+++ b/packages/web/src/mocks/fixtures/users.ts
@@ -63,7 +63,7 @@ for (const player of players) {
     soloWins: 1,
     draws: 3,
     losses: 6,
-    nmrRate: 2.5,
+    nmrRate: 0.05,
     cdRate: 0,
     reliabilityTier: "reliable",
   };


### PR DESCRIPTION
Closes #626

Per the discussion on #626, the player profile no longer surfaces the CD (civil disorder) rate — only the NMR rate. The CD rate penalises reliable players for abandoning games that were already dead (e.g. after most opponents had already gone into civil disorder), which isn't a fair reliability signal until a "concede" mechanism exists.

The `cd_rate` value is still computed in `get_player_stats` and still feeds the reliability tier; this change only removes the row from the profile UI.

The solo-wins half of the original report (wins counted as losses) was already fixed separately in #632 — verified against production data for the affected user, the corrected query now returns the expected solo wins.

Also corrects a mock profile fixture where `nmrRate` was `2.5` (rendering as 250%) to a realistic `0.05`.

### Screenshots

Desktop:

![player profile desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/fd93c444d18b1f2de9a7c228f4696ab5383a0561/shots/player-profile.png)

Mobile:

![player profile mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/fd93c444d18b1f2de9a7c228f4696ab5383a0561/shots/player-profile-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybb6xeWj1pTiT6qNNa3vuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ybb6xeWj1pTiT6qNNa3vuW)_