### PR TITLE
Fix game card title truncation and move badges below title

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -217,7 +217,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
       {!game.sandbox && (isActive || isFinished) && (
         <NationBadge nations={variant.nations} nation={playerNation} />
       )}
-      {isActive && currentMember?.eliminated && (
+      {isActive && !game.sandbox && currentMember?.eliminated && (
         <Tooltip>
           <TooltipTrigger asChild>
             <Badge variant="secondary" className="gap-1">

--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -213,6 +213,10 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
 
   const badgeCluster = (
     <div className="flex flex-wrap items-center gap-2">
+      {game.sandbox && <Badge variant="secondary">Sandbox</Badge>}
+      {!game.sandbox && (isActive || isFinished) && (
+        <NationBadge nations={variant.nations} nation={playerNation} />
+      )}
       {isActive && currentMember?.eliminated && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -284,15 +288,9 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
           <div className="flex items-center justify-between gap-2">
             <button
               onClick={handleClickGame}
-              className="text-left hover:underline min-w-0"
+              className="text-left hover:underline min-w-0 overflow-hidden"
             >
-              <CardTitle className="flex items-center gap-2 min-w-0">
-                <span className="truncate">{game.name}</span>
-                {game.sandbox && <Badge variant="secondary">Sandbox</Badge>}
-                {!game.sandbox && (isActive || isFinished) && (
-                  <NationBadge nations={variant.nations} nation={playerNation} />
-                )}
-              </CardTitle>
+              <CardTitle className="truncate">{game.name}</CardTitle>
             </button>
             <div className="flex items-center gap-2 shrink-0">
               {unreadPill}
@@ -345,7 +343,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
           </CardDescription>
         </CardHeader>
 
-        {!game.sandbox && (isActive || isFinished) && badgeCluster}
+        {(game.sandbox || isActive || isFinished) && badgeCluster}
 
         <div className="flex-grow" />
 

--- a/packages/web/src/components/NationBadge.tsx
+++ b/packages/web/src/components/NationBadge.tsx
@@ -23,7 +23,7 @@ const NationBadge: React.FC<NationBadgeProps> = ({ nations, nation, children }) 
   const color = findNationColor(nations, nation);
   return (
     <Badge
-      className="leading-none"
+      className="max-w-32 truncate"
       style={{ backgroundColor: color ?? undefined, color: getContrastColor(color) }}
     >
       {children ?? nation}


### PR DESCRIPTION
Closes #838

The game name now truncates with an ellipsis when it is too long, keeping the overflow menu always visible. The Sandbox and nation badges have been moved from the inline title row to the badge cluster row below the title.

**Changes:**
- `GameCard.tsx`: Added `overflow-hidden` to the title button and simplified `CardTitle` to use `truncate` directly. Removed Sandbox badge and NationBadge from the title row; added them at the top of `badgeCluster`. Updated the `badgeCluster` render condition to include sandbox games.
- `NationBadge.tsx`: Removed `leading-none` (which was making NationBadge shorter than other badges) and added `max-w-32 truncate` so very long nation names (e.g. "Kingdom of Tarnate") clip with an ellipsis instead of overflowing.

## Screenshots

**Desktop (1280×800)**
![my-games desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/bdb8b72/shots/my-games.png)

**Mobile (390×844)**
![my-games mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/bdb8b72/shots/my-games-mobile.png)