### PR TITLE
Add UI for players to recover from Civil Disorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -746,6 +746,7 @@ Registered game fixtures (the fixture's game `id` doubles as the URL slug, e.g. 
 | `activeGameBuild` | `active-build` | Fall 1901 adjustment; England can build 1 unit |
 | `activeGameDrawProposal` | `active-draw-proposal` | Active game with an open draw proposal, current user hasn't voted |
 | `activeGameEliminated` | `active-eliminated` | Active game; current user (England) has been eliminated |
+| `activeGameCivilDisorder` | `active-civil-disorder` | Active game; current user (England) is in civil disorder, cannot submit orders |
 | `finishedGameSolo` | `finished-solo` | Completed; current user won a solo victory |
 | `finishedGameDraw` | `finished-draw` | Completed; 3-way draw incl. current user |
 | `gameNotJoined` | `not-joined` | Active game the current user is not a member of |

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -57,9 +57,11 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         .replace(":gameId", gameId)
         .replace(":phaseId", phaseId);
       const badge =
-        item.label === "Chat" &&
-        game?.totalUnreadMessageCount &&
-        game.totalUnreadMessageCount > 0
+        (item.label === "Chat" &&
+          game?.totalUnreadMessageCount &&
+          game.totalUnreadMessageCount > 0) ||
+        (item.label === "Orders" &&
+          game?.members.some(m => m.isCurrentUser && m.civilDisorder))
           ? "•"
           : undefined;
       const path = searchParamsStr ? `${basePath}?${searchParamsStr}` : basePath;
@@ -74,7 +76,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
         badge,
       };
     });
-  }, [gameId, phaseId, searchParams, location.pathname, game?.totalUnreadMessageCount, game?.sandbox]);
+  }, [gameId, phaseId, searchParams, location.pathname, game?.totalUnreadMessageCount, game?.sandbox, game?.members]);
 
   // Filter out Map for desktop sidebar since map is already visible in right
   // panel. Unlike the bottom nav, the sidebar Chat icon should return to the

--- a/packages/web/src/mocks/fixtures/games.ts
+++ b/packages/web/src/mocks/fixtures/games.ts
@@ -576,3 +576,29 @@ const buildNotJoined = () => {
 };
 
 export const gameNotJoined = buildNotJoined();
+
+const buildActiveCivilDisorder = () => {
+  const members = makeActiveMembers().map(m =>
+    m.nation === "England" ? { ...m, civilDisorder: true } : m
+  );
+  const phase = makePhase(1001, 5, {
+    season: "Spring",
+    year: 1901,
+    type: "Movement",
+    remainingTime: 36 * 60 * 60,
+  });
+  return makeFixture({
+    description:
+      "Active game in Spring 1901 where the current user (England) is in civil disorder and cannot submit orders.",
+    game: makeGame("active-civil-disorder", "Lost Connection", members, [phase], {
+      orderStatus: "no_orders_required",
+      memberStatus: [],
+    }),
+    phases: [phase],
+    ordersByPhase: { 1001: [] },
+    phaseStates: members.map(m => makePhaseState(m, [])),
+    channels: [makeChannel("Public Press", members, [])],
+  });
+};
+
+export const activeGameCivilDisorder = buildActiveCivilDisorder();

