### PR TITLE
Fix variant category switch to auto-select first variant and restore previous selection

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -115,6 +115,19 @@ const communityVariant = {
 
 const variantsWithCommunity = [variantsFixture[0], communityVariant];
 
+const secondOfficialVariant = {
+  ...variantsFixture[0],
+  id: "hundred",
+  name: "Hundred",
+  official: true,
+};
+
+const variantsWithMultipleOfficial = [
+  variantsFixture[0],
+  secondOfficialVariant,
+  communityVariant,
+];
+
 const matchedGame: GameList = {
   id: "matched-game",
   name: "Matched Game",
@@ -725,5 +738,43 @@ describe("CreateGame — variant category toggle", () => {
     expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
       "homebrew"
     );
+  });
+
+  it("auto-selects the first community variant when switching to the Community tab", async () => {
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsWithCommunity,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe("homebrew");
+  });
+
+  it("restores the last-selected variant when returning to a category", async () => {
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsWithMultipleOfficial,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("combobox", { name: /variant/i }));
+    await user.click(screen.getByRole("option", { name: /hundred/i }));
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+    await user.click(screen.getByRole("tab", { name: /official/i }));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe("hundred");
   });
 });

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -440,11 +440,34 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const variantSelectionByCategoryRef = useRef<Record<VariantCategory, string>>({
+    official:
+      initialCategory === "official"
+        ? defaultVariantId
+        : (officialVariants[0]?.id ?? ""),
+    community:
+      initialCategory === "community"
+        ? defaultVariantId
+        : (communityVariants[0]?.id ?? ""),
+  });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    variantSelectionByCategoryRef.current[variantCategory] =
+      form.getValues("variantId");
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
   };
+
+  useEffect(() => {
+    const newCategoryVariants =
+      variantCategory === "official" ? officialVariants : communityVariants;
+    const savedId = variantSelectionByCategoryRef.current[variantCategory];
+    const newVariantId =
+      savedId && newCategoryVariants.some(v => v.id === savedId)
+        ? savedId
+        : (newCategoryVariants[0]?.id ?? "");
+    form.setValue("variantId", newVariantId, { shouldValidate: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- form.setValue is stable; variantSelectionByCategoryRef is a ref
+  }, [variantCategory]);
 
   const activeVariants =
     variantCategory === "official" ? officialVariants : communityVariants;


### PR DESCRIPTION
Closes #804

When switching between Official and Community tabs on the Create Game screen, the variant dropdown was being cleared (`form.setValue("variantId", "")`) instead of auto-selecting a sensible default. This also discarded any previously-made selection when returning to a tab.

**What changed:**

- Replaced the synchronous `form.setValue` call in the `handleVariantCategoryChange` handler with a `useEffect` that runs after React commits the `variantCategory` state change. This ensures RHF's internal store is updated in the correct order relative to React's render cycle, so validation on the next "Next" click finds a valid `variantId`.
- Added a `useRef` (`variantSelectionByCategoryRef`) to remember the last-selected variant per category. The handler saves the current selection before switching; the effect restores it (or falls back to the first variant in the new category).

**Behaviour:**

- Switching to a new category → first variant in that category is auto-selected.
- Returning to a previously visited category → the variant you last selected there is restored.

**Tests added** (both were failing before this change):

1. Auto-selects the first community variant when switching to the Community tab.
2. Restores the last-selected variant when returning to a category.

![Create Game screen](https://raw.githubusercontent.com/johnpooch/diplicity-react/ee41906b8c8fa08ead651052b053d4ebd2460895/shots/create-game-official-tab.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_015T1vS5suaNCVT7oDByBrvR)_