### PR TITLE
Remember last selected variant per category when switching tabs

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -440,10 +440,24 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Record<VariantCategory, string>
+  >({
+    official: (defaultVariant?.official ? defaultVariantId : officialVariants[0]?.id) ?? "",
+    community: (!defaultVariant?.official ? defaultVariantId : communityVariants[0]?.id) ?? "",
+  });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    const currentVariantId = form.getValues("variantId");
+    setLastSelectedByCategory(prev => ({ ...prev, [variantCategory]: currentVariantId }));
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    const newVariants = category === "official" ? officialVariants : communityVariants;
+    const restoredId = lastSelectedByCategory[category];
+    const newVariantId =
+      restoredId && newVariants.some(v => v.id === restoredId)
+        ? restoredId
+        : newVariants[0]?.id ?? "";
+    form.setValue("variantId", newVariantId, { shouldValidate: false });
   };
 
   const activeVariants =


### PR DESCRIPTION
Fixes the variant selector on the Create Game screen.

Previously, switching between the Official and Community tabs cleared `variantId` to an empty string, leaving the dropdown in an empty/invalid state. This PR changes `handleVariantCategoryChange` to:

1. **Auto-select the first variant** in the newly selected category, so the dropdown is never left empty.
2. **Restore the last-selected variant** when returning to a category already visited. For example: select Official→Hundred, switch to Community→Cold War, switch back to Official — Hundred is restored rather than reverting to Classical.

The per-category memory is kept in a `lastSelectedByCategory` local state object initialised from the default variant, and updated each time the tab switches.

Closes #804

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBhF8auBmisdbhAHD7invB)_