### PR TITLE
Add neutral-nations-auto-build to supported adjudication modifiers

### DIFF
--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -39,7 +39,7 @@ SUPPORTED_ORDER_TYPES = frozenset(
     {"Move", "Hold", "Support", "Convoy", "Build", "Disband", "Retreat"}
 )
 SUPPORTED_ADJUDICATION_MODIFIERS = frozenset(
-    {"allow-builds-in-non-home-centers"}
+    {"allow-builds-in-non-home-centers", "neutral-nations-auto-build"}
 )
 
 

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -45,6 +45,7 @@ from .engine import (
 )
 from .resolution import resolve_strengths_and_cuts
 from .serializers import (
+    VariantValidationError,
     deserialize_game_state,
     deserialize_variant,
     serialize_game_state,
@@ -809,6 +810,23 @@ def test_loader_rejects_unknown_order_type_in_game_state():
 
     with pytest.raises(Exception):
         adjudicate(variant, state)
+
+
+def test_loader_rejects_unknown_adjudication_modifier():
+    variant = _datc_classical_variant()
+    variant["adjudicationModifiers"] = ["unknown-modifier"]
+
+    with pytest.raises(VariantValidationError):
+        deserialize_variant(variant)
+
+
+def test_loader_accepts_neutral_nations_auto_build_modifier():
+    variant = _datc_classical_variant()
+    variant["adjudicationModifiers"] = ["neutral-nations-auto-build"]
+
+    result = deserialize_variant(variant)
+
+    assert "neutral-nations-auto-build" in result.adjudication_modifiers
 
 
 def test_state_builder_round_trips_through_adjudicate():


### PR DESCRIPTION
Fixes sandbox creation 500s for variants that use the `neutral-nations-auto-build` adjudication modifier.

The modifier constant `NEUTRAL_NATIONS_AUTO_BUILD` already existed in `types.py`, but it was never added to `SUPPORTED_ADJUDICATION_MODIFIERS` in `serializers.py`. Any call to `deserialize_variant` — which runs the first time a game with this variant is adjudicated — therefore raised `VariantValidationError: Unknown adjudication modifier: 'neutral-nations-auto-build'`, causing sandbox creation (and game start for private lobbies) to 500.

The fix is a one-line addition to the allow-list. Two regression tests exercise `deserialize_variant` directly to catch this class of omission at the serialization boundary rather than relying on tests that bypass it via `replace(...)`.

Closes #847

---
_Generated by [Claude Code](https://claude.ai/code/session_0186yxrLnG3oAwV8TiuvmpzP)_