### PR TITLE
Auto-select first variant when switching category tabs on Create Game screen

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -706,6 +706,56 @@ describe("CreateGame — variant category toggle", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("auto-selects the first community variant when switching to the Community tab", async () => {
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsWithCommunity,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
+      "homebrew"
+    );
+  });
+
+  it("restores the last-selected variant when returning to a previously visited category", async () => {
+    const hundredVariant = {
+      ...variantsFixture[0],
+      id: "hundred",
+      name: "Hundred",
+      official: true,
+    };
+    const user = userEvent.setup();
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: [variantsFixture[0], hundredVariant, communityVariant],
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+    renderCreateGame();
+
+    // Select Hundred in the Official tab
+    await user.click(screen.getByRole("combobox", { name: /variant/i }));
+    await user.click(screen.getByRole("option", { name: /hundred/i }));
+
+    // Switch to Community (auto-selects Homebrew), then back to Official
+    await user.click(screen.getByRole("tab", { name: /community/i }));
+    await user.click(screen.getByRole("tab", { name: /official/i }));
+
+    // Submit — should use Hundred, not Classical
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
+      "hundred"
+    );
+  });
+
   it("creates the game with a community variant selected from the Community tab", async () => {
     const user = userEvent.setup();
     mockedUseVariantsListSuspense.mockReturnValue({

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useState } from "react";
+import { flushSync } from "react-dom";
 import { useNavigate, useSearchParams } from "react-router";
 import { useForm, Control } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -440,10 +441,25 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const [step, setStep] = useState(0);
   const [variantCategory, setVariantCategory] =
     useState<VariantCategory>(initialCategory);
+  const [lastSelectedByCategory, setLastSelectedByCategory] = useState<
+    Partial<Record<VariantCategory, string>>
+  >({ [initialCategory]: defaultVariantId });
 
   const handleVariantCategoryChange = (category: VariantCategory) => {
-    setVariantCategory(category);
-    form.setValue("variantId", "", { shouldValidate: false });
+    const currentVariantId = form.getValues("variantId");
+    const targetVariants =
+      category === "official" ? officialVariants : communityVariants;
+    const savedId = lastSelectedByCategory[category];
+    const newVariantId = savedId ?? targetVariants[0]?.id ?? "";
+    // flushSync: Radix hidden <select> resets to "" if the new <option> isn't mounted yet.
+    flushSync(() => {
+      setLastSelectedByCategory(prev => ({
+        ...prev,
+        [variantCategory]: currentVariantId,
+      }));
+      setVariantCategory(category);
+    });
+    form.setValue("variantId", newVariantId, { shouldValidate: false });
   };
 
   const activeVariants =


### PR DESCRIPTION
Closes #804

When the user switches between Official and Community tabs on the Create Game screen, the variant select now auto-selects the first variant in the new category instead of clearing the selection. When returning to a previously visited category, the last-selected variant in that category is restored.

**Implementation notes:**

`flushSync` is used to force the React category state update to complete before calling `form.setValue`. Without this, Radix UI's hidden native `<select>` element (which syncs the controlled value via a `useEffect`) resets the form field to `""` because the new variant's `<option>` isn't mounted yet when RHF writes the new value. `flushSync` ensures the new `SelectItem` options are mounted before `form.setValue` runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyhyQe6hrsWf7geSpCgLqj)_