### PR TITLE
Scope My Games board prefetch to the current phase

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -89,16 +89,29 @@ class GameQuerySet(models.QuerySet):
                 order_count=Count("orders")
             ),
         )
+        current_phase_id = (
+            Phase.objects.filter(game=OuterRef("phase__game_id"))
+            .order_by("-ordinal")
+            .values("id")[:1]
+        )
+        current_units_prefetch = Prefetch(
+            "units",
+            queryset=Unit.objects.filter(phase=Subquery(current_phase_id))
+            .select_related("nation__flag", "province__parent")
+            .prefetch_related("province__named_coasts"),
+        )
+        current_supply_centers_prefetch = Prefetch(
+            "supply_centers",
+            queryset=SupplyCenter.objects.filter(phase=Subquery(current_phase_id))
+            .select_related("nation__flag", "province__parent")
+            .prefetch_related("province__named_coasts"),
+        )
         phases_prefetch = Prefetch(
             "phases",
             queryset=Phase.objects.prefetch_related(
                 phase_states_prefetch,
-                "units__nation__flag",
-                "units__province__parent",
-                "units__province__named_coasts",
-                "supply_centers__nation__flag",
-                "supply_centers__province__parent",
-                "supply_centers__province__named_coasts",
+                current_units_prefetch,
+                current_supply_centers_prefetch,
             ),
         )
 

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -437,6 +437,59 @@ class TestGameListView:
                 assert field in game
 
     @pytest.mark.django_db
+    def test_list_games_current_phase_includes_board(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_edinburgh_province,
+    ):
+        game = Game.objects.create(
+            name="Active board game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(user=primary_user, nation=classical_england_nation)
+        old_phase = game.phases.create(
+            game=game,
+            variant=game.variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            status=PhaseStatus.COMPLETED,
+            ordinal=1,
+        )
+        old_phase.units.create(
+            type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province
+        )
+        current_phase = game.phases.create(
+            game=game,
+            variant=game.variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            status=PhaseStatus.ACTIVE,
+            ordinal=2,
+        )
+        current_phase.units.create(
+            type=UnitType.FLEET, nation=classical_england_nation, province=classical_edinburgh_province
+        )
+        current_phase.supply_centers.create(
+            nation=classical_england_nation, province=classical_edinburgh_province
+        )
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url, {"mine": "true"})
+
+        assert response.status_code == status.HTTP_200_OK
+        result = next(g for g in response.data["results"] if g["id"] == game.id)
+        assert len(result["current_phase"]["units"]) == 1
+        assert result["current_phase"]["units"][0]["type"] == UnitType.FLEET
+        assert result["current_phase"]["units"][0]["province"]["id"] == classical_edinburgh_province.province_id
+        assert len(result["current_phase"]["supply_centers"]) == 1
+
+    @pytest.mark.django_db
     def test_list_games_filter_mine_true(
         self, authenticated_client, pending_game_created_by_primary_user, pending_game_created_by_secondary_user
     ):
