### PR TITLE
Make email login case-insensitive

### DIFF
--- a/service/login/serializers.py
+++ b/service/login/serializers.py
@@ -23,7 +23,7 @@ class EmailLoginSerializer(serializers.Serializer):
     refresh_token = serializers.CharField(read_only=True)
 
     def create(self, validated_data):
-        user = User.objects.filter(email=validated_data["email"]).first()
+        user = User.objects.filter(email__iexact=validated_data["email"]).first()
         if user is None or not user.check_password(validated_data["password"]):
             raise exceptions.AuthenticationFailed("Invalid email or password.")
         if not user.is_active:
@@ -101,7 +101,7 @@ class RegisterSerializer(serializers.Serializer):
     display_name = serializers.CharField(write_only=True)
 
     def validate_email(self, value):
-        if User.objects.filter(email=value).exists():
+        if User.objects.filter(email__iexact=value).exists():
             raise serializers.ValidationError(
                 "An account with this email already exists. "
                 "If you signed up with Google, please sign in with Google instead."
@@ -249,7 +249,7 @@ class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField(write_only=True)
 
     def create(self, validated_data):
-        user = User.objects.filter(email=validated_data["email"], is_active=True).first()
+        user = User.objects.filter(email__iexact=validated_data["email"], is_active=True).first()
         if user:
             uid = urlsafe_base64_encode(force_bytes(user.pk))
             token = default_token_generator.make_token(user)

--- a/service/login/tests_email_login.py
+++ b/service/login/tests_email_login.py
@@ -63,6 +63,24 @@ class TestEmailLogin:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert "Invalid email or password" in str(response.data)
 
+    def test_case_insensitive_email_login(self, unauthenticated_client):
+        user = User.objects.create_user(
+            username="Player@Example.com",
+            email="Player@Example.com",
+            password="strongpass123",
+            is_active=True,
+        )
+        UserProfile.objects.create(user=user, name="Test Player")
+
+        url = reverse(login_viewname)
+        response = unauthenticated_client.post(
+            url,
+            {"email": "PLAYER@EXAMPLE.COM", "password": "strongpass123"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
     def test_unverified_account_returns_401(self, unauthenticated_client):
         User.objects.create_user(
             username="unverified@example.com",

--- a/service/login/tests_password_reset.py
+++ b/service/login/tests_password_reset.py
@@ -37,6 +37,24 @@ class TestPasswordReset:
         assert "reset" in call_kwargs["subject"].lower()
         assert "reset-password?uid=" in call_kwargs["html"]
 
+    def test_case_insensitive_email_sends_reset(self, unauthenticated_client, mock_send_email):
+        User.objects.create_user(
+            username="Player@Example.com",
+            email="Player@Example.com",
+            password="strongpass123",
+            is_active=True,
+        )
+
+        url = reverse(password_reset_viewname)
+        response = unauthenticated_client.post(
+            url,
+            {"email": "player@example.com"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        mock_send_email.assert_called_once()
+
     def test_nonexistent_email_returns_200_without_sending(self, unauthenticated_client, mock_send_email):
         url = reverse(password_reset_viewname)
         response = unauthenticated_client.post(

--- a/service/login/tests_register.py
+++ b/service/login/tests_register.py
@@ -57,6 +57,27 @@ class TestRegister:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already exists" in str(response.data["email"])
 
+    def test_duplicate_email_case_insensitive_returns_400(self, unauthenticated_client, mock_send_email):
+        User.objects.create_user(
+            username="existing",
+            email="Taken@Example.com",
+            password="somepass123",
+        )
+
+        url = reverse(register_viewname)
+        response = unauthenticated_client.post(
+            url,
+            {
+                "email": "taken@example.com",
+                "password": "strongpass123",
+                "display_name": "Another Player",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already exists" in str(response.data["email"])
+
     def test_short_password_returns_400(self, unauthenticated_client, mock_send_email):
         url = reverse(register_viewname)
         response = unauthenticated_client.post(


### PR DESCRIPTION
Closes #814

Changes `email=` to `email__iexact=` in the three serializer methods that look up users by email: `EmailLoginSerializer.create`, `RegisterSerializer.validate_email`, and `PasswordResetSerializer.create`. Users who registered with any case variation of their email can now log in, reset their password, or be rejected for duplicate registration regardless of case.

A test was added to each of the three affected test files to assert the case-insensitive behaviour directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VURXawa9KzpHjuBR2mF6yV)_