### PR TITLE
Resolve fixed-time phases early when all players confirm orders

### DIFF
--- a/packages/web/src/components/PhaseGuidance.tsx
+++ b/packages/web/src/components/PhaseGuidance.tsx
@@ -40,7 +40,7 @@ function usePhaseGuidance(): GuidanceResult {
   }
 
   const userNation = userMember.nation;
-  const confirmationApplies = !game.sandbox && game.deadlineMode !== "fixed_time";
+  const confirmationApplies = !game.sandbox;
   const isConfirmed = confirmationApplies ? game.phaseConfirmed : undefined;
 
   switch (phase.type) {

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -143,6 +143,52 @@ describe("OrdersScreen civil disorder handling", () => {
   });
 });
 
+describe("OrdersScreen confirm orders button", () => {
+  beforeEach(() => {
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "active", supplyCenters: [], units: [],
+    });
+    mockPhaseStatesData.mockReturnValue([
+      {
+        member: baseMember({ civilDisorder: false }),
+        orderableProvinces: [{ id: "lon", name: "London" }],
+      },
+    ]);
+    mockOrdersData.mockReturnValue([]);
+  });
+
+  it("shows confirm orders button for fixed-time game", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "fixed_time",
+      phaseConfirmed: false,
+      members: [baseMember()],
+    });
+
+    renderOrdersScreen();
+
+    expect(screen.getByRole("button", { name: /confirm orders/i })).toBeInTheDocument();
+  });
+
+  it("shows confirm orders button for duration game", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember()],
+    });
+
+    renderOrdersScreen();
+
+    expect(screen.getByRole("button", { name: /confirm orders/i })).toBeInTheDocument();
+  });
+});
+
 describe("OrdersScreen named coast display", () => {
   beforeEach(() => {
     mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -274,7 +274,6 @@ const OrdersScreen: React.FC = () => {
           Resolve phase
         </Button>
       );
-    if (game.deadlineMode === "fixed_time") return null;
     if (hasContent)
       return (
         <Button disabled={confirmOrdersMutation.isPending} onClick={handleConfirmOrders}>

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -483,7 +483,7 @@ class Game(BaseModel):
         else:
             return self.effective_retreat_frequency
 
-    def get_scheduled_resolution(self, phase_type, is_first_phase=False):
+    def get_scheduled_resolution(self, phase_type, is_first_phase=False, reference_time=None):
         if self.deadline_mode == DeadlineMode.FIXED_TIME:
             frequency = self.get_phase_frequency(phase_type)
             if not frequency or not self.fixed_deadline_time or not self.fixed_deadline_timezone:
@@ -492,6 +492,7 @@ class Game(BaseModel):
                 target_time=self.fixed_deadline_time,
                 frequency=frequency,
                 tz_name=self.fixed_deadline_timezone,
+                reference_time=reference_time,
                 is_first_phase=is_first_phase,
             )
         else:

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -200,16 +200,9 @@ class PhaseManager(models.Manager):
         return self.resolve_due_phases(canary=True)
 
     def _check_and_apply_nmr_extensions(self, phase):
-        if phase.game.deadline_mode == DeadlineMode.FIXED_TIME:
-            unconfirmed = phase.phase_states.filter(
-                has_possible_orders=True,
-            ).annotate(order_count=Count('orders')).filter(
-                order_count=0,
-            ).select_related('member')
-        else:
-            unconfirmed = phase.phase_states.filter(
-                has_possible_orders=True, orders_confirmed=False
-            ).select_related('member')
+        unconfirmed = phase.phase_states.filter(
+            has_possible_orders=True, orders_confirmed=False
+        ).select_related('member')
 
         members_with_extensions = [
             ps.member for ps in unconfirmed

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -85,7 +85,7 @@ class PhaseQuerySet(models.QuerySet):
             & Q(game__paused_at__isnull=True)
             & ~Q(game__status=GameStatus.COMPLETED)
             & ~Q(game__status=GameStatus.ABANDONED)
-            & (deadline_passed | (~Q(game__deadline_mode=DeadlineMode.FIXED_TIME) & all_confirmed))
+            & (deadline_passed | all_confirmed)
         )
 
 
@@ -674,7 +674,8 @@ class PhaseManager(models.Manager):
 
                 # Calculate next phase details
                 scheduled_resolution = previous_phase.game.get_scheduled_resolution(
-                    adjudication_data["type"]
+                    adjudication_data["type"],
+                    reference_time=previous_phase.scheduled_resolution,
                 )
                 new_ordinal = previous_phase.ordinal + 1
 

--- a/service/phase/test_background_resolution.py
+++ b/service/phase/test_background_resolution.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import time, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +7,8 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 
-from common.constants import PhaseStatus
+from common.constants import DeadlineMode, PhaseFrequency, PhaseStatus
+from game.models import Game
 from phase.models import Phase
 from phase.serializers import PhaseStateSerializer
 
@@ -243,3 +244,48 @@ class TestSweepCanary:
 
         mock_capture.assert_not_called()
         mock_resolve.assert_called_once()
+
+
+class TestFixedTimeEarlyResolution:
+
+    @pytest.mark.django_db
+    def test_fixed_time_phase_is_due_when_all_confirmed(self, phase_factory, classical_england_nation, classical_variant):
+        game = Game.objects.create(
+            variant=classical_variant,
+            name="Fixed Time Test",
+            status="active",
+            deadline_mode=DeadlineMode.FIXED_TIME,
+            movement_frequency=PhaseFrequency.DAILY,
+            fixed_deadline_time=time(21, 0),
+            fixed_deadline_timezone="UTC",
+        )
+        phase_factory(
+            game=game,
+            scheduled_resolution=timezone.now() + timedelta(hours=24),
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": True},
+            ],
+        )
+
+        assert Phase.objects.filter_due_phases().filter(game=game).exists()
+
+    @pytest.mark.django_db
+    def test_fixed_time_phase_not_due_when_not_all_confirmed(self, phase_factory, classical_england_nation, classical_variant):
+        game = Game.objects.create(
+            variant=classical_variant,
+            name="Fixed Time Test",
+            status="active",
+            deadline_mode=DeadlineMode.FIXED_TIME,
+            movement_frequency=PhaseFrequency.DAILY,
+            fixed_deadline_time=time(21, 0),
+            fixed_deadline_timezone="UTC",
+        )
+        phase = phase_factory(
+            game=game,
+            scheduled_resolution=timezone.now() + timedelta(hours=24),
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+
+        assert not Phase.objects.filter_due_phases().filter(pk=phase.id).exists()

--- a/service/phase/test_background_resolution.py
+++ b/service/phase/test_background_resolution.py
@@ -1,4 +1,4 @@
-from datetime import time, timedelta
+from datetime import datetime, time, timedelta, timezone as dt_timezone
 from unittest.mock import patch
 
 import pytest
@@ -289,3 +289,31 @@ class TestFixedTimeEarlyResolution:
         )
 
         assert not Phase.objects.filter_due_phases().filter(pk=phase.id).exists()
+
+
+class TestDeadlineGridPreservation:
+
+    @pytest.mark.django_db
+    def test_next_deadline_anchored_to_scheduled_resolution_not_now(
+        self, classical_variant
+    ):
+        phase1_scheduled = datetime(2026, 1, 3, 21, 0, 0, tzinfo=dt_timezone.utc)
+
+        game = Game.objects.create(
+            variant=classical_variant,
+            name="Grid Test",
+            status="active",
+            deadline_mode=DeadlineMode.FIXED_TIME,
+            movement_frequency=PhaseFrequency.DAILY,
+            fixed_deadline_time=time(21, 0),
+            fixed_deadline_timezone="UTC",
+        )
+
+        next_with_reference = game.get_scheduled_resolution(
+            "Movement", reference_time=phase1_scheduled
+        )
+        next_from_now = game.get_scheduled_resolution("Movement")
+
+        expected = datetime(2026, 1, 4, 21, 0, 0, tzinfo=dt_timezone.utc)
+        assert next_with_reference == expected
+        assert next_from_now != expected

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4515,7 +4515,7 @@ class TestNMRExtensionsFixedTime:
         assert phase.scheduled_resolution > now + timedelta(hours=24)
 
     @pytest.mark.django_db
-    def test_fixed_time_with_any_order_skips_extension(
+    def test_fixed_time_confirmed_skips_extension(
         self,
         deadline_warning_game_factory,
         italy_vs_germany_italy_nation,
@@ -4525,6 +4525,10 @@ class TestNMRExtensionsFixedTime:
         game, italy, germany, phase = deadline_warning_game_factory(
             DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
         )
+        game.movement_frequency = PhaseFrequency.EVERY_2_DAYS
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
+        game.save()
         italy.nmr_extensions_remaining = 1
         italy.save()
         phase.units.create(
@@ -4532,8 +4536,7 @@ class TestNMRExtensionsFixedTime:
             type=UnitType.ARMY,
             nation=italy_vs_germany_italy_nation,
         )
-        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
-        ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
 
         result = Phase.objects._check_and_apply_nmr_extensions(phase)
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -2029,7 +2029,7 @@ class TestFilterDuePhasesBasicFiltering:
         assert phase in phases
 
     @pytest.mark.django_db
-    def test_filter_due_phases_fixed_time_all_confirmed_does_not_resolve_early(
+    def test_filter_due_phases_fixed_time_all_confirmed_resolves_early(
         self, phase_factory, classical_variant, classical_england_nation, classical_france_nation
     ):
         game = Game.objects.create(
@@ -2049,7 +2049,7 @@ class TestFilterDuePhasesBasicFiltering:
 
         phases = Phase.objects.filter_due_phases()
 
-        assert phase not in phases
+        assert phase in phases
 
     @pytest.mark.django_db
     def test_filter_due_phases_fixed_time_resolves_at_scheduled_time(

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4119,7 +4119,7 @@ class TestPhaseToCanonicalGameStatePerformance:
 class TestSendDeadlineWarnings:
 
     @pytest.mark.django_db
-    def test_fixed_time_all_orders_no_notification(
+    def test_fixed_time_all_orders_not_confirmed_sends_confirm_prompt(
         self,
         deadline_warning_game_factory,
         add_italy_germany_units,
@@ -4132,6 +4132,29 @@ class TestSendDeadlineWarnings:
         add_italy_germany_units(phase)
         italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True)
         germany_ps = phase.phase_states.create(member=germany, has_possible_orders=True)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+        germany_ps.orders.create(source=italy_vs_germany_kiel_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        assert mock_send_notification_to_users.call_count == 2
+        body = mock_send_notification_to_users.call_args_list[0].kwargs["body"]
+        assert "Confirm to advance the game early" in body
+
+    @pytest.mark.django_db
+    def test_fixed_time_all_orders_confirmed_no_notification(
+        self,
+        deadline_warning_game_factory,
+        add_italy_germany_units,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_kiel_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+        germany_ps = phase.phase_states.create(member=germany, has_possible_orders=True, orders_confirmed=True)
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
         germany_ps.orders.create(source=italy_vs_germany_kiel_province, order_type=OrderType.HOLD)
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4548,10 +4548,6 @@ class TestNMRExtensionsFixedTime:
         game, italy, germany, phase = deadline_warning_game_factory(
             DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
         )
-        game.movement_frequency = PhaseFrequency.EVERY_2_DAYS
-        game.fixed_deadline_time = time(12, 0)
-        game.fixed_deadline_timezone = "UTC"
-        game.save()
         italy.nmr_extensions_remaining = 1
         italy.save()
         phase.units.create(

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -34,7 +34,12 @@ def build_notification_body(orders_confirmed, is_fixed_time, orders_given, total
 
     if is_fixed_time:
         if orders_given == total_units:
-            return None
+            if orders_confirmed:
+                return None
+            return (
+                f"All orders ready. Confirm to advance the game early — "
+                f"the next deadline stays on schedule. {time_left} remaining."
+            )
         if orders_given > 0:
             return (
                 f"Deadline approaching - orders incomplete. "


### PR DESCRIPTION
Closes #843

## What this does

In fixed-time games, phases now resolve immediately once all eligible players confirm their orders, rather than always waiting for the wall-clock deadline.

Three backend changes:

1. **`filter_due_phases`** — removed the `~Q(game__deadline_mode=DeadlineMode.FIXED_TIME)` exclusion from the `all_confirmed` branch, so fixed-time phases are eligible for early resolution when everyone has confirmed.

2. **`get_scheduled_resolution`** — added a `reference_time` parameter that is forwarded to `calculate_next_fixed_deadline`. This lets callers anchor the next deadline to the previous scheduled deadline rather than `now()`.

3. **`create_from_adjudication_data`** — passes `reference_time=previous_phase.scheduled_resolution` when computing the next phase's deadline, so an early resolution does not shift the game's fixed deadline grid forward.

One frontend change:

4. **`OrdersScreen`** — removed the early return that hid the confirm-orders button for fixed-time games. Fixed-time games now display the same "Confirm orders" button as duration games.

## Behaviour change: NMR extension criterion for fixed-time games

The NMR-extension logic for fixed-time games previously used "has submitted at least one order" as the criterion for skipping an extension. This PR unifies the logic across all deadline modes so that the criterion is now "has confirmed orders".

**Impact on in-flight games:** Players in active fixed-time games who have submitted orders but have never confirmed (the confirm button was hidden before this PR) will be treated as unconfirmed after deploy. If the NMR sweep runs before they confirm, they may receive an extension. This is a one-time transition effect; once they see and use the confirm button the behaviour stabilises.

## Screenshot

The confirm-orders button (previously hidden for fixed-time games):

![Confirm orders button](https://raw.githubusercontent.com/johnpooch/diplicity-react/95658a9433c8b85e9871ac569ea38ab7a26adee7/shots/orders-confirm-button.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_0115PCApfMhMqA7iyK9dkkKk)_