### PR TITLE
Register neutral-nations-auto-build in SUPPORTED_ADJUDICATION_MODIFIERS

### DIFF
--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -39,7 +39,7 @@ SUPPORTED_ORDER_TYPES = frozenset(
     {"Move", "Hold", "Support", "Convoy", "Build", "Disband", "Retreat"}
 )
 SUPPORTED_ADJUDICATION_MODIFIERS = frozenset(
-    {"allow-builds-in-non-home-centers"}
+    {"allow-builds-in-non-home-centers", "neutral-nations-auto-build"}
 )
 
 

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.db import connection
 from rest_framework import status
 
-from adjudicator.serializers import deserialize_variant
+from adjudicator.serializers import deserialize_variant, VariantValidationError
 from variant.models import Variant, default_phase_progression
 from variant.utils import variant_to_canonical_dict
 
@@ -268,6 +268,19 @@ class TestVariantToCanonicalDict:
         assert initial_state["phase"] == {"season": "Spring", "year": 1901, "type": "Movement"}
         assert len(initial_state["units"]) == 22
         assert len(initial_state["supplyCenters"]) == 22
+
+    @pytest.mark.django_db
+    def test_neutral_nations_auto_build_modifier_accepted(self, classical_variant):
+        canonical = variant_to_canonical_dict(classical_variant)
+        canonical["adjudicationModifiers"] = ["neutral-nations-auto-build"]
+        deserialize_variant(canonical)
+
+    @pytest.mark.django_db
+    def test_unknown_modifier_raises_variant_validation_error(self, classical_variant):
+        canonical = variant_to_canonical_dict(classical_variant)
+        canonical["adjudicationModifiers"] = ["not-a-real-modifier"]
+        with pytest.raises(VariantValidationError, match="Unknown adjudication modifier"):
+            deserialize_variant(canonical)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Closes #847

The `neutral-nations-auto-build` modifier was implemented in the engine but never added to `SUPPORTED_ADJUDICATION_MODIFIERS` in `adjudicator/serializers.py`. This caused `deserialize_variant` to raise `VariantValidationError` whenever a variant using this modifier was adjudicated, producing a 500 on sandbox creation.

The fix is a one-line addition to the allow-list. Two regression tests are added to `variant/tests.py` that go through `deserialize_variant` directly (rather than bypassing it with `replace()`), covering both the happy path for the new modifier and the error path for a genuinely unknown one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXwykVSrz78AHB1TXiNSwX)_