### PR TITLE
Add real-device map performance telemetry (Block 2)

### DIFF
--- a/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMap.tsx
@@ -7,6 +7,7 @@ import type {
 import type { ParsedDsvg } from "./dsvgParser";
 import type { DiplicityMap, RenderState } from "./mapRenderer";
 import { toRenderState } from "./toRenderState";
+import { recordInitialRender } from "./mapTelemetry";
 import { isNativePlatform } from "../../utils/platform";
 
 type VariantForMap = Pick<Variant, "id" | "nations">;
@@ -72,9 +73,7 @@ const InteractiveMap: React.FC<InteractiveMapProps> = (props) => {
   const isNative = isNativePlatform();
   const [hoveredProvince, setHoveredProvince] = useState<string | null>(null);
 
-  // --- Diagnostic ---
-  const renderCountRef = useRef(0);
-  const prevPropsRef = useRef<InteractiveMapProps | null>(null);
+  const initialRenderRecordedRef = useRef(false);
 
   const orders = useMemo(() => props.orders ?? [], [props.orders]);
   const highlighted = useMemo(
@@ -105,12 +104,16 @@ const InteractiveMap: React.FC<InteractiveMapProps> = (props) => {
       const result = splitAfterProvinceFills(
         stripSvgWrapper(props.renderer.render(renderState))
       );
-      console.log(
-        `[InteractiveMap] renderer.render() took ${(performance.now() - t0).toFixed(1)}ms`
-      );
+      if (!initialRenderRecordedRef.current) {
+        initialRenderRecordedRef.current = true;
+        recordInitialRender({
+          variantId: props.variant.id,
+          renderMs: performance.now() - t0,
+        });
+      }
       return result;
     },
-    [props.renderer, renderState]
+    [props.renderer, renderState, props.variant.id]
   );
 
   const { viewBox, provincePaths, namedCoastPaths } = props.parsedDsvg;
@@ -172,21 +175,6 @@ const InteractiveMap: React.FC<InteractiveMapProps> = (props) => {
     : undefined;
   const hoveredIsSelected =
     hoveredProvince !== null && props.selected.includes(hoveredProvince);
-
-  // --- Diagnostic logging ---
-  renderCountRef.current += 1;
-  if (prevPropsRef.current) {
-    const changed = (Object.keys(props) as Array<keyof InteractiveMapProps>).filter(
-      (k) => props[k] !== prevPropsRef.current![k]
-    );
-    console.log(
-      `[InteractiveMap] render #${renderCountRef.current}`,
-      changed.length > 0 ? { changedProps: changed } : "(internal state change)"
-    );
-  } else {
-    console.log(`[InteractiveMap] render #${renderCountRef.current} (initial)`);
-  }
-  prevPropsRef.current = props;
 
   return (
     <svg

--- a/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
+++ b/packages/web/src/components/InteractiveMap/InteractiveMapZoomWrapper.tsx
@@ -8,6 +8,7 @@ import { Maximize, Minimize } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 import { InteractiveMap } from "./InteractiveMap";
+import { recordGesture, type GestureType } from "./mapTelemetry";
 import { useDsvg } from "../../hooks/useDsvg";
 import { parseDsvg } from "./dsvgParser";
 import { DiplicityMap } from "./mapRenderer";
@@ -38,12 +39,10 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // --- Diagnostic ---
-  const renderCountRef = useRef(0);
-  const prevZoomPropsRef = useRef<typeof interactiveMapProps | null>(null);
   const lastTransformTimeRef = useRef<number | null>(null);
   const transformFrameTimesRef = useRef<number[]>([]);
-  const fpsFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gestureTypeRef = useRef<GestureType | null>(null);
+  const gestureStartTimeRef = useRef<number>(0);
 
   const { data: dsvg, isLoading } = useDsvg(interactiveMapProps.variant.svgUrl);
 
@@ -130,16 +129,31 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
     });
   };
 
-  const handleGestureStart = () => {
+  const handleGestureStart = (gestureType: GestureType) => {
     if (svgRef.current) {
       svgRef.current.style.pointerEvents = "none";
     }
+    gestureTypeRef.current = gestureType;
+    gestureStartTimeRef.current = performance.now();
+    transformFrameTimesRef.current = [];
+    lastTransformTimeRef.current = null;
   };
 
   const handleGestureStop = () => {
     if (svgRef.current) {
       svgRef.current.style.pointerEvents = "";
     }
+    if (gestureTypeRef.current !== null) {
+      recordGesture({
+        variantId: interactiveMapProps.variant.id,
+        gestureType: gestureTypeRef.current,
+        durationMs: performance.now() - gestureStartTimeRef.current,
+        frameMs: transformFrameTimesRef.current,
+      });
+      gestureTypeRef.current = null;
+    }
+    transformFrameTimesRef.current = [];
+    lastTransformTimeRef.current = null;
   };
 
   const handleTransformed = () => {
@@ -148,19 +162,6 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
       transformFrameTimesRef.current.push(now - lastTransformTimeRef.current);
     }
     lastTransformTimeRef.current = now;
-
-    if (fpsFlushTimerRef.current) clearTimeout(fpsFlushTimerRef.current);
-    fpsFlushTimerRef.current = setTimeout(() => {
-      const times = transformFrameTimesRef.current;
-      if (times.length > 1) {
-        const avg = times.reduce((a, b) => a + b, 0) / times.length;
-        console.log(
-          `[InteractiveMapZoom] gesture: ${times.length} updates, avg ${avg.toFixed(1)}ms between transforms (~${(1000 / avg).toFixed(0)} fps)`
-        );
-      }
-      transformFrameTimesRef.current = [];
-      lastTransformTimeRef.current = null;
-    }, 500);
   };
 
   useEffect(() => {
@@ -199,21 +200,6 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
     }
   }, [minScale, containerDimensions, svgViewBox]);
 
