### PR TITLE
Fix inconsistent map preview card heights on desktop

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -273,7 +273,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
     <Card className="w-full flex flex-col md:flex-row overflow-hidden p-0">
       <button
         onClick={handleClickGame}
-        className="relative shrink-0 w-full h-40 md:h-auto md:w-48 md:self-stretch md:min-h-[150px] overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
+        className="relative shrink-0 w-full h-40 md:h-44 md:w-48 overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
         aria-label="Open game map"
       >
         {map}


### PR DESCRIPTION
Fixes inconsistent game card heights on desktop where the map panel used `md:h-auto`, causing each card's height to follow its variant's SVG aspect ratio (classical map ~171px vs Hundred ~313px).

Replaces `md:h-auto md:self-stretch md:min-h-[150px]` with a fixed `md:h-44` on the map panel button. All maps already use `preserveAspectRatio="xMidYMid slice"` (cover mode), so non-classical maps are cropped to fit rather than expanding the card.

Closes #845

## Screenshots

**Desktop (after)**
![home screen desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/9578b6f/shots/home-after.png)

**Mobile (after — no change in behaviour)**
![home screen mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/9578b6f/shots/home-mobile.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tgzn9BwV31HtttnHvLr55W)_