### PR TITLE
Reintroduce neutral (non_playable) nation support

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -75,6 +75,7 @@ export interface Nation {
   nationId: string;
   name: string;
   color: string;
+  nonPlayable: boolean;
   /** @nullable */
   readonly flagUrl: string | null;
 }

--- a/packages/web/src/components/InteractiveMap/toRenderState.test.ts
+++ b/packages/web/src/components/InteractiveMap/toRenderState.test.ts
@@ -17,8 +17,8 @@ const province = (id: string, parentId: string | null = null): Province => ({
 });
 
 const nations: Nation[] = [
-  { nationId: "england", name: "England", color: "#2196F3", flagUrl: null },
-  { nationId: "france", name: "France", color: "#80DEEA", flagUrl: null },
+  { nationId: "england", name: "England", color: "#2196F3", nonPlayable: false, flagUrl: null },
+  { nationId: "france", name: "France", color: "#80DEEA", nonPlayable: false, flagUrl: null },
 ];
 
 const variant = { nations };

--- a/packages/web/src/mocks/legacy.ts
+++ b/packages/web/src/mocks/legacy.ts
@@ -13,13 +13,13 @@ import type {
 } from "@/api/generated/endpoints";
 
 export const mockNations: Nation[] = [
-  { nationId: "austria", name: "Austria", color: "#FF0000", flagUrl: null },
-  { nationId: "england", name: "England", color: "#0000FF", flagUrl: null },
-  { nationId: "france", name: "France", color: "#00FFFF", flagUrl: null },
-  { nationId: "germany", name: "Germany", color: "#000000", flagUrl: null },
-  { nationId: "italy", name: "Italy", color: "#00FF00", flagUrl: null },
-  { nationId: "russia", name: "Russia", color: "#FFFFFF", flagUrl: null },
-  { nationId: "turkey", name: "Turkey", color: "#FFFF00", flagUrl: null },
+  { nationId: "austria", name: "Austria", color: "#FF0000", nonPlayable: false, flagUrl: null },
+  { nationId: "england", name: "England", color: "#0000FF", nonPlayable: false, flagUrl: null },
+  { nationId: "france", name: "France", color: "#00FFFF", nonPlayable: false, flagUrl: null },
+  { nationId: "germany", name: "Germany", color: "#000000", nonPlayable: false, flagUrl: null },
+  { nationId: "italy", name: "Italy", color: "#00FF00", nonPlayable: false, flagUrl: null },
+  { nationId: "russia", name: "Russia", color: "#FFFFFF", nonPlayable: false, flagUrl: null },
+  { nationId: "turkey", name: "Turkey", color: "#FFFF00", nonPlayable: false, flagUrl: null },
 ];
 
 export const mockMembers: Member[] = [

--- a/packages/web/src/screens/Tutorial/useTutorialEngine.test.ts
+++ b/packages/web/src/screens/Tutorial/useTutorialEngine.test.ts
@@ -23,6 +23,7 @@ const nation = (nationId: string): Nation => ({
   nationId,
   name: nationId,
   color: "#ffffff",
+  nonPlayable: false,
   flagUrl: null,
 });
 

--- a/packages/web/src/utils/buildOptimisticOrder.test.ts
+++ b/packages/web/src/utils/buildOptimisticOrder.test.ts
@@ -11,8 +11,8 @@ const makeProvince = (id: string): Province => ({
   namedCoastIds: [],
 });
 
-const england: Nation = { nationId: "england", name: "England", color: "rgb(255,0,0)", flagUrl: null };
-const france: Nation = { nationId: "france", name: "France", color: "rgb(0,0,255)", flagUrl: null };
+const england: Nation = { nationId: "england", name: "England", color: "rgb(255,0,0)", nonPlayable: false, flagUrl: null };
+const france: Nation = { nationId: "france", name: "France", color: "rgb(0,0,255)", nonPlayable: false, flagUrl: null };
 
 const lon = makeProvince("lon");
 const nth = makeProvince("nth");

--- a/packages/web/src/utils/buildOrderProgressText.test.ts
+++ b/packages/web/src/utils/buildOrderProgressText.test.ts
@@ -19,7 +19,7 @@ const makePhase = (units: PhaseRetrieve["units"] = []): PhaseRetrieve => ({
   nextPhaseId: null,
 });
 
-const nation = { nationId: "england", name: "England", color: "#fff", flagUrl: null };
+const nation = { nationId: "england", name: "England", color: "#fff", nonPlayable: false, flagUrl: null };
 
 const province = (id: string, name: string) => ({
   id,

--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -73,10 +73,10 @@ def start(phase) -> Dict[str, Any]:
         }
 
 
-def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id, variant):
+def _should_skip(options, units, supply_centers, skip_nations, nation_name_by_id, variant):
     if not options:
         return True
-    if not cd_nations:
+    if not skip_nations:
         return False
     location_to_nation = {
         u.location: nation_name_by_id.get(u.nation, u.nation)
@@ -96,7 +96,7 @@ def _should_skip(options, units, supply_centers, cd_nations, nation_name_by_id, 
             province = variant.parent_of(opt.source)
             if province in province_to_nation:
                 option_nations.add(province_to_nation[province])
-    return bool(option_nations) and option_nations.issubset(cd_nations)
+    return bool(option_nations) and option_nations.issubset(skip_nations)
 
 
 def resolve(phase) -> Dict[str, Any]:
@@ -113,6 +113,8 @@ def resolve(phase) -> Dict[str, Any]:
             .filter(civil_disorder=True)
             .values_list("nation__name", flat=True)
         )
+        non_playable_nations = {n.name for n in variant.nations if n.non_playable}
+        skip_nations = cd_nations | non_playable_nations
 
         states = Engine().adjudicate(state)
         resolved = states[0]
@@ -128,7 +130,7 @@ def resolve(phase) -> Dict[str, Any]:
         next_options = get_options(next_state) if len(states) > 1 else []
         _skip_count = 0
         _MAX_SKIP = 10
-        while len(states) > 1 and _should_skip(next_options, next_state.units, next_state.supply_centers, cd_nations, nation_name_by_id, next_state.variant):
+        while len(states) > 1 and _should_skip(next_options, next_state.units, next_state.supply_centers, skip_nations, nation_name_by_id, next_state.variant):
             _skip_count += 1
             if _skip_count >= _MAX_SKIP:
                 logger.warning(

--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -52,6 +52,7 @@ class Nation:
     id: str
     name: str
     color: str
+    non_playable: bool = False
 
 
 @dataclass(frozen=True)

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -128,7 +128,8 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
     _validate_against_schema(data)
 
     nations = tuple(
-        Nation(id=n["id"], name=n["name"], color=n["color"]) for n in data["nations"]
+        Nation(id=n["id"], name=n["name"], color=n["color"], non_playable=n.get("non_playable", False))
+        for n in data["nations"]
     )
 
     provinces: Dict[str, Province] = {}

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -10808,6 +10808,41 @@ def test_options_adjustment_no_disbands_when_no_surplus():
     assert [o for o in options if o.order_type == "Disband"] == []
 
 
+def _with_non_playable_south(variant: Variant) -> Variant:
+    nations = tuple(
+        replace(n, non_playable=True) if n.id == SOUTH else n
+        for n in variant.nations
+    )
+    return replace(variant, nations=nations)
+
+
+def test_options_adjustment_no_builds_for_non_playable_nation():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    options = get_options(state)
+    assert [o for o in options if o.order_type == "Build"] == []
+
+
+def test_options_adjustment_no_disbands_for_non_playable_nation():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[
+            Unit(nation=SOUTH, type=Unit.ARMY, location="lhs"),
+            Unit(nation=SOUTH, type=Unit.ARMY, location="mid"),
+        ],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    options = get_options(state)
+    assert [o for o in options if o.order_type == "Disband"] == []
+
+
 # === Generic / boundary ===
 
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -1056,10 +1056,20 @@ class NationView:
         )
 
     def allowed_builds(self) -> int:
+        if self._is_non_playable():
+            return 0
         return max(0, len(self.owned_supply_centers()) - self.standing_unit_count())
 
     def required_disbands(self) -> int:
+        if self._is_non_playable():
+            return 0
         return max(0, self.standing_unit_count() - len(self.owned_supply_centers()))
+
+    def _is_non_playable(self) -> bool:
+        for nation in self._state.variant.nations:
+            if nation.id == self._nation:
+                return nation.non_playable
+        return False
 
     def civil_disorder_ranking(self) -> Tuple[Unit, ...]:
         """Units of this nation ordered for civil-disorder selection:

--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -100,7 +100,7 @@ class IsSpaceAvailable(BasePermission):
 
     def has_permission(self, request, view):
         game = resolve_game(request, view.kwargs.get("game_id"))
-        return game.members.count() < game.variant.nations.count()
+        return game.members.count() < game.variant.nations.filter(non_playable=False).count()
 
 
 class MeetsReliabilityRequirement(BasePermission):

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -272,7 +272,7 @@ class GameManager(models.Manager):
         with transaction.atomic():
             game = self.create_from_template(variant, name=name, **kwargs)
 
-            nations_list = list(variant.nations.filter(non_playable=False))
+            nations_list = [n for n in variant.nations.all() if not n.non_playable]
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 
@@ -583,7 +583,7 @@ class Game(BaseModel):
             # Use prefetched nations if available, otherwise fetch
             # variant.nations.all() is already prefetched via with_game_creation_data()
             # Accessing .all() on a prefetched queryset doesn't trigger a new query
-            nations = list(self.variant.nations.filter(non_playable=False))
+            nations = [n for n in self.variant.nations.all() if not n.non_playable]
 
             if self.nation_assignment == NationAssignment.RANDOM:
                 import random

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -272,7 +272,7 @@ class GameManager(models.Manager):
         with transaction.atomic():
             game = self.create_from_template(variant, name=name, **kwargs)
 
-            nations_list = list(variant.nations.all())
+            nations_list = list(variant.nations.filter(non_playable=False))
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 
@@ -583,7 +583,7 @@ class Game(BaseModel):
             # Use prefetched nations if available, otherwise fetch
             # variant.nations.all() is already prefetched via with_game_creation_data()
             # Accessing .all() on a prefetched queryset doesn't trigger a new query
-            nations = list(self.variant.nations.all())
+            nations = list(self.variant.nations.filter(non_playable=False))
 
             if self.nation_assignment == NationAssignment.RANDOM:
                 import random

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -590,7 +590,7 @@ class GameCloneToSandboxSerializer(serializers.Serializer):
                 name=f"{source_game.name} (Sandbox)",
             )
 
-            nations_list = list(source_game.variant.nations.filter(non_playable=False))
+            nations_list = [n for n in source_game.variant.nations.all() if not n.non_playable]
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -590,7 +590,7 @@ class GameCloneToSandboxSerializer(serializers.Serializer):
                 name=f"{source_game.name} (Sandbox)",
             )
 
-            nations_list = list(source_game.variant.nations.all())
+            nations_list = list(source_game.variant.nations.filter(non_playable=False))
             members_to_create = [Member(game=game, user=user) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -24,7 +24,7 @@ class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
 
     def perform_create(self, serializer):
         member = serializer.save()
-        if member.game.variant.nations.count() == member.game.members.count():
+        if member.game.variant.nations.filter(non_playable=False).count() == member.game.members.count():
             member.game.start()
 
 

--- a/service/nation/migrations/0014_add_non_playable.py
+++ b/service/nation/migrations/0014_add_non_playable.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nation", "0013_remove_non_playable"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nation",
+            name="non_playable",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/service/nation/models.py
+++ b/service/nation/models.py
@@ -9,6 +9,7 @@ class Nation(models.Model):
     nation_id = models.CharField(max_length=50)
     name = models.CharField(max_length=50)
     color = models.CharField(max_length=7)
+    non_playable = models.BooleanField(default=False)
     variant = models.ForeignKey("variant.Variant", on_delete=models.CASCADE, related_name="nations")
 
     class Meta:

--- a/service/nation/serializers.py
+++ b/service/nation/serializers.py
@@ -10,6 +10,7 @@ class NationSerializer(serializers.Serializer):
     nation_id = serializers.CharField()
     name = serializers.CharField()
     color = serializers.CharField()
+    non_playable = serializers.BooleanField()
     flag_url = serializers.SerializerMethodField()
 
     def get_flag_url(self, nation) -> Optional[str]:

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2639,6 +2639,8 @@ components:
           type: string
         color:
           type: string
+        nonPlayable:
+          type: boolean
         flagUrl:
           type: string
           nullable: true
@@ -2648,6 +2650,7 @@ components:
       - flagUrl
       - name
       - nationId
+      - nonPlayable
     NationAssignmentEnum:
       enum:
       - random

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -40,7 +40,7 @@ class TestOrderListView:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
 
-        assert response.data[0]["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data[0]["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data[0]["order_type"] == OrderType.MOVE
 
         assert response.data[0]["source"]["id"] == "lon"
@@ -173,7 +173,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] is None
         assert response.data["unit_type"] is None
@@ -216,7 +216,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Move"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] == "Move"
         assert response.data["unit_type"] is None
@@ -244,7 +244,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Move", "gal"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "Move"
         assert response.data["unit_type"] is None
@@ -274,7 +274,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Support"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] == "Support"
         assert response.data["unit_type"] is None
@@ -301,7 +301,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Support", "vie"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] == "Support"
         assert response.data["unit_type"] is None
@@ -337,7 +337,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Support", "vie", "tri"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "Support"
         assert response.data["unit_type"] is None
@@ -361,7 +361,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Hold"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "Hold"
         assert response.data["unit_type"] is None
@@ -402,7 +402,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Build"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] == "Build"
         assert response.data["unit_type"] is None
@@ -445,7 +445,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Build", "Army"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "Build"
         assert response.data["unit_type"] == "Army"
@@ -476,7 +476,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "MoveViaConvoy"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is False
         assert response.data["order_type"] == "MoveViaConvoy"
         assert response.data["unit_type"] is None
@@ -514,7 +514,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "MoveViaConvoy", "gal"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "MoveViaConvoy"
         assert response.data["unit_type"] is None
@@ -572,7 +572,7 @@ class TestOrderCreateView:
         assert response.data["selected"] == ["bud", "Disband"]
         assert response.data["source"]["id"] == "bud"
         assert response.data["source"]["name"] == "Budapest"
-        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
+        assert response.data["nation"] == {"nation_id": "england", "name": "England", "color": "#2196F3", "non_playable": False, "flag_url": "http://testserver/variants/classical/nations/england/flag/0ede0375bd77bbf0d9e8a5706035bb3460193689cebe54ffe4c2760935a14f49.svg"}
         assert response.data["complete"] is True
         assert response.data["order_type"] == "Disband"
         assert response.data["unit_type"] is None

--- a/service/variant.schema.yaml
+++ b/service/variant.schema.yaml
@@ -185,6 +185,15 @@ properties:
             ownership marker, and chat badge.
           examples:
             - "#F44336"
+        non_playable:
+          type: boolean
+          default: false
+          description: |
+            If true, no human player controls this nation. Its units hold
+            automatically every turn and are disbanded immediately if
+            dislodged. Non-playable nations must have as many units as
+            supply centers they own in initialState so the adjustment
+            phase stays balanced.
 
   provinces:
     type: array

--- a/service/variant/tests/test_variant_crud.py
+++ b/service/variant/tests/test_variant_crud.py
@@ -67,6 +67,32 @@ def test_create_variant_success(authenticated_client, primary_user, classical_dv
 
 
 @pytest.mark.django_db
+def test_create_variant_preserves_non_playable_nation(
+    authenticated_client, primary_user, classical_dvar, classical_dsvg
+):
+    dvar = copy.deepcopy(classical_dvar)
+    dvar["id"] = "neutral-draft"
+    dvar["name"] = "Neutral Draft"
+    neutral_id = dvar["nations"][0]["id"]
+    dvar["nations"][0]["non_playable"] = True
+
+    response = authenticated_client.post(
+        reverse("variant-list"),
+        _dvar_upload(dvar, classical_dsvg),
+        format="multipart",
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.data
+
+    variant = Variant.objects.get(id=f"{primary_user.id}-neutral-draft")
+    assert variant.nations.get(nation_id=neutral_id).non_playable is True
+    assert variant.nations.filter(non_playable=True).count() == 1
+
+    roundtripped = variant_to_canonical_dict(variant)
+    nation = next(n for n in roundtripped["nations"] if n["id"] == neutral_id)
+    assert nation["non_playable"] is True
+
+
+@pytest.mark.django_db
 def test_create_variant_id_prefixed_with_owner(
     authenticated_client, primary_user, classical_dvar, classical_dsvg
 ):

--- a/service/variant/utils.py
+++ b/service/variant/utils.py
@@ -243,7 +243,7 @@ def variant_to_canonical_dict(variant):
         "adjudicationModifiers": variant.adjudication_modifiers,
         "phaseProgression": variant.phase_progression,
         "nations": [
-            {"id": nation.nation_id, "name": nation.name, "color": nation.color}
+            {"id": nation.nation_id, "name": nation.name, "color": nation.color, "non_playable": nation.non_playable}
             for nation in nations
         ],
         "provinces": canonical_provinces,
@@ -1021,6 +1021,7 @@ def apply_safe_replacement(variant, dvar, dsvg_text):
         nation = nation_by_id[payload["id"]]
         nation.name = payload["name"]
         nation.color = payload["color"]
+        nation.non_playable = payload.get("non_playable", False)
         nation.save()
     nation_by_id = {nation.nation_id: nation for nation in variant.nations.all()}
 
@@ -1105,6 +1106,7 @@ def _build_variant_children(variant, dvar):
             nation_id=nation["id"],
             name=nation["name"],
             color=nation["color"],
+            non_playable=nation.get("non_playable", False),
         )
         for nation in dvar["nations"]
     ]


### PR DESCRIPTION
Closes #624

Restores the neutral nation system originally implemented in PR #573 and merged in `a88ba73`, which was removed when PR #616 dropped the orphaned `non_playable` column (migration `0013_remove_non_playable`). The original revert was caused by a botched partial revert leaving a NOT NULL column with no default — a schema problem, not a logic one — so this change re-applies PR #573's code (adapted to the evolved `adjudication/service.py` skip logic) plus a fresh migration `0014_add_non_playable`.

### What it does
- **`Nation.non_playable`** boolean field, exposed through the nation serializer, the variant JSON schema, and the variant import/export round-trip (`variant_to_canonical_dict` / `_build_variant_children` / safe-replacement).
- **Seating** excludes neutral nations everywhere a game counts powers: `IsSpaceAvailable`, `Game.start`, sandbox creation, sandbox clone, and member auto-start.
- **Adjudication**: neutral nations never build or disband (`allowed_builds` / `required_disbands` return 0), and retreat/adjustment phases where *only* neutral nations have options are skipped (`skip_nations = cd_nations | non_playable_nations`). The skip path means a dislodged neutral unit is removed from the board without retreating, and unordered neutral units hold by default — satisfying the PRD's neutral-unit behaviour without engine-internal changes.

### Notes for the reviewer
- PR #573 shipped without tests; this PR adds engine-level tests for the build/disband gating and a variant-upload round-trip test for field preservation.
- The OpenAPI schema and generated `endpoints.ts` were updated for the single new `nonPlayable` field only. I deliberately avoided committing the full `spectacular`/`orval` regen because in this environment it also dropped unrelated, environment-dependent entries (`/devices/`, `/api/test-sentry/`, and an `OrderStatusEnum` value) — pre-existing drift unrelated to this change.

No frontend UI changes (the field is data-only; the Variant Creator emitting `non_playable: true` is out of scope here).


---
_Generated by [Claude Code](https://claude.ai/code/session_012odxzBkfoRFYzE5XQcoVAk)_