### PR TITLE
Sync package-lock.json to package.json version 1.5.3

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",


### PR DESCRIPTION
## Summary

- `package.json` was bumped to `1.5.3` in a prior commit ("Bump version to 1.5.3 for new iOS build") but `package-lock.json` was not updated at the same time
- `npm install` during the session-start hook detected the mismatch and synced the lockfile

## No visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUdspr4GNAGDpCbe9wTvz3)_