### PR TITLE
Mobile: tapping Chat while in a channel returns to chat overview

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -52,6 +52,8 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
       ? navigationItems.filter(item => item.label !== "Chat")
       : navigationItems;
     const searchParamsStr = searchParams.toString();
+    const chatBasePath = `/game/${gameId}/phase/${phaseId}/chat`;
+    const isInChatChannel = location.pathname.startsWith(chatBasePath + "/");
     return items.map(item => {
       const basePath = item.path
         .replace(":gameId", gameId)
@@ -64,8 +66,15 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           game?.members.some(m => m.isCurrentUser && m.civilDisorder))
           ? "•"
           : undefined;
-      const path = searchParamsStr ? `${basePath}?${searchParamsStr}` : basePath;
-      const chatBasePath = `/game/${gameId}/phase/${phaseId}/chat`;
+      let path: string;
+      if (item.label === "Chat" && isInChatChannel) {
+        const params = new URLSearchParams(searchParams);
+        params.delete("channelId");
+        const paramsStr = params.toString();
+        path = paramsStr ? `${chatBasePath}?${paramsStr}` : chatBasePath;
+      } else {
+        path = searchParamsStr ? `${basePath}?${searchParamsStr}` : basePath;
+      }
       const isActive = item.label === "Chat"
         ? location.pathname === chatBasePath || location.pathname.startsWith(chatBasePath + "/")
         : location.pathname === basePath;


### PR DESCRIPTION
Closes #892

When the user is already inside a chat channel on mobile, tapping the Chat bottom nav item now navigates to the channel list instead of staying in the current channel. Resume-from-Map/Orders (preserving `channelId` in the search params) is unchanged.

The fix is in `GameDetailLayout.tsx`: when `location.pathname` is inside a chat channel path (`/chat/channel/...`), the bottom nav Chat item drops `channelId` from its target URL, mirroring what `sidebarNavItems` already does for the desktop sidebar.

![chat channel on mobile](https://raw.githubusercontent.com/johnpooch/diplicity-react/bd5ebb5/shots/chat-channel-mobile.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrUczFgHqTb3hq9PsfNsus)_