### PR TITLE
Show eliminated players' games with Lost badge and section divider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -745,6 +745,7 @@ Registered game fixtures (the fixture's game `id` doubles as the URL slug, e.g. 
 | `activeGameRetreat` | `active-retreat` | Fall 1901 retreat; England army dislodged from Norway |
 | `activeGameBuild` | `active-build` | Fall 1901 adjustment; England can build 1 unit |
 | `activeGameDrawProposal` | `active-draw-proposal` | Active game with an open draw proposal, current user hasn't voted |
+| `activeGameEliminated` | `active-eliminated` | Active game; current user (England) has been eliminated |
 | `finishedGameSolo` | `finished-solo` | Completed; current user won a solo victory |
 | `finishedGameDraw` | `finished-draw` | Completed; 3-way draw incl. current user |
 | `gameNotJoined` | `not-joined` | Active game the current user is not a member of |

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -244,31 +244,31 @@ describe("GameCard", () => {
       m.isCurrentUser ? { ...m, eliminated: true } : m
     );
 
-    it("shows 'Lost' badge when the current user is eliminated in an active game", () => {
+    it("shows 'Eliminated' badge when the current user is eliminated in an active game", () => {
       renderGameCard({
         game: { ...mockGames[0], members: eliminatedMembers },
         ...defaultProps,
       });
-      expect(screen.getByText("Lost")).toBeInTheDocument();
+      expect(screen.getByText("Eliminated")).toBeInTheDocument();
     });
 
-    it("does not show 'Lost' badge when the current user is not eliminated", () => {
+    it("does not show 'Eliminated' badge when the current user is not eliminated", () => {
       renderGameCard({
         game: { ...mockGames[0], members: mockMembers },
         ...defaultProps,
       });
-      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
+      expect(screen.queryByText("Eliminated")).not.toBeInTheDocument();
     });
 
-    it("does not show 'Lost' badge for sandbox games", () => {
+    it("does not show 'Eliminated' badge for sandbox games", () => {
       renderGameCard({
         game: { ...mockSandboxGames[0], members: eliminatedMembers },
         ...defaultProps,
       });
-      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
+      expect(screen.queryByText("Eliminated")).not.toBeInTheDocument();
     });
 
-    it("does not show 'Lost' badge when no member is the current user", () => {
+    it("does not show 'Eliminated' badge when no member is the current user", () => {
       renderGameCard({
         game: {
           ...mockGames[0],
@@ -276,7 +276,7 @@ describe("GameCard", () => {
         },
         ...defaultProps,
       });
-      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
+      expect(screen.queryByText("Eliminated")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/components/GameCard.test.tsx
+++ b/packages/web/src/components/GameCard.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GameCard } from "./GameCard";
 import {
   mockGames,
+  mockMembers,
   mockNations,
   mockSandboxGames,
   mockPendingGames,
@@ -235,6 +236,47 @@ describe("GameCard", () => {
       renderGameCard({ game: { ...mockGames[0], orderStatus: null, memberStatus: null }, ...defaultProps });
       expect(screen.queryByText("NMR")).not.toBeInTheDocument();
       expect(screen.queryByText("CD")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("eliminated player", () => {
+    const eliminatedMembers = mockMembers.map(m =>
+      m.isCurrentUser ? { ...m, eliminated: true } : m
+    );
+
+    it("shows 'Lost' badge when the current user is eliminated in an active game", () => {
+      renderGameCard({
+        game: { ...mockGames[0], members: eliminatedMembers },
+        ...defaultProps,
+      });
+      expect(screen.getByText("Lost")).toBeInTheDocument();
+    });
+
+    it("does not show 'Lost' badge when the current user is not eliminated", () => {
+      renderGameCard({
+        game: { ...mockGames[0], members: mockMembers },
+        ...defaultProps,
+      });
+      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
+    });
+
+    it("does not show 'Lost' badge for sandbox games", () => {
+      renderGameCard({
+        game: { ...mockSandboxGames[0], members: eliminatedMembers },
+        ...defaultProps,
+      });
+      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
+    });
+
+    it("does not show 'Lost' badge when no member is the current user", () => {
+      renderGameCard({
+        game: {
+          ...mockGames[0],
+          members: mockMembers.map(m => ({ ...m, isCurrentUser: false, eliminated: true })),
+        },
+        ...defaultProps,
+      });
+      expect(screen.queryByText("Lost")).not.toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -23,6 +23,7 @@ import {
   AlertTriangle,
   UserX,
   Pause,
+  Skull,
   Trophy,
   Users,
 } from "lucide-react";
@@ -90,6 +91,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
   const isPending = game.status === "pending";
   const isAbandoned = game.status === "abandoned";
   const isFinished = game.status === "completed" || isAbandoned;
+  const currentMember = game.members.find(m => m.isCurrentUser);
   const showAvatars = !game.sandbox;
   const totalSlots = variant.nations.length;
   const joinedCount = game.members.length;
@@ -211,6 +213,17 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
 
   const badgeCluster = (
     <div className="flex flex-wrap items-center gap-2">
+      {isActive && currentMember?.eliminated && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="secondary" className="gap-1">
+              <Skull className="size-3" />
+              Lost
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>You have been eliminated from this game</TooltipContent>
+        </Tooltip>
+      )}
       {isActive && orderStatusConfig && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -218,7 +218,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
           <TooltipTrigger asChild>
             <Badge variant="secondary" className="gap-1">
               <Skull className="size-3" />
-              Lost
+              Eliminated
             </Badge>
           </TooltipTrigger>
           <TooltipContent>You have been eliminated from this game</TooltipContent>

--- a/packages/web/src/mocks/fixtures/games.ts
+++ b/packages/web/src/mocks/fixtures/games.ts
@@ -461,6 +461,32 @@ const buildActiveDrawProposal = () => {
 
 export const activeGameDrawProposal = buildActiveDrawProposal();
 
+const buildActiveEliminated = () => {
+  const members = makeActiveMembers().map(m =>
+    m.nation === "England" ? { ...m, eliminated: true } : m
+  );
+  const phase = makePhase(801, 5, {
+    season: "Fall",
+    year: 1902,
+    type: "Movement",
+    remainingTime: 36 * 60 * 60,
+  });
+  return makeFixture({
+    description:
+      "Active game in Fall 1902 where the current user (England) has been eliminated. The game continues for the remaining players.",
+    game: makeGame("active-eliminated", "The Fallen Kingdom", members, [phase], {
+      orderStatus: "no_orders_required",
+      memberStatus: [],
+    }),
+    phases: [phase],
+    ordersByPhase: { 801: [] },
+    phaseStates: members.map(m => makePhaseState(m, [])),
+    channels: [makeChannel("Public Press", members, [])],
+  });
+};
+
+export const activeGameEliminated = buildActiveEliminated();
+
 const buildFinishedSolo = () => {
   const members = makeActiveMembers().map(m =>
     m.nation === "Austria" || m.nation === "Italy"

--- a/packages/web/src/mocks/fixtures/index.ts
+++ b/packages/web/src/mocks/fixtures/index.ts
@@ -2,6 +2,7 @@ import type { GameFixture } from "./types";
 import {
   activeGameBuild,
   activeGameDrawProposal,
+  activeGameEliminated,
   activeGameMovement,
   activeGameNamedCoast,
   activeGameRetreat,
@@ -28,6 +29,7 @@ export const gameFixtures = {
   activeGameRetreat,
   activeGameBuild,
   activeGameDrawProposal,
+  activeGameEliminated,
   finishedGameSolo,
   finishedGameDraw,
   gameMasterGame,

--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -115,6 +115,48 @@ describe("MyGames empty states", () => {
   });
 });
 
+describe("MyGames eliminated games", () => {
+  it("shows 'Lost' section header before eliminated games in the active tab", async () => {
+    const activeGame = mockActiveGames[0];
+    const eliminatedGame = {
+      ...activeGame,
+      id: "eliminated-game",
+      name: "Eliminated Game",
+      members: activeGame.members.map((m: (typeof activeGame.members)[0]) =>
+        m.isCurrentUser ? { ...m, eliminated: true } : m
+      ),
+    };
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: [activeGame, eliminatedGame], next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    await screen.findByText(activeGame.name);
+    expect(screen.getByRole("heading", { name: "Lost", level: 3 })).toBeInTheDocument();
+  });
+
+  it("does not show 'Lost' section header when no games have eliminated current user", async () => {
+    const game = mockActiveGames[0];
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: [game], next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    await screen.findByText(game.name);
+    expect(screen.queryByRole("heading", { name: "Lost", level: 3 })).not.toBeInTheDocument();
+  });
+});
+
 describe("MyGames phase fetching", () => {
   it("renders without fanning out per-game phase fetches", async () => {
     const game = mockActiveGames[0];

--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -116,7 +116,7 @@ describe("MyGames empty states", () => {
 });
 
 describe("MyGames eliminated games", () => {
-  it("shows 'Lost' section header before eliminated games in the active tab", async () => {
+  it("shows 'Eliminated' section header before eliminated games in the active tab", async () => {
     const activeGame = mockActiveGames[0];
     const eliminatedGame = {
       ...activeGame,
@@ -137,10 +137,10 @@ describe("MyGames eliminated games", () => {
     renderMyGames();
 
     await screen.findByText(activeGame.name);
-    expect(screen.getByRole("heading", { name: "Lost", level: 3 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Eliminated", level: 3 })).toBeInTheDocument();
   });
 
-  it("does not show 'Lost' section header when no games have eliminated current user", async () => {
+  it("does not show 'Eliminated' section header when no games have eliminated current user", async () => {
     const game = mockActiveGames[0];
     mockUseGamesListInfinite.mockReturnValue({
       data: { pages: [{ results: [game], next: null }] },
@@ -153,7 +153,7 @@ describe("MyGames eliminated games", () => {
     renderMyGames();
 
     await screen.findByText(game.name);
-    expect(screen.queryByRole("heading", { name: "Lost", level: 3 })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Eliminated", level: 3 })).not.toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -124,7 +124,7 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
       {knownGames.map((game, index) => (
         <Fragment key={game.id}>
           {index === firstEliminatedIndex && (
-            <h3 className="text-sm font-semibold pt-2">Lost</h3>
+            <h3 className="text-sm font-semibold pt-2">Eliminated</h3>
           )}
           <GameCard
             game={game}

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -116,7 +116,7 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
 
   const firstEliminatedIndex =
     status === "active"
-      ? knownGames.findIndex(game => game.members.find(m => m.isCurrentUser)?.eliminated)
+      ? knownGames.findIndex(game => !game.sandbox && game.members.find(m => m.isCurrentUser)?.eliminated)
       : -1;
 
   return (

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import React, { Fragment, Suspense, useState } from "react";
 import { Link } from "react-router";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -114,22 +114,31 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
     );
   }
 
+  const firstEliminatedIndex =
+    status === "active"
+      ? knownGames.findIndex(game => game.members.find(m => m.isCurrentUser)?.eliminated)
+      : -1;
+
   return (
     <div className="space-y-4">
-      {knownGames.map(game => (
-        <GameCard
-          key={game.id}
-          game={game}
-          variant={variantMap.get(game.variantId)!}
-          map={
-            <MapPreview
-              variant={variantMap.get(game.variantId)!}
-              phase={variantMap.get(game.variantId)!.templatePhase}
-              cover
-              className="w-full h-full"
-            />
-          }
-        />
+      {knownGames.map((game, index) => (
+        <Fragment key={game.id}>
+          {index === firstEliminatedIndex && (
+            <h3 className="text-sm font-semibold pt-2">Lost</h3>
+          )}
+          <GameCard
+            game={game}
+            variant={variantMap.get(game.variantId)!}
+            map={
+              <MapPreview
+                variant={variantMap.get(game.variantId)!}
+                phase={variantMap.get(game.variantId)!.templatePhase}
+                cover
+                className="w-full h-full"
+              />
+            }
+          />
+        </Fragment>
       ))}
       {isFetchingNextPage && (
         <div className="flex justify-center py-4">

--- a/service/game/filters.py
+++ b/service/game/filters.py
@@ -1,7 +1,8 @@
 import django_filters
-from django.db.models import Count, F, OuterRef, Q, Subquery
+from django.db.models import Count, Exists, F, OuterRef, Q, Subquery
 
 from common.constants import GameStatus, MinReliability, MovementPhaseDuration, PhaseStatus
+from member.models import Member
 from phase.models import Phase
 from user_profile.utils import get_player_stats
 
@@ -77,7 +78,23 @@ class GameFilter(django_filters.FilterSet):
                 .order_by("-ordinal")
                 .values("scheduled_resolution")[:1]
             )
-            return queryset.annotate(next_deadline=Subquery(next_deadline)).order_by(
+            qs = queryset.annotate(next_deadline=Subquery(next_deadline))
+            if self.request.user.is_authenticated:
+                user_eliminated = Exists(
+                    Member.objects.filter(
+                        game=OuterRef("pk"),
+                        user=self.request.user,
+                        eliminated=True,
+                    )
+                )
+                qs = qs.annotate(user_eliminated=user_eliminated)
+                return qs.order_by(
+                    "sandbox",
+                    "user_eliminated",
+                    F("next_deadline").asc(nulls_last=True),
+                    "-created_at",
+                )
+            return qs.order_by(
                 "sandbox",
                 F("next_deadline").asc(nulls_last=True),
                 "-created_at",

--- a/service/game/tests/test_game_list_deadline_ordering.py
+++ b/service/game/tests/test_game_list_deadline_ordering.py
@@ -42,6 +42,29 @@ def test_started_games_ordered_by_deadline_with_sandboxes_last(
 
 
 @pytest.mark.django_db
+def test_eliminated_games_sort_last_regardless_of_deadline(
+    authenticated_client, primary_user, classical_variant, game_factory, phase_factory
+):
+    now = timezone.now()
+
+    active = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    active.members.create(user=primary_user)
+    phase_factory(game=active, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=5))
+
+    eliminated = game_factory(variant=classical_variant, status=GameStatus.ACTIVE)
+    eliminated.members.create(user=primary_user, eliminated=True)
+    phase_factory(game=eliminated, status=PhaseStatus.ACTIVE, scheduled_resolution=now + timedelta(hours=1))
+
+    url = reverse(list_viewname) + "?mine=true&status=active&ordering=deadline"
+    response = authenticated_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = [g["id"] for g in response.data["results"]]
+    my_ids = {active.id, eliminated.id}
+    assert [i for i in ids if i in my_ids] == [active.id, eliminated.id]
+
+
+@pytest.mark.django_db
 def test_started_games_default_order_is_created_at(
     authenticated_client, primary_user, classical_variant, game_factory, phase_factory
 ):


### PR DESCRIPTION
Closes #823

Eliminated players' active games now stay in the Started tab but are visually distinguished:

- **Lost badge** on the GameCard when the current user has been eliminated from the game
- **Server-side ordering** sorts eliminated games to the bottom of the Started list (annotates the queryset with a per-user `user_eliminated` boolean so the ORDER BY is a single DB pass, not N queries)
- **"Lost" section divider** rendered client-side before the first eliminated game in the Started tab

The unauthenticated path in `filter_ordering` is left unchanged — no `user_eliminated` annotation is added for anonymous requests.

![My Games — Started tab showing Lost section divider and eliminated game](https://raw.githubusercontent.com/johnpooch/diplicity-react/66d55b4dda2a08842e6701c36c4233c9879df67e/shots/my-games.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHVp1xqjARSAAB2vhJ32AV)_