@@ -874,7 +927,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 15
+        assert query_count == 9
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_phases_and_units(
@@ -915,7 +968,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 15
+        assert query_count == 9
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_different_nations(
@@ -966,7 +1019,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 15
+        assert query_count == 9
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_phase_states(
@@ -1015,7 +1068,72 @@ class TestGameListViewQueryPerformance:
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
 
-        assert query_count == 15
+        assert query_count == 9
+
+    @pytest.mark.django_db
+    def test_list_games_hydrates_units_for_current_phase_only(
+        self,
+        django_assert_num_queries,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_edinburgh_province,
+    ):
+        games_count = 2
+        phases_per_game = 8
+        units_per_phase = 3
+        supply_centers_per_phase = 2
+
+        created_game_ids = []
+        for i in range(games_count):
+            game = Game.objects.create(
+                name=f"Deep history game {i}",
+                variant=classical_variant,
+                status=GameStatus.ACTIVE,
+            )
+            created_game_ids.append(game.id)
+            game.members.create(user=primary_user, nation=classical_england_nation)
+
+            for ordinal in range(1, phases_per_game + 1):
+                phase = game.phases.create(
+                    game=game,
+                    variant=game.variant,
+                    season="Spring",
+                    year=1900 + ordinal,
+                    type=PhaseType.MOVEMENT,
+                    status=PhaseStatus.ACTIVE if ordinal == phases_per_game else PhaseStatus.COMPLETED,
+                    ordinal=ordinal,
+                )
+                for _ in range(units_per_phase):
+                    phase.units.create(
+                        type=UnitType.FLEET,
+                        nation=classical_england_nation,
+                        province=classical_edinburgh_province,
+                    )
+                for _ in range(supply_centers_per_phase):
+                    phase.supply_centers.create(
+                        nation=classical_england_nation,
+                        province=classical_edinburgh_province,
+                    )
+
+        queryset = (
+            Game.objects.filter(id__in=created_game_ids)
+            .with_list_data()
+            .with_total_unread_counts(primary_user)
+            .order_by("-created_at")
+        )
+        games = list(queryset)
+
+        with django_assert_num_queries(0):
+            hydrated_units = sum(
+                len(phase.units.all()) for game in games for phase in game.phases.all()
+            )
+            hydrated_supply_centers = sum(
+                len(phase.supply_centers.all()) for game in games for phase in game.phases.all()
+            )
+
+        assert hydrated_units == games_count * units_per_phase
+        assert hydrated_supply_centers == games_count * supply_centers_per_phase
 
 
 class TestGameCreateView:


### PR DESCRIPTION
## What this does

Fixes a performance regression on the `GET /games/` endpoint (the My Games screen) introduced by #857.

#857 added `units`/`supply_centers` to the games-list response so the map preview reflects live board state, prefetching them via `units__…`/`supply_centers__…` on the **phases** prefetch. Because that prefetch loads *all* phases of every game, it hydrated the board for **every historical phase** even though only the current phase is ever serialized. On games with long histories this pulls tens of thousands of unit/SC rows (plus their nation-flag and province joins) per request.

The impact is visible in production Honeycomb: `GET /games/` **p50 roughly tripled (~135ms → ~390ms)** and p95/p99 roughly doubled, with a clean step-change in the first hour after #857 merged, sustained since.

## The fix

Scope the units/supply-centre prefetches to the **current phase** (latest ordinal) via a correlated subquery, so hydration is **O(games)** instead of **O(games × phases)**. The lightweight all-phases prefetch (needed for `current_phase` derivation, `phase_confirmed`, `order_status`) is unchanged, as is the serialized response shape — so **no codegen or frontend changes**.

Games-list query count drops from **15 → 9**.

## Tests

- **`test_list_games_hydrates_units_for_current_phase_only`** — regression test asserting only the current phase's board is hydrated regardless of history depth. It fails against the previous prefetch (`48 != 6` for a 2-game × 8-phase fixture) and passes with this fix. The waste was internal hydration (the JSON response was identical before/after), so this test evaluates the view's queryset and asserts the prefetch footprint, with `django_assert_num_queries(0)` confirming no N+1.
- **`test_list_games_current_phase_includes_board`** — new functional coverage (#857 shipped without it) asserting the list response still carries the current phase's units/supply centres, and only the current phase's (a FLEET in the active phase, not the ARMY in the prior completed phase).
- Updated the four existing query-count assertions 15 → 9.
- Full game app suite green (307 passed).

## Follow-ups (not in this PR)

- **Lean preview serializer**: the map preview only consumes `{province_id, nation_name, type, dislodged}`, but the full `UnitSerializer`/`SupplyCenterSerializer` (nation-flag URL, province parent, named coasts) is still loaded and serialized. A preview-specific serializer would let us drop those joins and trim query count further. Deferred because it touches the API contract (codegen + frontend types).
- **Denormalise board state at phase resolution** if list latency is still a hotspot at scale.

No visual changes (backend only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vzjSckZXj3CUwbMbXjMKV)_