### PR TITLE
Fix game card name truncation pushing overflow menu off-screen on mobile

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -271,9 +271,9 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
           <div className="flex items-center justify-between gap-2">
             <button
               onClick={handleClickGame}
-              className="text-left hover:underline min-w-0"
+              className="text-left hover:underline min-w-0 overflow-hidden"
             >
-              <CardTitle className="flex items-center gap-2 min-w-0">
+              <CardTitle className="flex flex-wrap items-center gap-2 min-w-0">
                 <span className="truncate min-w-0">{game.name}</span>
                 {game.sandbox && <Badge variant="secondary">Sandbox</Badge>}
                 {!game.sandbox && (isActive || isFinished) && (

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -274,7 +274,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
               className="text-left hover:underline min-w-0"
             >
               <CardTitle className="flex items-center gap-2 min-w-0">
-                <span className="truncate">{game.name}</span>
+                <span className="truncate min-w-0">{game.name}</span>
                 {game.sandbox && <Badge variant="secondary">Sandbox</Badge>}
                 {!game.sandbox && (isActive || isFinished) && (
                   <NationBadge nations={variant.nations} nation={playerNation} />

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -271,7 +271,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
           <div className="flex items-center justify-between gap-2">
             <button
               onClick={handleClickGame}
-              className="text-left hover:underline min-w-0 overflow-hidden"
+              className="text-left hover:underline flex-1 min-w-0 overflow-hidden"
             >
               <CardTitle className="flex flex-wrap items-center gap-2 min-w-0">
                 <span className="truncate min-w-0">{game.name}</span>


### PR DESCRIPTION
Fixes game cards where a long name (or wide inline badge) would push the ⋯ overflow menu off-screen on mobile.

**Changes to `GameCard.tsx`:**
- `flex-1` on the title button so it fills exactly the space left by the actions div — the ⋯ menu is now always visible regardless of title length
- `overflow-hidden` on the button as a safety clip
- `flex-wrap` on `CardTitle` so inline badges (Sandbox / NationBadge) wrap to a second row when they don't fit alongside the title, instead of overflowing into the actions area
- `min-w-0` on the title `<span>` so it can shrink below its text width and trigger `truncate`'s ellipsis

**Behaviour:**
- Short title + small badge → both on the same row, no truncation
- Long title + small badge → both on the same row, title truncates with `…`
- Any title + badge that doesn't fit on one row → badge wraps to a second row, title fills the full row and truncates only if it's itself too long
- ⋯ menu always visible

Closes #838

---

![home mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/ea48ae33df85a8442f288a6fd0af8c265707d3e3/shots/home-mobile.png)