### PR TITLE
Derive SUPPORTED_ADJUDICATION_MODIFIERS from the modifier constants

### DIFF
--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -31,15 +31,13 @@ from .domain import (
     VictoryCondition,
     VictoryConditionType,
 )
+from .types import SUPPORTED_ADJUDICATION_MODIFIERS
 
 
 SUPPORTED_PHASE_TYPES = frozenset({Phase.MOVEMENT, Phase.RETREAT, Phase.ADJUSTMENT})
 SUPPORTED_UNIT_TYPES = frozenset({Unit.ARMY, Unit.FLEET})
 SUPPORTED_ORDER_TYPES = frozenset(
     {"Move", "Hold", "Support", "Convoy", "Build", "Disband", "Retreat"}
-)
-SUPPORTED_ADJUDICATION_MODIFIERS = frozenset(
-    {"allow-builds-in-non-home-centers", "neutral-nations-auto-build"}
 )
 
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -63,6 +63,10 @@ ALLOW_NON_HOME_BUILDS: str = "allow-builds-in-non-home-centers"
 # Variant modifier id enabling auto-rebuild for non-playable nations.
 NEUTRAL_NATIONS_AUTO_BUILD: str = "neutral-nations-auto-build"
 
+SUPPORTED_ADJUDICATION_MODIFIERS: frozenset = frozenset(
+    {ALLOW_NON_HOME_BUILDS, NEUTRAL_NATIONS_AUTO_BUILD}
+)
+
 
 # === Marker base classes ===
 


### PR DESCRIPTION
Moves `SUPPORTED_ADJUDICATION_MODIFIERS` from `serializers.py` into `types.py`, where it's built directly from the `ALLOW_NON_HOME_BUILDS` and `NEUTRAL_NATIONS_AUTO_BUILD` constants. `serializers.py` now imports it instead of duplicating the string literals.

This eliminates the drift that caused #847/#853: a modifier added to the engine in `types.py` was not added to the allow-list in `serializers.py` because nothing linked the two. Now adding a modifier means adding the constant and including it in the set — both in `types.py`, in one place.

No visual changes.

Closes #865

---
_Generated by [Claude Code](https://claude.ai/code/session_018z82wc4t8V7V9DB2vMvFNH)_