### PR TITLE
Fix inconsistent card heights caused by map aspect ratio differences

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -260,7 +260,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
     <Card className="w-full flex flex-col md:flex-row overflow-hidden p-0">
       <button
         onClick={handleClickGame}
-        className="relative shrink-0 w-full h-40 md:h-auto md:w-48 md:self-stretch md:min-h-[150px] overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
+        className="relative shrink-0 w-full h-40 md:h-44 md:w-48 overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
         aria-label="Open game map"
       >
         {map}


### PR DESCRIPTION
Replace md:h-auto on the desktop map panel with a fixed md:h-44 (176px),
matching the classical map's natural height at w-48 (1524×1357 viewBox
gives ~171px). All maps already use cover=true (preserveAspectRatio
xMidYMid slice), so they fill and crop into the fixed dimensions.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RJpP2L77nLXomF3g3AGwQR