-  // --- Diagnostic logging ---
-  renderCountRef.current += 1;
-  if (prevZoomPropsRef.current) {
-    const changed = (
-      Object.keys(interactiveMapProps) as Array<keyof typeof interactiveMapProps>
-    ).filter((k) => interactiveMapProps[k] !== prevZoomPropsRef.current![k]);
-    console.log(
-      `[InteractiveMapZoom] render #${renderCountRef.current}`,
-      changed.length > 0 ? { changedProps: changed } : "(internal state change)"
-    );
-  } else {
-    console.log(`[InteractiveMapZoom] render #${renderCountRef.current} (initial)`);
-  }
-  prevZoomPropsRef.current = interactiveMapProps;
-
   if (isLoading || !parsedDsvg || !renderer) {
     return (
       <div
@@ -240,11 +226,11 @@ const InteractiveMapZoomWrapper: React.FC<InteractiveMapZoomWrapperProps> = ({
         panning={{ velocityDisabled: true }}
         velocityAnimation={{ disabled: true }}
         onTransformed={handleTransformed}
-        onPanningStart={handleGestureStart}
+        onPanningStart={() => handleGestureStart("pan")}
         onPanningStop={handleGestureStop}
-        onPinchingStart={handleGestureStart}
+        onPinchingStart={() => handleGestureStart("pinch")}
         onPinchingStop={handleGestureStop}
-        onZoomStart={handleGestureStart}
+        onZoomStart={() => handleGestureStart("zoom")}
         onZoomStop={handleGestureStop}
       >
         <TransformComponent wrapperStyle={{ width: "100%", height: "100%" }}>

--- a/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
+++ b/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { startSpanSpy, endSpy } = vi.hoisted(() => {
+  const endSpy = vi.fn();
+  return { startSpanSpy: vi.fn(() => ({ end: endSpy })), endSpy };
+});
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: { getTracer: () => ({ startSpan: startSpanSpy }) },
+}));
+
+import { recordInitialRender, recordGesture } from "./mapTelemetry";
+
+describe("mapTelemetry", () => {
+  beforeEach(() => {
+    startSpanSpy.mockClear();
+    endSpy.mockClear();
+  });
+
+  it("emits a map.initial_render span with render time and variant", () => {
+    recordInitialRender({ variantId: "classical", renderMs: 12.5 });
+
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    const [name, options] = startSpanSpy.mock.calls[0];
+    expect(name).toBe("map.initial_render");
+    expect(options.attributes["map.variant_id"]).toBe("classical");
+    expect(options.attributes["map.render_ms"]).toBe(12.5);
+    expect(endSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a map.gesture span with computed frame statistics", () => {
+    recordGesture({
+      variantId: "classical",
+      gestureType: "pan",
+      durationMs: 100,
+      frameMs: [16, 16, 40, 16],
+    });
+
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    const [name, options] = startSpanSpy.mock.calls[0];
+    expect(name).toBe("map.gesture");
+    expect(options.attributes["map.gesture_type"]).toBe("pan");
+    expect(options.attributes["map.duration_ms"]).toBe(100);
+    expect(options.attributes["map.median_frame_ms"]).toBe(16);
+    expect(options.attributes["map.p95_frame_ms"]).toBe(40);
+    expect(options.attributes["map.dropped_frame_pct"]).toBe(25);
+    expect(options.attributes["map.frame_count"]).toBe(4);
+    expect(endSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit a gesture span when no frames were recorded", () => {
+    recordGesture({
+      variantId: "classical",
+      gestureType: "zoom",
+      durationMs: 50,
+      frameMs: [],
+    });
+
+    expect(startSpanSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
+++ b/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+type StartSpan = (
+  name: string,
+  options: { attributes: Record<string, string | number> }
+) => { end: () => void };
+
 const { startSpanSpy, endSpy } = vi.hoisted(() => {
   const endSpy = vi.fn();
-  return { startSpanSpy: vi.fn(() => ({ end: endSpy })), endSpy };
+  const startSpanSpy = vi.fn<StartSpan>(() => ({ end: endSpy }));
+  return { startSpanSpy, endSpy };
 });
 
 vi.mock("@opentelemetry/api", () => ({
@@ -20,11 +26,15 @@ describe("mapTelemetry", () => {
   it("emits a map.initial_render span with render time and variant", () => {
     recordInitialRender({ variantId: "classical", renderMs: 12.5 });
 
-    expect(startSpanSpy).toHaveBeenCalledTimes(1);
-    const [name, options] = startSpanSpy.mock.calls[0];
-    expect(name).toBe("map.initial_render");
-    expect(options.attributes["map.variant_id"]).toBe("classical");
-    expect(options.attributes["map.render_ms"]).toBe(12.5);
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      "map.initial_render",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          "map.variant_id": "classical",
+          "map.render_ms": 12.5,
+        }),
+      })
+    );
     expect(endSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -36,15 +46,19 @@ describe("mapTelemetry", () => {
       frameMs: [16, 16, 40, 16],
     });
 
-    expect(startSpanSpy).toHaveBeenCalledTimes(1);
-    const [name, options] = startSpanSpy.mock.calls[0];
-    expect(name).toBe("map.gesture");
-    expect(options.attributes["map.gesture_type"]).toBe("pan");
-    expect(options.attributes["map.duration_ms"]).toBe(100);
-    expect(options.attributes["map.median_frame_ms"]).toBe(16);
-    expect(options.attributes["map.p95_frame_ms"]).toBe(40);
-    expect(options.attributes["map.dropped_frame_pct"]).toBe(25);
-    expect(options.attributes["map.frame_count"]).toBe(4);
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      "map.gesture",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          "map.gesture_type": "pan",
+          "map.duration_ms": 100,
+          "map.median_frame_ms": 16,
+          "map.p95_frame_ms": 40,
+          "map.dropped_frame_pct": 25,
+          "map.frame_count": 4,
+        }),
+      })
+    );
     expect(endSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/web/src/components/InteractiveMap/mapTelemetry.ts
+++ b/packages/web/src/components/InteractiveMap/mapTelemetry.ts
@@ -1,0 +1,93 @@
+import { trace, type Attributes } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("map-performance");
+
+const FRAME_BUDGET_MS = 1000 / 60;
+const DROPPED_THRESHOLD = 1.5;
+
+export type GestureType = "pan" | "pinch" | "zoom";
+
+type FrameStats = {
+  medianFrameMs: number;
+  p95FrameMs: number;
+  droppedFramePct: number;
+  frameCount: number;
+  effectiveFps: number;
+};
+
+const median = (xs: number[]): number => {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+const percentile = (xs: number[], p: number): number => {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+};
+
+const frameStats = (frameMs: number[]): FrameStats => {
+  const dropped = frameMs.filter((d) => d > DROPPED_THRESHOLD * FRAME_BUDGET_MS).length;
+  const total = frameMs.reduce((a, b) => a + b, 0);
+  return {
+    medianFrameMs: median(frameMs),
+    p95FrameMs: percentile(frameMs, 95),
+    droppedFramePct: frameMs.length ? (dropped / frameMs.length) * 100 : 0,
+    frameCount: frameMs.length,
+    effectiveFps: total > 0 ? (frameMs.length / total) * 1000 : 0,
+  };
+};
+
+const deviceContext = (): Attributes => {
+  const nav = navigator as Navigator & { deviceMemory?: number };
+  const attributes: Attributes = {
+    "viewport.width": window.innerWidth,
+    "viewport.height": window.innerHeight,
+    "device.pixel_ratio": window.devicePixelRatio,
+    "device.cpu_cores": nav.hardwareConcurrency,
+  };
+  if (nav.deviceMemory !== undefined) {
+    attributes["device.memory_gb"] = nav.deviceMemory;
+  }
+  return attributes;
+};
+
+const recordInitialRender = (params: { variantId: string; renderMs: number }): void => {
+  const span = tracer.startSpan("map.initial_render", {
+    attributes: {
+      "map.variant_id": params.variantId,
+      "map.render_ms": params.renderMs,
+      ...deviceContext(),
+    },
+  });
+  span.end();
+};
+
+const recordGesture = (params: {
+  variantId: string;
+  gestureType: GestureType;
+  durationMs: number;
+  frameMs: number[];
+}): void => {
+  if (params.frameMs.length === 0) return;
+  const stats = frameStats(params.frameMs);
+  const span = tracer.startSpan("map.gesture", {
+    attributes: {
+      "map.variant_id": params.variantId,
+      "map.gesture_type": params.gestureType,
+      "map.duration_ms": params.durationMs,
+      "map.median_frame_ms": stats.medianFrameMs,
+      "map.p95_frame_ms": stats.p95FrameMs,
+      "map.dropped_frame_pct": stats.droppedFramePct,
+      "map.frame_count": stats.frameCount,
+      "map.effective_fps": stats.effectiveFps,
+      ...deviceContext(),
+    },
+  });
+  span.end();
+};
+
+export { recordInitialRender, recordGesture };


### PR DESCRIPTION
## What this does

Block 2 of the map re-architecture ([discussion #788](https://github.com/johnpooch/diplicity-react/discussions/788)). Block 1 ([PR #867](https://github.com/johnpooch/diplicity-react/pull/867)) gave a **synthetic** baseline from a headless harness that is GPU-blind by design. Block 2 captures **real-user, real-device** map performance from production and sends it to Honeycomb, so the eventual Leaflet rewrite can be measured against real-world data — not just the synthetic harness.

## Approach

Reuses the OpenTelemetry → Honeycomb pipeline that is **already wired up** on the frontend (`observability.ts`). A new helper emits two spans through the existing global tracer; no backend, no DB table, no migration.

- `map.initial_render` — render time on first map render.
- `map.gesture` — one per pan/zoom/pinch gesture: median / p95 frame ms, dropped-frame %, effective fps, gesture type, duration.

Both spans carry device context (`device.memory_gb`, `device.cpu_cores`, viewport, pixel ratio) and `map.variant_id`, plus the `deployment.environment` already attached by the provider — so production data is trivially filterable in Honeycomb. The metric formulas (median/p95, 16.67ms frame budget, 1.5× dropped threshold) **match the Block 1 harness exactly**, so the real-device distributions sit on the same axes as the synthetic baseline and the future Leaflet numbers.

### Zero new env-gating

The global OTel tracer provider is only registered when `VITE_HONEYCOMB_API_KEY` is set. So `trace.getTracer(...)` spans are **real in production** and **automatic no-ops in dev/mocks/Netlify previews** — no `if (production)` branches to maintain.

## Files

- **add** `mapTelemetry.ts` — the tracer + `frameStats` + `deviceContext` + `recordInitialRender` / `recordGesture`.
- **add** `mapTelemetry.test.ts` — unit tests for span emission and frame-statistics computation.
- **modify** `InteractiveMapZoomWrapper.tsx` — wire the existing `handleGestureStart/Stop` hooks (now typed pan/pinch/zoom) and the `handleTransformed` frame accumulator to `recordGesture`.
- **modify** `InteractiveMap.tsx` — wire the existing `renderer.render()` timing to `recordInitialRender` (once per mount).

Also removes the noisy per-render diagnostic `console.log`s in both files — superseded by the spans.

## Verification

- `npx tsc -b --noEmit` ✅ and `npm run lint` ✅ on all four files (no `any` — `navigator.deviceMemory` is narrowly typed; no suppressions).
- `mapTelemetry.test.ts` ✅ (3 tests): asserts `map.initial_render` / `map.gesture` attributes and that an empty-frame gesture emits nothing.
- `GameMap.test.tsx` ✅ (5 tests) still pass.
- Ran the app under `dev:mocks` (no Honeycomb key) and confirmed the map at `/game/active-movement/phase/101` renders and behaves identically — spans are silent no-ops, no console errors.

After this merges and real traffic arrives, the standard Honeycomb query (heatmap of `map.p95_frame_ms`, `P95(map.dropped_frame_pct)` grouped by `device.memory_gb` / `map.variant_id`) becomes the artifact re-run to compare the Leaflet rewrite.

## No visual changes

UI is untouched. The only user-observable delta is the removal of dev-console diagnostic logs.

> Note: `VITE_HONEYCOMB_API_KEY` is not injected in `netlify.toml`; if it isn't set in the Netlify production env, no frontend spans flow. That's a one-time ops check, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4

---
_Generated by [Claude Code](https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4)_