### PR TITLE
Fix toast action button native appearance on Chrome/Linux

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -152,27 +152,11 @@ body {
   }
 }
 
-[data-rich-colors='true'][data-sonner-toast][data-type='success'] [data-button] {
-  background: transparent;
-  border: 1px solid var(--success-text);
-  color: var(--success-text);
-}
-
-[data-rich-colors='true'][data-sonner-toast][data-type='error'] [data-button] {
-  background: transparent;
-  border: 1px solid var(--error-text);
-  color: var(--error-text);
-}
-
-[data-rich-colors='true'][data-sonner-toast][data-type='warning'] [data-button] {
-  background: transparent;
-  border: 1px solid var(--warning-text);
-  color: var(--warning-text);
-}
-
-[data-rich-colors='true'][data-sonner-toast][data-type='info'] [data-button] {
-  background: transparent;
-  border: 1px solid var(--info-text);
-  color: var(--info-text);
+/* Tailwind v4 preflight no longer strips native button appearance, so on
+   Chrome/Linux the GTK button style overrides Sonner's background/border.
+   Force appearance: none so Sonner's own CSS takes full effect. */
+[data-sonner-toast] [data-button] {
+  -webkit-appearance: none;
+  appearance: none;
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -151,3 +151,28 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+[data-rich-colors='true'][data-sonner-toast][data-type='success'] [data-button] {
+  background: transparent;
+  border: 1px solid var(--success-text);
+  color: var(--success-text);
+}
+
+[data-rich-colors='true'][data-sonner-toast][data-type='error'] [data-button] {
+  background: transparent;
+  border: 1px solid var(--error-text);
+  color: var(--error-text);
+}
+
+[data-rich-colors='true'][data-sonner-toast][data-type='warning'] [data-button] {
+  background: transparent;
+  border: 1px solid var(--warning-text);
+  color: var(--warning-text);
+}
+
+[data-rich-colors='true'][data-sonner-toast][data-type='info'] [data-button] {
+  background: transparent;
+  border: 1px solid var(--info-text);
+  color: var(--info-text);
+}
+


### PR DESCRIPTION
Fixes the action button rendering with native GTK browser styling on Chrome/Linux instead of Sonner's intended dark button.

Tailwind v4's preflight no longer strips `appearance: button` from form controls (unlike v3), so on Chrome/Linux the GTK button style renders over Sonner's CSS-specified `background` and `border`. Adding `appearance: none` to `[data-sonner-toast] [data-button]` removes the native rendering and lets Sonner's own styles take full effect.

Closes #869

## After

![after](https://raw.githubusercontent.com/johnpooch/diplicity-react/ff0f05b/shots/after.png)
