### PR TITLE
Add map performance benchmark harness (Block 1)

### DIFF
--- a/packages/map/.gitignore
+++ b/packages/map/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+bench/results.json

--- a/packages/map/bench/baseline.json
+++ b/packages/map/bench/baseline.json
@@ -1,0 +1,99 @@
+{
+  "generatedAt": "2026-06-24T00:40:35.181Z",
+  "git": {
+    "commit": "8b0f012fafefad96760dc5fc5e5c559b595f89ef",
+    "dirty": true
+  },
+  "environment": {
+    "harness": "map-bench.mjs",
+    "chromium": "sparticuz-fallback",
+    "gpu": "disabled (--disable-gpu)",
+    "note": "headless software rendering; absolute fps not comparable to real devices"
+  },
+  "gesture": {
+    "zoomTicks": 12,
+    "panSteps": 40,
+    "reps": 3,
+    "frameBudgetMs": 16.67,
+    "droppedThreshold": 1.5
+  },
+  "results": [
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "1280x800",
+      "cpuThrottle": 1,
+      "initialRenderMs": 3.8,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 16.8,
+      "droppedFramePct": 1.61,
+      "frameCount": 246,
+      "effectiveFps": 58.82
+    },
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "1280x800",
+      "cpuThrottle": 4,
+      "initialRenderMs": 18.7,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 33.4,
+      "droppedFramePct": 9.52,
+      "frameCount": 253,
+      "effectiveFps": 45.09
+    },
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "1280x800",
+      "cpuThrottle": 6,
+      "initialRenderMs": 27.4,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 66.7,
+      "droppedFramePct": 11.89,
+      "frameCount": 240,
+      "effectiveFps": 36.85
+    },
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "390x844",
+      "cpuThrottle": 1,
+      "initialRenderMs": 3.7,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 16.7,
+      "droppedFramePct": 0,
+      "frameCount": 222,
+      "effectiveFps": 60
+    },
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "390x844",
+      "cpuThrottle": 4,
+      "initialRenderMs": 18.4,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 33.3,
+      "droppedFramePct": 9.66,
+      "frameCount": 239,
+      "effectiveFps": 50.64
+    },
+    {
+      "fixture": "classical-active-movement",
+      "route": "/game/active-movement/phase/101",
+      "viewport": "390x844",
+      "cpuThrottle": 6,
+      "initialRenderMs": 29.2,
+      "medianFrameMs": 16.7,
+      "p95FrameMs": 66.6,
+      "droppedFramePct": 24.47,
+      "frameCount": 187,
+      "effectiveFps": 37.6
+    }
+  ],
+  "notes": [
+    "Only classical variant benchmarked: every mock game is wired to variantId 'classical'; godip coverage deferred.",
+    "Absolute timings are headless + software-render; use only for before/after delta on the same machine/config.",
+    "GPU compositing cost (the real-device hot path) is NOT captured here; real-user data is Block 2 (telemetry)."
+  ]
+}

--- a/packages/map/package-lock.json
+++ b/packages/map/package-lock.json
@@ -1,0 +1,304 @@
+{
+  "name": "@diplicity/map",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@diplicity/map",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@sparticuz/chromium": "^149.0.0",
+        "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
+      "integrity": "sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tar-fs": "^3.1.2"
+      },
+      "engines": {
+        "node": "^22.17.0 || >=24.0.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@diplicity/map",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "bench:map": "node scripts/map-bench.mjs"
+  },
+  "devDependencies": {
+    "@sparticuz/chromium": "^149.0.0",
+    "playwright": "^1.60.0"
+  }
+}

