### PR TITLE
Auto-select first variant when switching variant category

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -706,6 +706,25 @@ describe("CreateGame — variant category toggle", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("auto-selects the first variant when switching tabs, without manual selection", async () => {
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsWithCommunity,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
+      "homebrew"
+    );
+  });
+
   it("creates the game with a community variant selected from the Community tab", async () => {
     const user = userEvent.setup();
     mockedUseVariantsListSuspense.mockReturnValue({

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -231,6 +231,7 @@ const VariantSelector: React.FC<VariantSelectorProps> = ({
               />
             ) : (
               <Select
+                key={category}
                 onValueChange={field.onChange}
                 value={field.value}
                 disabled={disabled}
@@ -443,7 +444,11 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
     setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    const firstVariant =
+      category === "official" ? officialVariants[0] : communityVariants[0];
+    form.setValue("variantId", firstVariant?.id ?? "", {
+      shouldValidate: false,
+    });
   };
 
   const activeVariants =


### PR DESCRIPTION
## Summary

Fixes #804. Switching between the Official and Community variant tabs on the Create Game screen cleared `variantId` to an empty string, leaving the "Select a variant" drop-down empty and forcing the user to pick a variant manually. Now switching a category auto-selects the first variant in that category's list, so the drop-down is never left empty.

## Changes

- `handleVariantCategoryChange` now sets `variantId` to the first variant in the newly-selected category (`officialVariants[0]` / `communityVariants[0]`) instead of clearing it. It still falls back to `""` when a category has no variants, so the existing empty-state and "please select a variant" validation behaviour is preserved.
- Added `key={category}` to the variant `Select`. During a tab switch the Radix `Select` reconciles its item list and fires `onValueChange("")`, which clobbered the value we'd just set — this was the underlying mechanism of the bug. Keying the `Select` on the category forces a clean remount with the correct controlled value and prevents the spurious reset. This was confirmed via instrumented logging: the handler set `variantId` to `homebrew`, then the `Select` immediately fired `onValueChange("")`.

## Testing

- Added a test asserting that switching to the Community tab and creating the game (without manually opening the drop-down) submits with the auto-selected community variant.
- Full `CreateGame.test.tsx` suite passes (25 tests), including the existing empty-category validation test.
- `npx tsc -b --noEmit` and `eslint` clean on the changed files.

## Screenshots

No screenshot included: the tab-switch behaviour can only be exercised when more than one variant category exists, but the MSW mock data ships only the single official `classical` variant (no community variant to switch to). The behaviour is covered by the new unit test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vn573e4dU5D3A5KFmwP7b

---
_Generated by [Claude Code](https://claude.ai/code/session_017Vn573e4dU5D3A5KFmwP7b)_