### PR TITLE
Preserve per-category variant selection when switching tabs

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -440,10 +440,33 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Record<VariantCategory, string>
+  >({
+    official: defaultVariant?.official
+      ? defaultVariantId
+      : (officialVariants[0]?.id ?? ""),
+    community:
+      defaultVariant && !defaultVariant.official
+        ? defaultVariantId
+        : (communityVariants[0]?.id ?? ""),
+  });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    const currentVariantId = form.getValues("variantId");
+    setLastSelectedByCategory(prev => ({
+      ...prev,
+      [variantCategory]: currentVariantId,
+    }));
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    const newVariants =
+      category === "official" ? officialVariants : communityVariants;
+    const lastSelected = lastSelectedByCategory[category];
+    const variantIdToSet =
+      lastSelected && newVariants.some(v => v.id === lastSelected)
+        ? lastSelected
+        : (newVariants[0]?.id ?? "");
+    form.setValue("variantId", variantIdToSet, { shouldValidate: false });
   };
 
   const activeVariants =


### PR DESCRIPTION
Closes #804

## Summary

Fixes `handleVariantCategoryChange` in `CreateGame.tsx` so that switching between the Official and Community variant tabs never leaves the dropdown empty.

- On first visit to a category, the first available variant is pre-selected.
- On returning to a previously visited category, the last-selected variant is restored (e.g. switching Official → Community → Official restores the previously chosen Official variant, not the default).

This is implemented with a `lastSelectedByCategory` state object that records the selected variant ID per category, updated whenever the user switches tabs.

## Screenshots

Create game page (variant pre-selected in Official tab — behaviour is the same in Community tab after the fix):

![create game screen](https://raw.githubusercontent.com/johnpooch/diplicity-react/b6113e178d040ca9aa3f71f46d0ce13a29c318c7/shots/create-game-official.png)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xgbdp5cxPhR5qxKBNGkyGB)_