--- a/packages/map/scripts/map-bench.mjs
+++ b/packages/map/scripts/map-bench.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+// Map performance benchmark harness (Block 1 of the map re-architecture).
+//
+// Drives a fixed pan/zoom gesture on the CURRENT map (react-zoom-pan-pinch + dSVG)
+// in headless Chromium under CDP CPU throttling, captures frame cadence via an injected
+// requestAnimationFrame recorder, and writes a committed JSON baseline + stdout table.
+// It changes nothing in the app: all metrics are captured externally.
+//
+// Prereq: the mock dev server must be running:
+//   npm --prefix ../web run dev:mocks    # serves real SVGs via MSW at http://localhost:5173
+//
+// Usage:
+//   node scripts/map-bench.mjs [options]
+//
+// Options:
+//   --base URL          Dev server base URL (default http://localhost:5173)
+//   --reps N            Repetitions per cell, median reported (default 3)
+//   --cpu a,b,c         CPU throttle tiers (default 1,4,6)
+//   --viewports WxH,... Viewport tiers (default 1280x800,390x844)
+//   --out PATH          Working JSON output path (default bench/results.json)
+//   --write-baseline    Also write bench/baseline.json
+//   --wait MS           Extra settle time after readiness gate (default 1000)
+
+import { chromium } from "playwright";
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(HERE, "..");
+
+const FRAME_BUDGET_MS = 1000 / 60;
+const DROPPED_THRESHOLD = 1.5;
+const WARMUP_MS = 200;
+const GESTURE = { zoomTicks: 12, panSteps: 40, wheelIntervalMs: 40, panIntervalMs: 16, settleMs: 300 };
+
+const FIXTURES = [
+  {
+    name: "classical-active-movement",
+    route: "/game/active-movement/phase/101",
+  },
+];
+
+const args = process.argv.slice(2);
+const getOption = name => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? null : args[index + 1];
+};
+
+const base = getOption("base") ?? "http://localhost:5173";
+const reps = Number(getOption("reps") ?? 3);
+const cpuTiers = (getOption("cpu") ?? "1,4,6").split(",").map(Number);
+const viewports = (getOption("viewports") ?? "1280x800,390x844").split(",");
+const outPath = resolve(PACKAGE_ROOT, getOption("out") ?? "bench/results.json");
+const writeBaseline = args.includes("--write-baseline");
+const settleMs = Number(getOption("wait") ?? 1000);
+
+const delay = ms => new Promise(r => setTimeout(r, ms));
+const median = xs => {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+};
+const percentile = (xs, p) => {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const idx = Math.min(s.length - 1, Math.ceil((p / 100) * s.length) - 1);
+  return s[Math.max(0, idx)];
+};
+const round = (n, d = 2) => Number(n.toFixed(d));
+
+const resolveExecutablePath = async () => {
+  try {
+    const probe = await chromium.launch({ headless: true });
+    await probe.close();
+    return { executablePath: undefined, source: "system" };
+  } catch {
+    const sparticuz = (await import("@sparticuz/chromium")).default;
+    return { executablePath: await sparticuz.executablePath(), source: "sparticuz-fallback" };
+  }
+};
+
+// Injected before navigation. Records requestAnimationFrame timestamps into window.__mapBench
+// only while recording is active. Purely external — never touches app source.
+const rafRecorderInit = () => {
+  window.__mapBench = { frames: [], recording: false };
+  window.__mapBenchStart = () => {
+    window.__mapBench.frames = [];
+    window.__mapBench.recording = true;
+    const loop = t => {
+      if (!window.__mapBench.recording) return;
+      window.__mapBench.frames.push(t);
+      requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  };
+  window.__mapBenchStop = () => {
+    window.__mapBench.recording = false;
+    return window.__mapBench.frames;
+  };
+};
+
+const runGesture = async (cdp, center) => {
+  const wheel = deltaY => cdp.send("Input.dispatchMouseEvent", { type: "mouseWheel", x: center.x, y: center.y, deltaX: 0, deltaY });
+  for (let i = 0; i < GESTURE.zoomTicks; i++) {
+    await wheel(-120);
+    await delay(GESTURE.wheelIntervalMs);
+  }
+  await delay(GESTURE.settleMs);
+
+  await cdp.send("Input.dispatchMouseEvent", { type: "mousePressed", x: center.x, y: center.y, button: "left", buttons: 1, clickCount: 1 });
+  for (let i = 1; i <= GESTURE.panSteps; i++) {
+    const f = i / GESTURE.panSteps;
+    await cdp.send("Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: center.x - Math.round(f * 200),
+      y: center.y - Math.round(f * 150),
+      button: "left",
+      buttons: 1,
+    });
+    await delay(GESTURE.panIntervalMs);
+  }
+  await cdp.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: center.x - 200, y: center.y - 150, button: "left", buttons: 1, clickCount: 1 });
+  await delay(GESTURE.settleMs);
+
+  for (let i = 0; i < GESTURE.zoomTicks; i++) {
+    await wheel(120);
+    await delay(GESTURE.wheelIntervalMs);
+  }
+  await delay(GESTURE.settleMs);
+};
+
+const summarizeFrames = frames => {
+  if (frames.length < 2) return { medianFrameMs: 0, p95FrameMs: 0, droppedFramePct: 0, frameCount: frames.length, effectiveFps: 0 };
+  const t0 = frames[0];
+  const kept = frames.filter(t => t - t0 >= WARMUP_MS);
+  const deltas = [];
+  for (let i = 1; i < kept.length; i++) deltas.push(kept[i] - kept[i - 1]);
+  if (deltas.length === 0) return { medianFrameMs: 0, p95FrameMs: 0, droppedFramePct: 0, frameCount: kept.length, effectiveFps: 0 };
+  const dropped = deltas.filter(d => d > DROPPED_THRESHOLD * FRAME_BUDGET_MS).length;
+  const spanMs = kept[kept.length - 1] - kept[0];
+  return {
+    medianFrameMs: round(median(deltas)),
+    p95FrameMs: round(percentile(deltas, 95)),
+    droppedFramePct: round((dropped / deltas.length) * 100),
+    frameCount: kept.length,
+    effectiveFps: round(spanMs > 0 ? ((kept.length - 1) / spanMs) * 1000 : 0),
+  };
+};
+
+const runRep = async (context, fixture, cpuThrottle) => {
+  const page = await context.newPage();
+  let initialRenderMs = null;
+  page.on("console", msg => {
+    if (initialRenderMs !== null) return;
+    const m = msg.text().match(/renderer\.render\(\) took ([\d.]+)ms/);
+    if (m) initialRenderMs = Number(m[1]);
+  });
+  page.on("pageerror", error => console.error("[pageerror]", error.message));
+
+  await page.addInitScript(rafRecorderInit);
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuThrottle });
+
+  try {
+    const url = new URL(fixture.route, base).toString();
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+    await page.waitForSelector(".react-transform-component svg", { timeout: 30000 });
+    await page.waitForTimeout(settleMs);
+
+    const box = await page.locator(".react-transform-component").first().boundingBox();
+    const center = box
+      ? { x: Math.round(box.x + box.width / 2), y: Math.round(box.y + box.height / 2) }
+      : { x: 640, y: 400 };
+
+    await page.evaluate(() => window.__mapBenchStart());
+    await runGesture(cdp, center);
+    const frames = await page.evaluate(() => window.__mapBenchStop());
+
+    return { ...summarizeFrames(frames), initialRenderMs: initialRenderMs ?? 0 };
+  } finally {
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 });
+    await page.close();
+  }
+};
+
+const gitInfo = () => {
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd: PACKAGE_ROOT }).toString().trim();
+    const dirty = execSync("git status --porcelain", { cwd: PACKAGE_ROOT }).toString().trim().length > 0;
+    return { commit, dirty };
+  } catch {
+    return { commit: "unknown", dirty: false };
+  }
+};
+
+const { executablePath, source } = await resolveExecutablePath();
+const browser = await chromium.launch({
+  headless: true,
+  executablePath,
+  args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+});
+
+const results = [];
+try {
+  const chromiumVersion = source === "system" ? browser.version() : "sparticuz-fallback";
+  for (const viewportArg of viewports) {
+    const [width, height] = viewportArg.split("x").map(Number);
+    const context = await browser.newContext({ viewport: { width, height } });
+    try {
+      for (const fixture of FIXTURES) {
+        for (const cpuThrottle of cpuTiers) {
+          const repResults = [];
+          for (let r = 0; r < reps; r++) {
+            repResults.push(await runRep(context, fixture, cpuThrottle));
+          }
+          const row = {
+            fixture: fixture.name,
+            route: fixture.route,
+            viewport: viewportArg,
+            cpuThrottle,
+            initialRenderMs: round(median(repResults.map(x => x.initialRenderMs))),
+            medianFrameMs: round(median(repResults.map(x => x.medianFrameMs))),
+            p95FrameMs: round(median(repResults.map(x => x.p95FrameMs))),
+            droppedFramePct: round(median(repResults.map(x => x.droppedFramePct))),
+            frameCount: Math.round(median(repResults.map(x => x.frameCount))),
+            effectiveFps: round(median(repResults.map(x => x.effectiveFps))),
+          };
+          results.push(row);
+          console.log(
+            `  ${row.viewport}  cpu ${row.cpuThrottle}x  median ${row.medianFrameMs}ms  p95 ${row.p95FrameMs}ms  dropped ${row.droppedFramePct}%  init ${row.initialRenderMs}ms  fps ${row.effectiveFps}`
+          );
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    git: gitInfo(),
+    environment: {
+      harness: "map-bench.mjs",
+      chromium: chromiumVersion,
+      gpu: "disabled (--disable-gpu)",
+      note: "headless software rendering; absolute fps not comparable to real devices",
+    },
+    gesture: {
+      zoomTicks: GESTURE.zoomTicks,
+      panSteps: GESTURE.panSteps,
+      reps,
+      frameBudgetMs: round(FRAME_BUDGET_MS),
+      droppedThreshold: DROPPED_THRESHOLD,
+    },
+    results,
+    notes: [
+      "Only classical variant benchmarked: every mock game is wired to variantId 'classical'; godip coverage deferred.",
+      "Absolute timings are headless + software-render; use only for before/after delta on the same machine/config.",
+      "GPU compositing cost (the real-device hot path) is NOT captured here; real-user data is Block 2 (telemetry).",
+    ],
+  };
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n");
+  console.log(`\nWrote ${outPath}`);
+  if (writeBaseline) {
+    const baselinePath = resolve(PACKAGE_ROOT, "bench/baseline.json");
+    writeFileSync(baselinePath, JSON.stringify(output, null, 2) + "\n");
+    console.log(`Wrote ${baselinePath}`);
+  }
+  console.log("\nNotes:");
+  for (const n of output.notes) console.log(`  - ${n}`);
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## What this does

Block 1 of the map re-architecture from [discussion #788](https://github.com/johnpooch/diplicity-react/discussions/788): a reproducible benchmark of the **current** map (react-zoom-pan-pinch + dSVG) that produces a committed baseline. Every later block (Leaflet base/hit-test/overlay layers, cutover) is measured against these numbers to prove it helped rather than just moving cost between GPU and CPU.

This is measurement-only — **no app code is touched**.

## Approach

New `@diplicity/map` workspace (standalone package, following the `@diplicity/map-parse` convention) containing an external Playwright harness. For each viewport × CPU-throttle cell it navigates to the classical map route on the mock dev server, runs a **fixed scripted pan/zoom gesture** (CDP wheel + drag), captures frame cadence, and writes a JSON baseline.

All metrics are captured externally so the harness measures the shipping app unmodified:
- **frame cadence** — an injected `requestAnimationFrame` recorder (`page.addInitScript`)
- **initial render** — scraped from the existing `[InteractiveMap] renderer.render() took Xms` console log
- **CPU throttle / viewport** — CDP (`Emulation.setCPUThrottlingRate`) + browser context

Reuses the `@sparticuz/chromium` fallback from `scripts/screenshot.mjs` (since `playwright install` is blocked in cloud sessions).

## Files

- `packages/map/package.json` — new `@diplicity/map` package (devDeps: `playwright`, `@sparticuz/chromium`; script `bench:map`)
- `packages/map/scripts/map-bench.mjs` — the harness
- `packages/map/bench/baseline.json` — committed baseline
- `packages/map/.gitignore`

## Baseline (this run)

Matrix: classical `active-movement` × {desktop 1280×800, mobile 390×844} × {1×, 4×, 6× CPU}, median of 3 reps. The expected **monotonic degradation under throttle** holds on both viewports (the sanity check that the throttle is actually applying):

| viewport | cpu | median ms | p95 ms | dropped % | init ms | fps |
|---|---|---|---|---|---|---|
| 1280×800 | 1× | 16.7 | 16.8 | 1.6 | 3.8 | 58.8 |
| 1280×800 | 4× | 16.7 | 33.4 | 9.5 | 18.7 | 45.1 |
| 1280×800 | 6× | 16.7 | 66.7 | 11.9 | 27.4 | 36.9 |
| 390×844 | 1× | 16.7 | 16.7 | 0.0 | 3.7 | 60.0 |
| 390×844 | 4× | 16.7 | 33.3 | 9.7 | 18.4 | 50.6 |
| 390×844 | 6× | 16.7 | 66.6 | 24.5 | 29.2 | 37.6 |

## Honest limitations (recorded in `baseline.json` notes)

- **Classical only.** Cold War / Spice Islands (the discussion's "worst offenders") don't exist in the repo, and every mock fixture game uses `variantId: "classical"`, so classical active-movement is the densest map reachable through a real route today. Godip-variant coverage is deferred.
- **Headless + `--disable-gpu` (software rendering).** Absolute fps ≠ real-device fps, and GPU compositing cost — the actual user-facing hot path — is **not** captured here. The baseline is a relative before/after instrument on the same config. Real-device truth is Block 2 (telemetry).

## How to run

```bash
npm --prefix packages/web run dev:mocks         # serves real SVGs via MSW at :5173
npm --prefix packages/map run bench:map -- --write-baseline
```

## No visual changes

App behaviour and UI are untouched; this PR adds dev tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4

---
_Generated by [Claude Code](https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4)_