### PR TITLE
Fix map preview not filling card height for wide-aspect-ratio variants

### DIFF
--- a/packages/web/src/components/MapPreview.tsx
+++ b/packages/web/src/components/MapPreview.tsx
@@ -70,9 +70,16 @@ const MapPreview: React.FC<MapPreviewProps> = ({
   }, [dsvg, variant, phase, cover]);
 
   return (
-    <div ref={containerRef} className={className} style={style}>
+    <div
+      ref={containerRef}
+      className={cover ? `relative overflow-hidden ${className ?? ""}` : className}
+      style={style}
+    >
       {svg ? (
-        <div className="w-full h-full" dangerouslySetInnerHTML={{ __html: svg }} />
+        <div
+          className={cover ? "absolute inset-0" : "w-full h-full"}
+          dangerouslySetInnerHTML={{ __html: svg }}
+        />
       ) : (
         <Skeleton className="w-full h-full" />
       )}

--- a/packages/web/src/components/MapPreview.tsx
+++ b/packages/web/src/components/MapPreview.tsx
@@ -81,7 +81,7 @@ const MapPreview: React.FC<MapPreviewProps> = ({
           dangerouslySetInnerHTML={{ __html: svg }}
         />
       ) : (
-        <Skeleton className="w-full h-full" />
+        <Skeleton className={cover ? "absolute inset-0" : "w-full h-full"} />
       )}
     </div>
   );


### PR DESCRIPTION
Closes #882

## What changed

`MapPreview` with `cover=true` was leaving empty space below the map for variants whose SVG has a wider aspect ratio than the game card container (e.g. Canton: 2081×1500 ≈ 1.39:1 vs container 192×176 ≈ 1.09:1).

**Root cause**: SVG `height="100%"` presentation attributes don't reliably override an SVG's intrinsic aspect ratio in all browsers. When the browser couldn't resolve the height, it fell back to the intrinsic ratio — rendering Canton at ~138px tall inside a 176px card, leaving a ~38px gap at the bottom.

**Fix**: In cover mode, the inner div (SVG wrapper) now uses `absolute inset-0` instead of `w-full h-full`. Height from absolute positioning constraints is always resolved concretely (never falls back to intrinsic ratio). The outer div gets `relative overflow-hidden` to scope the positioning. The SVG's `preserveAspectRatio="xMidYMid slice"` continues to handle the content scaling.

## Screenshots

**Variants list (all variant maps fill their containers):**

![variants list](https://raw.githubusercontent.com/johnpooch/diplicity-react/34fdc45f83fe52993c6cfc3c796d53840b7c9406/shots/variants-full.png)

**Card gallery (desktop):**

![card gallery desktop](https://raw.githubusercontent.com/johnpooch/diplicity-react/34fdc45f83fe52993c6cfc3c796d53840b7c9406/shots/card-gallery.png)

**Card gallery (mobile):**

![card gallery mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/34fdc45f83fe52993c6cfc3c796d53840b7c9406/shots/card-gallery-mobile.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaPMW1SFyPC98CHobFYDKJ)_