### PR TITLE
Add frozen MapView interface and route GameMap through it

### DIFF
--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -9,7 +9,7 @@ import {
   buildOrderProgressText,
   unitAbbrev,
 } from "../utils/buildOrderProgressText";
-import { InteractiveMapZoomWrapper } from "./InteractiveMap/InteractiveMapZoomWrapper";
+import { MapView } from "./MapView";
 import { FloatingMenu, FloatingMenuItem } from "./FloatingMenu";
 import {
   useGameRetrieve,
@@ -161,11 +161,11 @@ const GameMap: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mutateAsync is stable
   }, [wizard.isComplete]);
 
-  const captureMenuPosition = (event: React.MouseEvent<SVGPathElement>) => {
+  const captureMenuPosition = (position: { x: number; y: number }) => {
     if (containerRef.current) {
       const containerRect = containerRef.current.getBoundingClientRect();
-      const x = event.clientX - containerRect.left;
-      const y = event.clientY - containerRect.top;
+      const x = position.x - containerRect.left;
+      const y = position.y - containerRect.top;
       if (x > 0 && y > 0) {
         setMenuPosition({ x, y });
       }
@@ -174,7 +174,7 @@ const GameMap: React.FC = () => {
 
   const handleProvinceClick = (
     province: string,
-    event: React.MouseEvent<SVGPathElement>
+    position: { x: number; y: number }
   ) => {
     if (!renderableProvinces.includes(province)) {
       return;
@@ -193,7 +193,7 @@ const GameMap: React.FC = () => {
         }
         return;
       }
-      captureMenuPosition(event);
+      captureMenuPosition(position);
       wizard.select(province);
     } else if (
       wizard.nextField === "target" ||
@@ -208,7 +208,7 @@ const GameMap: React.FC = () => {
         wizard.nextField === "namedCoast") &&
       province === wizard.resolvedSelections["source"]
     ) {
-      captureMenuPosition(event);
+      captureMenuPosition(position);
     }
   };
 
@@ -272,18 +272,16 @@ const GameMap: React.FC = () => {
     <div ref={containerRef} className="relative w-full h-full">
       {game && variant && phase && orders && (
         <>
-          <InteractiveMapZoomWrapper
-            interactiveMapProps={{
-              interactive: true,
-              variant: variant,
-              phase: phase,
-              orders: displayOrders,
-              selected: wizard.selectedArray,
-              onClickProvince: handleProvinceClick,
-              renderableProvinces: renderableProvinces,
-              highlighted: highlightedIds,
-              civilDisorderNations: civilDisorderNations,
-            }}
+          <MapView
+            interactive
+            variant={variant}
+            phase={phase}
+            orders={displayOrders}
+            selected={wizard.selectedArray}
+            onClickProvince={handleProvinceClick}
+            renderableProvinces={renderableProvinces}
+            highlighted={highlightedIds}
+            civilDisorderNations={civilDisorderNations}
           />
           <FloatingMenu
             open={showMenu}

--- a/packages/web/src/components/MapView.test.tsx
+++ b/packages/web/src/components/MapView.test.tsx
@@ -1,0 +1,46 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MapView, type MapViewProps } from "./MapView";
+
+vi.mock("./InteractiveMap/InteractiveMapZoomWrapper", () => ({
+  InteractiveMapZoomWrapper: ({
+    interactiveMapProps,
+  }: {
+    interactiveMapProps: {
+      onClickProvince?: (
+        province: string,
+        event: { clientX: number; clientY: number }
+      ) => void;
+    };
+  }) => (
+    <button
+      data-testid="province"
+      onClick={() =>
+        interactiveMapProps.onClickProvince?.("lon", {
+          clientX: 42,
+          clientY: 99,
+        })
+      }
+    />
+  ),
+}));
+
+const baseProps: MapViewProps = {
+  variant: { id: "standard", nations: [], svgUrl: null },
+  phase: {} as MapViewProps["phase"],
+  orders: undefined,
+  selected: [],
+};
+
+describe("MapView", () => {
+  it("adapts the SVG click event into renderer-agnostic client coordinates", () => {
+    const onClickProvince = vi.fn();
+    const { getByTestId } = render(
+      <MapView {...baseProps} onClickProvince={onClickProvince} />
+    );
+
+    fireEvent.click(getByTestId("province"));
+
+    expect(onClickProvince).toHaveBeenCalledWith("lon", { x: 42, y: 99 });
+  });
+});

--- a/packages/web/src/components/MapView.tsx
+++ b/packages/web/src/components/MapView.tsx
@@ -1,0 +1,32 @@
+import type { Order, PhaseRetrieve, Variant } from "../api/generated/endpoints";
+import { InteractiveMapZoomWrapper } from "./InteractiveMap/InteractiveMapZoomWrapper";
+
+interface MapViewProps {
+  variant: Pick<Variant, "id" | "nations" | "svgUrl">;
+  phase: PhaseRetrieve;
+  orders: Order[] | undefined;
+  selected: string[];
+  highlighted?: string[];
+  civilDisorderNations?: string[];
+  renderableProvinces?: string[];
+  interactive?: boolean;
+  onClickProvince?: (province: string, position: { x: number; y: number }) => void;
+  style?: React.CSSProperties;
+}
+
+const MapView: React.FC<MapViewProps> = ({ onClickProvince, ...props }) => {
+  return (
+    <InteractiveMapZoomWrapper
+      interactiveMapProps={{
+        ...props,
+        onClickProvince: onClickProvince
+          ? (province, event) =>
+              onClickProvince(province, { x: event.clientX, y: event.clientY })
+          : undefined,
+      }}
+    />
+  );
+};
+
+export { MapView };
+export type { MapViewProps };


### PR DESCRIPTION
## What this does

This is the first step of the map re-architecture (discussion #788) following the merged telemetry work (#867 harness, #872 real-device telemetry). It establishes a single, renderer-agnostic **public interface** for the map so the eventual implementation swap (toward a Leaflet `CRS.Simple` renderer) is a change to one file rather than a churn across every consumer.

It introduces a `MapView` component as the only public seam, with today's SVG map (`InteractiveMapZoomWrapper`) as the first implementation behind it, and routes `GameMap` — the primary interactive surface — through it.

## Changes

- **`MapView.tsx` (new)** — the frozen `MapViewProps` contract (`variant` / `phase` / `orders` / `selected` / … in, `onClickProvince` out). It removes the three bits of SVG leakage from today's public surface:
  - flattens the wrapper's nested `interactiveMapProps`;
  - drops the unused `ref?: React.Ref<SVGSVGElement>`;
  - replaces `onClickProvince(province, MouseEvent<SVGPathElement>)` with the renderer-agnostic `onClickProvince(province, { x, y })`, emitting plain client coordinates. `MapView` is the single place that knows the current renderer is SVG.
- **`GameMap.tsx`** — imports `MapView` instead of `InteractiveMapZoomWrapper`, passes flat props, and `handleProvinceClick` / `captureMenuPosition` now consume `{ x, y }` (they only ever read `clientX`/`clientY`, so behaviour is identical).
- **`MapView.test.tsx` (new)** — asserts the one piece of logic `MapView` owns: the SVG-event → `{ x, y }` adapter.

## Why no package / no A/B

Per the simplified roadmap agreed for this work: the new map will be built as a standalone module inside `packages/web` (not a separate workspace package — the repo root isn't a workspaces root and the map props depend on generated API types that live in `packages/web`), and validated by **flipping** to it and comparing real-device telemetry against the existing Block 2 baseline, rather than a synchronized A/B. `MapView` is the flip + instant-rollback point for that.

## Scope

GameMap only, per #788's "prove on one surface first". `MapPreview`, `ExpandableMapPreview`, and `TutorialMap` still use the SVG internals directly and migrate after the flip is validated.

## Verification

- `npm run build` (`tsc -b && vite build`), `npm run lint`, and tests all green.
- `MapView.test.tsx` + the existing `GameMap.test.tsx` pass (6 tests) — the latter unchanged, confirming `MapView` is a transparent pass-through.
- Screenshot below (dev:mocks, `/game/active-movement/phase/101`) confirms the map renders identically through `MapView`.

**No visual change** — this is a pure interface refactor.

![GameMap rendered through MapView](https://raw.githubusercontent.com/johnpooch/diplicity-react/7fca499dcc61824cb6a087eee53bc7ddccbb0c72/shots/mapview-orders.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4

---
_Generated by [Claude Code](https://claude.ai/code/session_018AvfpHiqBvx26kZH3nm3B4)_