--- a/packages/web/src/mocks/fixtures/index.ts
+++ b/packages/web/src/mocks/fixtures/index.ts
@@ -1,6 +1,7 @@
 import type { GameFixture } from "./types";
 import {
   activeGameBuild,
+  activeGameCivilDisorder,
   activeGameDrawProposal,
   activeGameEliminated,
   activeGameMovement,
@@ -30,6 +31,7 @@ export const gameFixtures = {
   activeGameBuild,
   activeGameDrawProposal,
   activeGameEliminated,
+  activeGameCivilDisorder,
   finishedGameSolo,
   finishedGameDraw,
   gameMasterGame,

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -147,7 +147,7 @@ export const handlers = [
     const game = { ...fixture.game } as Record<string, unknown>;
     delete game.currentPhase;
     const members = recoveredCivilDisorderGames.has(String(params.gameId))
-      ? (fixture.game.members as Array<Record<string, unknown>>).map(m =>
+      ? fixture.game.members.map(m =>
           m.isCurrentUser ? { ...m, civilDisorder: false } : m
         )
       : fixture.game.members;

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -73,6 +73,8 @@ const gameOr404 = (gameId: string | readonly string[]) => {
 const notFound = () =>
   HttpResponse.json({ detail: "Not found." }, { status: 404 });
 
+const recoveredCivilDisorderGames = new Set<string>();
+
 export const handlers = [
   http.get("*/version/", () =>
     HttpResponse.json({ environment: "mock", version: "mock" } satisfies Version)
@@ -144,8 +146,14 @@ export const handlers = [
     if (!fixture) return notFound();
     const game = { ...fixture.game } as Record<string, unknown>;
     delete game.currentPhase;
+    const members = recoveredCivilDisorderGames.has(String(params.gameId))
+      ? (fixture.game.members as Array<Record<string, unknown>>).map(m =>
+          m.isCurrentUser ? { ...m, civilDisorder: false } : m
+        )
+      : fixture.game.members;
     return HttpResponse.json({
       ...game,
+      members,
       totalUnreadMessageCount: fixture.totalUnreadMessageCount,
     });
   }),
@@ -232,6 +240,7 @@ export const handlers = [
     if (!fixture) return notFound();
     const member = fixture.game.members.find(m => m.isCurrentUser);
     if (!member) return notFound();
+    recoveredCivilDisorderGames.add(String(params.gameId));
     return HttpResponse.json({ ...member, civilDisorder: false });
   }),
 

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -227,6 +227,14 @@ export const handlers = [
     HttpResponse.json({ id: "active-movement" }, { status: 201 })
   ),
 
+  http.post("*/game/:gameId/recover-from-civil-disorder/", ({ params }) => {
+    const fixture = gameOr404(params.gameId as string);
+    if (!fixture) return notFound();
+    const member = fixture.game.members.find(m => m.isCurrentUser);
+    if (!member) return notFound();
+    return HttpResponse.json({ ...member, civilDisorder: false });
+  }),
+
   http.post("*/game/:gameId/orders/", async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json(body, { status: 201 });

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -36,10 +36,12 @@ vi.mock("@/api/generated/endpoints", () => ({
   useGameOrdersDeleteDestroy: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameConfirmPhasePartialUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameResolvePhaseCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useGameRecoverFromCivilDisorderCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGamesDrawProposalsListSuspense: () => ({ data: [] }),
   getGameRetrieveQueryKey: () => ["game"],
   getGameOrdersListQueryKey: () => ["orders"],
   getGameOptionsRetrieveQueryKey: () => ["options"],
+  getGamePhaseStatesListQueryKey: () => ["phase-states"],
 }));
 
 vi.mock("@/components/NationFlag", () => ({
@@ -140,6 +142,36 @@ describe("OrdersScreen civil disorder handling", () => {
     renderOrdersScreen();
 
     expect(screen.queryByRole("button", { name: /confirm orders/i })).not.toBeInTheDocument();
+  });
+
+  it("shows 'I'm back' button when current member is in civil disorder", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember({ civilDisorder: true })],
+    });
+
+    renderOrdersScreen();
+
+    expect(screen.getByRole("button", { name: /i'm back/i })).toBeInTheDocument();
+  });
+
+  it("does not show 'I'm back' button when current member is not in civil disorder", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember({ civilDisorder: false })],
+    });
+
+    renderOrdersScreen();
+
+    expect(screen.queryByRole("button", { name: /i'm back/i })).not.toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -15,7 +15,6 @@ import {
 import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -56,6 +55,7 @@ import {
   useGameRetrieveSuspense,
   useVariantsListSuspense,
   useGamesDrawProposalsListSuspense,
+  useGameRecoverFromCivilDisorderCreate,
   getGameRetrieveQueryKey,
   getGameOrdersListQueryKey,
   getGamePhaseStatesListQueryKey,
@@ -173,6 +173,7 @@ const OrdersScreen: React.FC = () => {
   const deleteOrderMutation = useGameOrdersDeleteDestroy();
   const confirmOrdersMutation = useGameConfirmPhasePartialUpdate();
   const resolvePhaseMutation = useGameResolvePhaseCreate();
+  const recoverMutation = useGameRecoverFromCivilDisorderCreate();
 
   const variant = variants.find(v => v.id === game.variantId)!;
 
@@ -235,6 +236,18 @@ const OrdersScreen: React.FC = () => {
       navigate(`/game/${gameId}/phase/${result.id}/orders`);
     } catch {
       toast.error("Failed to resolve phase");
+    }
+  };
+
+  const handleRecoverFromCivilDisorder = async () => {
+    try {
+      await recoverMutation.mutateAsync({ gameId });
+      queryClient.invalidateQueries({
+        queryKey: getGameRetrieveQueryKey(gameId),
+      });
+      toast.success("Welcome back!");
+    } catch {
+      toast.error("Failed to recover from civil disorder");
     }
   };
 
@@ -328,17 +341,23 @@ const OrdersScreen: React.FC = () => {
       />
       <div className="flex-1 overflow-y-auto">
         <Panel>
-          {isCurrentMemberInCivilDisorder && (
-            <Alert className="border-x-0 border-t-0 rounded-none">
-              <UserX className="size-4" />
-              <AlertDescription>
-                Your nation is in civil disorder. Your units hold each turn and
-                you cannot submit orders.
-              </AlertDescription>
-            </Alert>
-          )}
           <Panel.Content>
-            {!hasContent ? (
+            {isCurrentMemberInCivilDisorder ? (
+              <Notice
+                icon={UserX}
+                title="Civil Disorder"
+                message="Your nation is in civil disorder. Your units hold each turn and you cannot submit orders."
+                className="h-full"
+                actions={
+                  <Button
+                    onClick={handleRecoverFromCivilDisorder}
+                    disabled={recoverMutation.isPending}
+                  >
+                    I'm back
+                  </Button>
+                }
+              />
+            ) : !hasContent ? (
               <Notice
                 icon={emptyState.icon}
                 title={emptyState.title}
@@ -439,7 +458,7 @@ const OrdersScreen: React.FC = () => {
             )}
           </Panel.Content>
 
-          {(rightFooterButton || showDrawProposalsButton) && (
+          {!isCurrentMemberInCivilDisorder && (rightFooterButton || showDrawProposalsButton) && (
             <Panel.Footer divider>
               <div className="flex w-full items-center">
                 <div className="flex-1">


### PR DESCRIPTION
Closes #875

When a player is in civil disorder the Orders screen now replaces the orders list with a centred state showing the CD icon, a title, a short explanation, and an **"I'm back"** button. Clicking the button calls `POST /game/{id}/recover-from-civil-disorder/` and invalidates the game query so the screen transitions back to normal orders.

The normal orders accordion and the footer (confirm/resolve buttons) are both hidden while in CD — the player has no orders to manage.

A red dot badge is added to the Orders tab in the navigation (bottom nav on mobile, icon sidebar on desktop) whenever the current user is in civil disorder, matching the existing unread-message dot on Chat.

A new mock fixture `active-civil-disorder` is included so the screen can be exercised end-to-end in mock mode.

## Screenshots

**Desktop**
![Civil Disorder orders screen — desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/d12bdf0ff7dbc5873c53e6e2c8b5d80c4d254f94/shots/cd-orders.png)

**Mobile** (note the red dot on the Orders tab in the bottom nav)
![Civil Disorder orders screen — mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/d12bdf0ff7dbc5873c53e6e2c8b5d80c4d254f94/shots/cd-orders-mobile.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUD3xS75vyRPx6oZhqtWnJ)_