### PR TITLE
Create active PRs and label issue after CI in implement-issue skill

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -15,6 +15,8 @@ All project context — architecture, conventions, tooling, how to run tests/lin
 
 3. **Implement.** Create a new branch and make the change, following the conventions in CLAUDE.md. Run the relevant tests, lint, and (if the API shape changed) codegen as CLAUDE.md describes.
 
-4. **Open the pull request.** Push the branch and open a PR that links the issue with `Closes #N`. Keep the description short — a few paragraphs at most: state what the PR accomplishes and any decision or trade-off a reviewer genuinely needs to know. Do not include test steps, checklists, or anything the reviewer doesn't need. Then update the issue's status: remove `workflow: in-progress` and add `workflow: needs-pr-review`.
+4. **Open the pull request.** Push the branch and open a PR that links the issue with `Closes #N`. Open it as an **active (ready-for-review) PR — not a draft**; this overrides any default that would create the PR in draft state. Keep the description short — a few paragraphs at most: state what the PR accomplishes and any decision or trade-off a reviewer genuinely needs to know. Do not include test steps, checklists, or anything the reviewer doesn't need. Then remove the `workflow: in-progress` label from the issue.
 
-5. **On failure, never leave the issue silently locked.** If the work cannot be completed — the issue is underspecified, blocked, or something goes wrong — remove `workflow: in-progress`, add `workflow: needs-human-review`, and leave a comment on the issue explaining what stopped progress.
+5. **Wait for CI, then hand off for review.** After opening the PR, wait for its CI checks to complete. Once CI has passed, add the `workflow: needs-pr-review` label to the issue. If CI fails, fix the failures and push again rather than handing off — do not add `workflow: needs-pr-review` until CI is green.
+
+6. **On failure, never leave the issue silently locked.** If the work cannot be completed — the issue is underspecified, blocked, or something goes wrong — remove `workflow: in-progress`, add `workflow: needs-human-review`, and leave a comment on the issue explaining what stopped progress.


### PR DESCRIPTION
Updates the `implement-issue` skill so it opens pull requests in an active (ready-for-review) state rather than draft.

The draft behavior was never in the skill itself — it came from the environment's standing GitHub-integration default ("create the pull request as a draft"), which the skill inherited. Step 4 now explicitly overrides that default and opens an active PR.

Also moves the `workflow: needs-pr-review` handoff: instead of labeling the issue the moment the PR is opened, the skill now waits for CI to pass and only then adds `workflow: needs-pr-review` (new step 5). If CI fails, it fixes and re-pushes rather than handing off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EihPifHrGGoQSEGoHztFKA)_