### PR TITLE
Bump version to 1.5.3 for new iOS build

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## What this does

Bumps the app version from `1.5.2` to `1.5.3` to cut a new iOS build.

The iOS `MARKETING_VERSION` is read from `packages/web/package.json` `version` field (via `xcargs`), so this bump is all that's needed to mark the next release. The `CURRENT_PROJECT_VERSION` (build number) is auto-generated as a Unix timestamp per build, so no manual change there.

On merge to `main`, the `ios-release.yml` workflow builds the web app, syncs Capacitor, and runs `fastlane ios release` to upload the new build to TestFlight.

## No visual changes

Version-bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVNf3Sa45ss47WYE4koEZu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVNf3Sa45ss47WYE4koEZu)_