### PR TITLE
Restore last-selected variant when switching between Official/Community tabs

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -706,6 +706,54 @@ describe("CreateGame — variant category toggle", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("auto-selects the first community variant when switching to the Community tab", async () => {
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsWithCommunity,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
+      "homebrew"
+    );
+  });
+
+  it("restores the last selected variant when returning to a previously visited category", async () => {
+    const user = userEvent.setup();
+    const secondOfficialVariant = {
+      ...variantsFixture[0],
+      id: "fleet-rome",
+      name: "Fleet Rome",
+      official: true,
+    };
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: [...variantsFixture, secondOfficialVariant, communityVariant],
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("combobox", { name: /variant/i }));
+    await user.click(screen.getByRole("option", { name: /fleet rome/i }));
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+    await user.click(screen.getByRole("tab", { name: /official/i }));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
+      "fleet-rome"
+    );
+  });
+
   it("creates the game with a community variant selected from the Community tab", async () => {
     const user = userEvent.setup();
     mockedUseVariantsListSuspense.mockReturnValue({

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -440,11 +440,37 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Record<VariantCategory, string>
+  >({
+    official:
+      initialCategory === "official"
+        ? defaultVariantId
+        : (officialVariants[0]?.id ?? ""),
+    community:
+      initialCategory === "community"
+        ? defaultVariantId
+        : (communityVariants[0]?.id ?? ""),
+  });
+
+  const lastSelectedByCategoryRef = useRef(lastSelectedByCategory);
+  lastSelectedByCategoryRef.current = lastSelectedByCategory;
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
+    const currentVariantId = form.getValues("variantId");
+    const updated = { ...lastSelectedByCategory, [variantCategory]: currentVariantId };
+    setLastSelectedByCategory(updated);
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
   };
+
+  useEffect(() => {
+    form.setValue(
+      "variantId",
+      lastSelectedByCategoryRef.current[variantCategory],
+      { shouldValidate: false }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- setValue is stable; ref provides latest lastSelectedByCategory without causing re-runs on every selection change
+  }, [variantCategory]);
 
   const activeVariants =
     variantCategory === "official" ? officialVariants : communityVariants;


### PR DESCRIPTION
Closes #804

When the user switches between the Official and Community variant category tabs, the variant selection now auto-selects the first variant in the new category instead of clearing to empty. Returning to a previously visited tab restores the last variant chosen there.

The implementation adds `lastSelectedByCategory` state (keyed by `"official"` | `"community"`) initialised to the current selection for the active category and the first available variant for the other. On tab switch the handler saves the current form value into the store for the departing category; a `useEffect` keyed on `variantCategory` then writes the stored value for the arriving category back into the form field. The effect fires after the React render that updates `activeVariants`, so there is no intermediate render where the Radix Select sees a value that isn't in its options list — which is what caused the previous `form.setValue` call in the handler to be silently discarded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLHTv2g3Sp3ZZhRDPQ6djc)_