### PR TITLE
Fix colorblind mode map recolour without page reload

### DIFF
--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -79,6 +79,23 @@ def test_etag_changes_when_colorblind_mode_changes(user_factory, authenticated_c
 
 
 @pytest.mark.django_db
+def test_list_variants_cache_control_forces_revalidation(authenticated_client):
+    response = authenticated_client.get(reverse(viewname))
+
+    assert response["Cache-Control"] == "private, no-cache"
+
+
+@pytest.mark.django_db
+def test_list_variants_returns_304_when_etag_matches(authenticated_client):
+    response1 = authenticated_client.get(reverse(viewname))
+    etag = response1["ETag"]
+
+    response2 = authenticated_client.get(reverse(viewname), HTTP_IF_NONE_MATCH=etag)
+
+    assert response2.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+@pytest.mark.django_db
 def test_list_variants_includes_svg_url(authenticated_client):
     response = authenticated_client.get(reverse(viewname))
 

--- a/service/variant/tests/test_variants_list_performance.py
+++ b/service/variant/tests/test_variants_list_performance.py
@@ -82,8 +82,7 @@ def test_list_variants_returns_etag_and_cache_control(authenticated_client):
     response = authenticated_client.get(reverse("variant-list"))
     assert response.status_code == status.HTTP_200_OK
     assert response["ETag"].startswith('"') and response["ETag"].endswith('"')
-    assert "max-age=60" in response["Cache-Control"]
-    assert "must-revalidate" in response["Cache-Control"]
+    assert response["Cache-Control"] == "private, no-cache"
 
 
 @pytest.mark.django_db

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -76,7 +76,7 @@ class VariantListCreateView(generics.ListCreateAPIView):
         else:
             response = super().list(request, *args, **kwargs)
         response["ETag"] = etag
-        response["Cache-Control"] = "private, must-revalidate, max-age=60"
+        response["Cache-Control"] = "private, no-cache"
         return response
 
 


### PR DESCRIPTION
Changes `Cache-Control` on `GET /variants/` from `private, must-revalidate, max-age=60` to `private, no-cache`. The 60-second `max-age` window was intercepting React Query's explicit `invalidateQueries` call after a colorblind mode change — the browser/WebView served the cached (old-colour) response without hitting the server, so the ETag logic never ran and the map stayed the same colour.

`no-cache` forces revalidation on every request while preserving the ETag/304 path: when nothing has changed the server returns `304 Not Modified` (headers only, no body); when the mode changed it returns `200` with fresh colours. The efficiency trade-off is effectively zero because React Query's `staleTime: 60 * 60 * 1000` already governs how often `/variants/` is fetched — the `max-age=60` window only ever shadowed requests React Query had already suppressed.

Two tests added: one pins the new `Cache-Control` contract, one proves the `304` revalidation path still works.

Closes #894

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpHQ6vpqT4Dpep176XM5q)_