### PR TITLE
Fix adjustment-phase disband for units on named coasts

### DIFF
--- a/service/adjudicator/engine.py
+++ b/service/adjudicator/engine.py
@@ -400,7 +400,6 @@ class ParseAdjustmentOrdersReducer(Reducer):
 
     @classmethod
     def reduce(cls, state: StateView, action: Action) -> StateView:
-        standing = state.units().standing_by_loc()
         parsed: List[Order] = []
         for raw in state.raw_orders():
             if raw.order_type == OrderType.BUILD:
@@ -413,7 +412,7 @@ class ParseAdjustmentOrdersReducer(Reducer):
                 continue
             if raw.order_type == OrderType.DISBAND:
                 source = raw.source or ""
-                unit = standing.get(source)
+                unit = state.units().at_parent(source)
                 unit_type = unit.type if unit is not None else (raw.unit_type or "")
                 parsed.append(
                     AdjustmentDisbandOrder(
@@ -819,6 +818,7 @@ class ApplyCivilDisorderReducer(Reducer):
 
     @classmethod
     def reduce(cls, state: StateView, action: Action) -> StateView:
+        variant = state.variant()
         resolutions = state.resolutions()
         disbanding_by_nation: Dict[str, set] = {}
         for i, order in enumerate(state.parsed_orders()):
@@ -826,7 +826,9 @@ class ApplyCivilDisorderReducer(Reducer):
                 continue
             if resolutions[i].status is not None:
                 continue
-            disbanding_by_nation.setdefault(order.nation, set()).add(order.location)
+            disbanding_by_nation.setdefault(order.nation, set()).add(
+                variant.parent_of(order.location)
+            )
         nations: List[str] = []
         for u in state.units().all():
             if u.dislodged:
@@ -845,7 +847,7 @@ class ApplyCivilDisorderReducer(Reducer):
             for unit in nation_view.civil_disorder_ranking():
                 if picked >= shortfall:
                     break
-                if unit.location in already:
+                if variant.parent_of(unit.location) in already:
                     continue
                 civil.append(unit.location)
                 picked += 1
@@ -1172,17 +1174,18 @@ class ApplyAdjustmentOutcomesReducer(Reducer):
         """Populate next_units with the non-dislodged units whose location
         is not the source of an OK AdjustmentDisbandOrder and not in the
         civil-disorder set."""
-        disbanded: set = set(state.civil_disorder_disbands())
+        variant = state.variant()
+        disbanded: set = {variant.parent_of(loc) for loc in state.civil_disorder_disbands()}
         resolutions = state.resolutions()
         for i, order in enumerate(state.parsed_orders()):
             if not isinstance(order, AdjustmentDisbandOrder):
                 continue
             if resolutions[i].status != Status.OK:
                 continue
-            disbanded.add(order.location)
+            disbanded.add(variant.parent_of(order.location))
         kept = tuple(
             u for u in state.units().all()
-            if not u.dislodged and u.location not in disbanded
+            if not u.dislodged and variant.parent_of(u.location) not in disbanded
         )
         return state.replace(next_units=kept)
 

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -7246,6 +7246,48 @@ def test_excess_disbands_beyond_required_are_illegal():
     assert resolutions[1].resolution == Status.ILLEGAL
 
 
+def test_disband_unit_on_named_coast_resolves_ok():
+    variant = make_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[
+            Unit(nation=NORTH, type=Unit.FLEET, location="mlc/sc"),
+            Unit(nation=NORTH, type=Unit.ARMY, location="lhs"),
+        ],
+        supply_centers=[SupplyCenter(nation=NORTH, province="lhs")],
+        orders=[RawOrder(nation=NORTH, source="mlc", order_type="Disband")],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "mlc") == Status.OK
+    assert _unit_at(result, "mlc/sc") is None
+    assert _unit_at(result, "lhs") is not None
+
+
+def test_civil_disorder_does_not_double_disband_explicit_named_coast_unit():
+    variant = make_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[
+            Unit(nation=NORTH, type=Unit.FLEET, location="mlc/sc"),
+            Unit(nation=NORTH, type=Unit.ARMY, location="lhs"),
+            Unit(nation=NORTH, type=Unit.ARMY, location="mid"),
+        ],
+        supply_centers=[SupplyCenter(nation=NORTH, province="lhs")],
+        orders=[RawOrder(nation=NORTH, source="mlc", order_type="Disband")],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "mlc") == Status.OK
+    assert _unit_at(result, "mlc/sc") is None
+    assert _unit_at(result, "lhs") is not None
+    assert _unit_at(result, "mid") is None
+
+
 # === Civil-disorder tests ===
 
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -591,7 +591,7 @@ class AdjustmentDisbandUnitExistsCheck(Check):
     @classmethod
     def check(cls, state: "StateView", order: Order) -> bool:
         assert isinstance(order, AdjustmentDisbandOrder)
-        unit = state.units().standing_by_loc().get(order.location)
+        unit = state.units().at_parent(order.location)
         return unit is not None and unit.nation == order.nation
 
 


### PR DESCRIPTION
Closes #824

Units standing on named coasts (e.g. `spa/sc`) were incorrectly marked ILLEGAL on adjustment-phase disband. The disband order carries the parent province (`spa`) as its location — because named coasts are collapsed at order creation — but three places in the adjudicator did exact-location lookups that keyed on the full coast id.

**What changed:**

- `AdjustmentDisbandUnitExistsCheck` (`types.py`): switched from `standing_by_loc().get(order.location)` to `at_parent(order.location)`, which resolves both bare parents and named coasts.
- `ParseAdjustmentOrdersReducer` (`engine.py`): same fix — uses `at_parent(source)` to recover the unit's actual type even when the raw order source is the parent province.
- `ApplyAdjustmentOutcomesReducer._remove_disbanded_units` (`engine.py`): normalises all locations to parent province before comparing, so a fleet at `mlc/sc` is correctly removed when the order location is `mlc`.
- `ApplyCivilDisorderReducer` (`engine.py`): normalises unit and order locations to parent province when checking whether a unit is already covered by an explicit disband, preventing a named-coast unit from being double-selected for civil disorder.

Two new tests added: one for the basic case (explicit disband of a named-coast unit resolves OK and removes the unit) and one for the civil-disorder edge case (no double-disband when explicit and civil disorder would otherwise target the same named-coast unit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8nc2sGY6cxgJzN9vZd7xb)_