### PR TITLE
Show minReliability on Game Info screen

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BookOpen, Calendar, Clock, Users, Lock, Unlock, User, Map, Trophy, Pause, Shield, MessageSquare, MessageSquareOff } from "lucide-react";
+import { BookOpen, Calendar, Clock, Users, Lock, Unlock, User, Map, Trophy, Pause, Shield, ShieldCheck, MessageSquare, MessageSquareOff } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -11,6 +11,7 @@ import {
   useVariantsListSuspense,
 } from "@/api/generated/endpoints";
 import { getCurrentPhaseId, formatDateTime, formatTimeAgo } from "@/util";
+import { MIN_RELIABILITY_OPTIONS } from "@/constants";
 import { ExpandableMapPreview } from "@/components/ExpandableMapPreview";
 import { CardTitle } from "@/components/ui/card";
 import {
@@ -156,6 +157,14 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
               value={`${game.nmrExtensionsAllowed} per player`}
             />
           )}
+          <MetadataRow
+            icon={<ShieldCheck className="size-4" />}
+            label="Player reliability"
+            value={
+              MIN_RELIABILITY_OPTIONS.find(o => o.value === game.minReliability)?.label ??
+              game.minReliability
+            }
+          />
           <MetadataRow
             icon={<Users className="size-4" />}
             label="Players"

--- a/packages/web/src/screens/Home/GameInfo.test.tsx
+++ b/packages/web/src/screens/Home/GameInfo.test.tsx
@@ -43,7 +43,14 @@ vi.mock("@/components/GameDropdownMenu", () => ({
 }));
 
 const pendingGameCanJoin = mockPendingGames.find((g) => g.canJoin)!;
-const pendingGameCanLeave = mockPendingGames.find((g) => !g.canJoin)!;
+const pendingGameCanLeave = mockPendingGames.find((g) => !g.canJoin && g.canLeave)!;
+const pendingGameReliabilityRequired = {
+  ...mockPendingGames.find((g) => g.canJoin)!,
+  id: "game-reliability-test",
+  canJoin: false,
+  canLeave: false,
+  minReliability: "reliable_only" as const,
+};
 
 const renderGameInfo = (gameId: string) => {
   const queryClient = new QueryClient({
@@ -89,6 +96,20 @@ describe("GameInfoScreen", () => {
       const content = screen.getByTestId("game-info-content");
       expect(
         within(content).getByRole("button", { name: /^leave$/i })
+      ).toBeInTheDocument();
+    });
+
+    it("shows disabled 'Join game' button with reliability message for a pending game with reliability requirement the user cannot join", () => {
+      mockUseGameRetrieveSuspense.mockReturnValue({
+        data: pendingGameReliabilityRequired,
+      });
+      renderGameInfo(pendingGameReliabilityRequired.id);
+
+      const content = screen.getByTestId("game-info-content");
+      const joinButton = within(content).getByRole("button", { name: /join game/i });
+      expect(joinButton).toBeDisabled();
+      expect(
+        within(content).getByText(/your reliability is too low to join this game/i)
       ).toBeInTheDocument();
     });
 

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -78,7 +78,7 @@ const GameInfo: React.FC = () => {
       >
         Join game
       </Button>
-    ) : (
+    ) : game.canLeave ? (
       <div className="flex gap-2 w-full sm:w-auto">
         <Button
           onClick={handleLeaveGame}
@@ -93,7 +93,16 @@ const GameInfo: React.FC = () => {
           Share &amp; invite
         </Button>
       </div>
-    )
+    ) : game.minReliability !== "open" ? (
+      <div className="flex flex-col gap-1 w-full sm:w-auto">
+        <Button disabled className="w-full sm:w-auto">
+          Join game
+        </Button>
+        <p className="text-xs text-muted-foreground text-center">
+          Your reliability is too low to join this game
+        </p>
+      </div>
+    ) : null
   ) : null;
 
   return (


### PR DESCRIPTION
Closes #873

Surfaces the game's minimum reliability requirement on the Game Info screen, alongside the other settings (Visibility, Press type, NMR extensions).

Also fixes the pending-game action when a non-member cannot join due to the game's reliability requirement: instead of showing the Leave button (which would be incorrect for a non-member), a disabled "Join game" button is shown with the message "Your reliability is too low to join this game". The existing Leave + Share action is now gated on `canLeave` rather than `!canJoin`.

## Screenshots

**Desktop (1280×800)**
![Game Info screen — Player reliability row](https://raw.githubusercontent.com/johnpooch/diplicity-react/440747ace3b3cb9fca80343f13c5de40e1db5a53/shots/game-info.png)

**Mobile (390×844)**
![Game Info screen — mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/440747ace3b3cb9fca80343f13c5de40e1db5a53/shots/game-info-mobile.png)