### PR TITLE
Remember last variant selection per category when switching tabs

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -440,10 +440,31 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Record<VariantCategory, string>
+  >({
+    official:
+      initialCategory === "official"
+        ? defaultVariantId
+        : (officialVariants[0]?.id ?? ""),
+    community:
+      initialCategory === "community"
+        ? defaultVariantId
+        : (communityVariants[0]?.id ?? ""),
+  });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    const currentVariantId = form.getValues("variantId");
+    setLastSelectedByCategory(prev => ({
+      ...prev,
+      [variantCategory]: currentVariantId || prev[variantCategory],
+    }));
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    const nextVariantId =
+      lastSelectedByCategory[category] ||
+      (category === "official" ? officialVariants[0]?.id : communityVariants[0]?.id) ||
+      "";
+    form.setValue("variantId", nextVariantId, { shouldValidate: false });
   };
 
   const activeVariants =


### PR DESCRIPTION
Closes #804

Switching between Official and Community variant tabs previously cleared `variantId` to an empty string, leaving the drop-down blank and forcing a manual pick.

The fix adds a `lastSelectedByCategory` state (keyed by `"official"` / `"community"`) that is initialised to the default selection for each category. When the user switches tabs:

1. The current selection is saved under the outgoing category.
2. The incoming category's saved value is restored — or, if the category has never been visited, the first variant in that list is selected.

This covers both requirements from the issue: the drop-down is never left empty, and returning to a previously visited category restores the last variant the user picked there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RA33wr1hGuLycx2Q3y57kw)_