### PR TITLE
Add neutral-nations-auto-build adjudication modifier

### DIFF
--- a/service/adjudicator/engine.py
+++ b/service/adjudicator/engine.py
@@ -15,6 +15,7 @@ from .domain import (
 from .resolution import resolve_strengths_and_cuts
 from .types import (
     ALLOW_NON_HOME_BUILDS,
+    NEUTRAL_NATIONS_AUTO_BUILD,
     Action,
     AdjudicationState,
     AdjustmentDisbandOrder,
@@ -197,6 +198,14 @@ class Actions:
     class ApplyAdjustmentOutcomes(Action):
         """Compute the Adjustment-phase post-resolution units list:
         existing units kept, OK builds appended as new units."""
+
+    @dataclass(frozen=True)
+    class AutoBuildNeutralNations(Action):
+        """When the 'neutral-nations-auto-build' adjudication modifier is set,
+        append an Army (or Fleet for sea provinces) to next_units for each
+        non-playable nation's owned supply centre that has no unit after
+        ApplyAdjustmentOutcomes. Nations whose unit count already meets or
+        exceeds their supply-centre count are skipped."""
 
 
 # === Reducers ===
@@ -1209,6 +1218,37 @@ class ApplyAdjustmentOutcomesReducer(Reducer):
         return state.replace(next_units=tuple(next_units))
 
 
+class AutoBuildNeutralNationsReducer(Reducer):
+    """When the 'neutral-nations-auto-build' modifier is active, append
+    auto-built units to next_units for each non-playable nation's owned
+    supply centres that lack a unit. Nations whose existing unit count
+    meets or exceeds their supply-centre count are skipped entirely."""
+
+    ACTION = Actions.AutoBuildNeutralNations
+
+    @classmethod
+    def reduce(cls, state: StateView, action: Action) -> StateView:
+        if NEUTRAL_NATIONS_AUTO_BUILD not in state.variant().adjudication_modifiers:
+            return state
+        variant = state.variant()
+        next_units: List[Unit] = list(state.next_units())
+        occupied = {variant.parent_of(u.location) for u in next_units}
+        for nation in variant.nations:
+            if not nation.non_playable:
+                continue
+            owned_scs = state.nation(nation.id).owned_supply_centers()
+            nation_unit_count = sum(1 for u in next_units if u.nation == nation.id)
+            if nation_unit_count >= len(owned_scs):
+                continue
+            for sc_province in sorted(owned_scs):
+                if sc_province in occupied:
+                    continue
+                unit_type = Unit.FLEET if state.province(sc_province).is_sea() else Unit.ARMY
+                next_units.append(Unit(nation=nation.id, type=unit_type, location=sc_province))
+                occupied.add(sc_province)
+        return state.replace(next_units=tuple(next_units))
+
+
 # === Phase resolvers ===
 
 
@@ -1341,7 +1381,10 @@ class AdjustmentPhaseResolver(PhaseResolver):
                                  civil-disorder selection.
     7. FinalizeStatuses        — remaining undecided -> OK.
     8. ApplyAdjustmentOutcomes — drop disbanded units (explicit + civil),
-                                 then append new units for OK builds."""
+                                 then append new units for OK builds.
+    9. AutoBuildNeutralNations — when the 'neutral-nations-auto-build' modifier
+                                 is set, append one unit per empty owned SC for
+                                 each non-playable nation (unit count < SC count)."""
 
     PHASE_TYPE = Phase.ADJUSTMENT
 
@@ -1354,6 +1397,7 @@ class AdjustmentPhaseResolver(PhaseResolver):
         Actions.ApplyCivilDisorder,
         Actions.FinalizeStatuses,
         Actions.ApplyAdjustmentOutcomes,
+        Actions.AutoBuildNeutralNations,
     )
 
 

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -10885,6 +10885,75 @@ def test_options_adjustment_no_disbands_for_non_playable_nation():
     assert [o for o in options if o.order_type == "Disband"] == []
 
 
+def _with_neutral_auto_build(variant: Variant) -> Variant:
+    return replace(variant, adjudication_modifiers=("neutral-nations-auto-build",))
+
+
+def test_adjustment_neutral_auto_build_adds_unit_on_empty_sc():
+    variant = _with_neutral_auto_build(_with_non_playable_south(make_variant()))
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    result = Engine().adjudicate(state)
+    assert _unit_at(result, "rhs") is not None
+
+
+def test_adjustment_neutral_auto_build_skipped_when_unit_already_present():
+    variant = _with_neutral_auto_build(_with_non_playable_south(make_variant()))
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[Unit(nation=SOUTH, type=Unit.ARMY, location="rhs")],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    result = Engine().adjudicate(state)
+    assert sum(1 for u in result[0].units if u.nation == SOUTH) == 1
+
+
+def test_adjustment_neutral_auto_build_skipped_when_units_exceed_scs():
+    variant = _with_neutral_auto_build(_with_non_playable_south(make_variant()))
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[
+            Unit(nation=SOUTH, type=Unit.ARMY, location="lhs"),
+            Unit(nation=SOUTH, type=Unit.ARMY, location="mid"),
+        ],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    result = Engine().adjudicate(state)
+    assert sum(1 for u in result[0].units if u.nation == SOUTH) == 2
+
+
+def test_adjustment_neutral_auto_build_no_effect_without_modifier():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="rhs")],
+    )
+    result = Engine().adjudicate(state)
+    assert _unit_at(result, "rhs") is None
+
+
+def test_adjustment_neutral_auto_build_fleet_on_sea_province():
+    variant = _with_neutral_auto_build(_with_non_playable_south(make_variant()))
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[SupplyCenter(nation=SOUTH, province="sea")],
+    )
+    result = Engine().adjudicate(state)
+    unit = _unit_at(result, "sea")
+    assert unit is not None
+    assert unit.type == Unit.FLEET
+
+
 # === Generic / boundary ===
 
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -60,6 +60,9 @@ class OrderType:
 # Variant modifier id permitting builds in any owned supply center.
 ALLOW_NON_HOME_BUILDS: str = "allow-builds-in-non-home-centers"
 
+# Variant modifier id enabling auto-rebuild for non-playable nations.
+NEUTRAL_NATIONS_AUTO_BUILD: str = "neutral-nations-auto-build"
+
 
 # === Marker base classes ===
 


### PR DESCRIPTION
Closes #825

## What this does

Adds a new `"neutral-nations-auto-build"` adjudication modifier. When present in a variant's `adjudication_modifiers`, the adjustment-phase pipeline automatically rebuilds a unit on each non-playable nation's owned supply centre that has no unit after regular builds and disbands are applied.

The modifier follows the existing `adjudication_modifiers` pattern (same as `"allow-builds-in-non-home-centers"`) — it is opt-in at the variant level, defaults to absent, and requires no database migration.

## Key decisions

- **No new model field**: as suggested in the issue thread, the existing `adjudication_modifiers` JSON field carries this. Variant authors add `"neutral-nations-auto-build"` to that array.
- **Skip when units ≥ SCs**: if a non-playable nation already has as many units as owned supply centres, no auto-build is attempted for that nation.
- **Unit type**: Army for land and coastal provinces, Fleet for sea provinces.
- **Pipeline position**: the new `AutoBuildNeutralNations` action runs as step 9, after `ApplyAdjustmentOutcomes`, so it sees the final unit list and does not interact with the legality-check or build-limit steps.

## No visual changes

This is a pure backend adjudicator change; no frontend files were modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxPsePdahJHZXoCGBqLaQb)_