### PR TITLE
Recover from stale chunk errors after redeploy

### DIFF
--- a/packages/web/public/_redirects
+++ b/packages/web/public/_redirects
@@ -1,1 +1,6 @@
-/*    /index.html   200
+# Hashed build assets must never fall back to index.html. A missing chunk
+# (stale after a redeploy) should 404 so the app can recover, rather than
+# receiving index.html served as JavaScript (a MIME-type crash). Existing
+# files are still served normally since Netlify prioritises them over rules.
+/assets/*    /assets/:splat   404
+/*           /index.html      200

--- a/packages/web/src/components/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react";
 import { DiplicityLogo } from "./DiplicityLogo";
 import { Button } from "@/components/ui/button";
 import { SafeAreaView } from "@/components/SafeAreaView";
+import { isStaleChunkError, reloadForStaleChunk } from "@/utils/staleChunk";
 
 interface ErrorFallbackUIProps {
   error: Error;
@@ -39,6 +40,21 @@ interface ErrorFallbackProps {
 }
 
 const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error }) => {
+  const staleChunk = isStaleChunkError(error);
+
+  React.useEffect(() => {
+    if (staleChunk) reloadForStaleChunk();
+  }, [staleChunk]);
+
+  if (staleChunk) {
+    return (
+      <SafeAreaView className="flex flex-col items-center justify-center min-h-screen text-center gap-6">
+        <DiplicityLogo />
+        <p className="text-muted-foreground">Updating to the latest version…</p>
+      </SafeAreaView>
+    );
+  }
+
   const errorObject = error instanceof Error ? error : new Error(String(error));
   return <ErrorFallbackUI error={errorObject} />;
 };

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -9,10 +9,16 @@ import App from "./App.tsx";
 import { initializeObservability } from "./observability";
 import { initializeSentry } from "./sentry";
 import { themeStorage } from "./theme/themeStorage";
+import { reloadForStaleChunk } from "./utils/staleChunk";
 
 themeStorage.initialize();
 initializeObservability();
 initializeSentry();
+
+window.addEventListener("vite:preloadError", (event) => {
+  event.preventDefault();
+  reloadForStaleChunk();
+});
 
 const enableMocking = async () => {
   if (import.meta.env.VITE_MOCKS !== "true") return;

--- a/packages/web/src/utils/staleChunk.test.ts
+++ b/packages/web/src/utils/staleChunk.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isStaleChunkError, reloadForStaleChunk } from "./staleChunk";
+
+describe("isStaleChunkError", () => {
+  it("returns true for a failed dynamic import error", () => {
+    const error = new Error(
+      "Failed to fetch dynamically imported module: https://www.diplicity.com/assets/OrdersScreen-D67pRsLI.js"
+    );
+    expect(isStaleChunkError(error)).toBe(true);
+  });
+
+  it("returns true for a MIME type module error", () => {
+    const error = new Error(
+      'Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".'
+    );
+    expect(isStaleChunkError(error)).toBe(true);
+  });
+
+  it("returns true for a string error message", () => {
+    expect(
+      isStaleChunkError("error loading dynamically imported module")
+    ).toBe(true);
+  });
+
+  it("returns false for an unrelated error", () => {
+    expect(isStaleChunkError(new Error("Network request failed"))).toBe(false);
+  });
+
+  it("returns false for a non-error value", () => {
+    expect(isStaleChunkError(null)).toBe(false);
+  });
+});
+
+describe("reloadForStaleChunk", () => {
+  const reloadMock = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadMock.mockClear();
+    Object.defineProperty(window, "location", {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reloads the page on the first call", () => {
+    reloadForStaleChunk();
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload again within the debounce window", () => {
+    reloadForStaleChunk();
+    reloadForStaleChunk();
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads again after the debounce window elapses", () => {
+    reloadForStaleChunk();
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000 + 11_000);
+    reloadForStaleChunk();
+    expect(reloadMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/utils/staleChunk.ts
+++ b/packages/web/src/utils/staleChunk.ts
@@ -1,0 +1,28 @@
+const RELOAD_TIMESTAMP_KEY = "stale-chunk-reload-at";
+const RELOAD_DEBOUNCE_MS = 10_000;
+
+const STALE_CHUNK_MESSAGES = [
+  "Failed to fetch dynamically imported module",
+  "error loading dynamically imported module",
+  "Importing a module script failed",
+  "Expected a JavaScript-or-Wasm module script",
+];
+
+export const isStaleChunkError = (error: unknown): boolean => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  return STALE_CHUNK_MESSAGES.some((candidate) => message.includes(candidate));
+};
+
+export const reloadForStaleChunk = (): void => {
+  const lastReloadAt = Number(
+    sessionStorage.getItem(RELOAD_TIMESTAMP_KEY) ?? "0"
+  );
+  if (Date.now() - lastReloadAt < RELOAD_DEBOUNCE_MS) return;
+  sessionStorage.setItem(RELOAD_TIMESTAMP_KEY, String(Date.now()));
+  window.location.reload();
+};


### PR DESCRIPTION
## Problem

Production occasionally crashes with errors like:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the
server responded with a MIME type of "text/html".
TypeError: Failed to fetch dynamically imported module:
  https://www.diplicity.com/assets/OrdersScreen-D67pRsLI.js
```

Screens are code-split via `React.lazy` into content-hashed chunks (`OrdersScreen-…`, `Panel-…`, `PhaseGuidance-…`). When a new build is deployed, the old hashed filenames are removed. A client still running the **old** `index.html` then lazy-loads a now-missing chunk. The Netlify `/* → /index.html 200` catch-all serves `index.html` (as `text/html`) in place of the missing `.js`, the browser refuses to execute HTML as a module script, and the error propagates to the error boundary and crashes the page.

(The `429`s in the console are secondary — Sentry rate-limiting the burst of crash reports — not the cause.)

## Fix

1. **Graceful recovery** — a `vite:preloadError` listener in `main.tsx` reloads the page (debounced to avoid reload loops) so the client picks up the fresh `index.html` and new chunk hashes. `ErrorBoundary.tsx` is hardened to reload on the same class of error as a catch-all, showing a brief "Updating to the latest version…" state instead of the crash UI.
2. **Stop serving HTML for missing JS** — `_redirects` now excludes `/assets/*` from the SPA fallback, so a missing chunk returns a real `404` rather than `index.html`. Existing assets are still served normally (Netlify prioritises real files over redirect rules).

Detection and reload logic live in a small tested util (`src/utils/staleChunk.ts`).

## Testing

- `npx vitest run src/utils/staleChunk.test.ts` — 8 tests pass (error detection + reload debounce)
- `npx tsc -b --noEmit` — clean
- `npx eslint` on changed files — clean

No visual changes (the only user-facing surface is a transient "Updating…" message during an automatic reload, shown in place of the existing crash screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138zTZuKTX74VV54jnREACv)_