### PR TITLE
Fix variant category switch to preserve and restore selection

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -440,10 +440,24 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Record<VariantCategory, string>
+  >({
+    official:
+      initialCategory === "official" ? defaultVariantId : (officialVariants[0]?.id ?? ""),
+    community:
+      initialCategory === "community" ? defaultVariantId : (communityVariants[0]?.id ?? ""),
+  });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    const currentVariantId = form.getValues("variantId");
+    setLastSelectedByCategory(prev => ({ ...prev, [variantCategory]: currentVariantId }));
+    const nextVariantId =
+      lastSelectedByCategory[category] ||
+      (category === "official" ? officialVariants[0]?.id : communityVariants[0]?.id) ||
+      "";
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    form.setValue("variantId", nextVariantId, { shouldValidate: false });
   };
 
   const activeVariants =


### PR DESCRIPTION
Closes #804

Fixes `handleVariantCategoryChange` in `CreateGame.tsx` so that switching between the Official and Community variant tabs never leaves the dropdown empty.

- On first visit to a category, the first available variant is auto-selected.
- On returning to a previously visited category, the last-selected variant is restored (e.g. Official→Hundred → Community→Cold War → Official restores Hundred, not Classical).

The per-category memory is a `lastSelectedByCategory` state object, initialised from the default selections and updated each time the user switches tabs.

## Screenshots

![create game screen](https://raw.githubusercontent.com/johnpooch/diplicity-react/a361e39/shots/create-game-official.png)

![create game screen mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/a361e39/shots/create-game-mobile.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfnFLJnz3ivzbUxc7FefwF)_