### PR TITLE
Require PR screenshots to show the specific changed component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,11 +769,13 @@ MSW is dev-only: `main.tsx` dynamically imports the worker only when `VITE_MOCKS
 
 **If a PR changes anything a user can see in the web app — new screens, layout changes, styling tweaks, new components, changed copy, empty states, error states — you MUST take screenshots of the affected screens and embed them in the PR description.** This is not optional polish; it is part of completing the PR. The reviewer should be able to see what changed without pulling the branch.
 
+**Screenshots must show the component that changed.** A screenshot of the wrong tab, a different variant map, or an unrelated screen does not count. Pick the fixture and navigate to the exact state where the changed component is visible. If the changed component is nested (e.g., a control on an "Advanced" tab, a non-standard map variant), navigate to that specific state — do not settle for a screenshot that merely includes the page without the changed component in view.
+
 The workflow (each step detailed below):
 
 1. Start the dev server with mock data (`npm run dev:mocks`)
 2. Pick the fixture(s) from the registry that exercise the changed UI (see "Mock Data" above) — add a fixture only if none covers the scenario
-3. Screenshot the affected route(s) with `npm run screenshot` — before/after pairs when modifying existing UI, mobile viewport (`--viewport 390x844`) when the change affects mobile layout
+3. Screenshot the changed component with `npm run screenshot`. Frame the screenshot so the specific component that changed is clearly visible. Before/after pairs are required when modifying existing UI. Use the mobile viewport (`--viewport 390x844`) when the change affects mobile layout.
 4. Push the screenshots to a dedicated `screenshots/*` branch and embed commit-pinned raw URLs in the PR description
 
 Only skip this when the change is genuinely invisible (pure refactor, backend-only, build tooling) — and if you skip it, say so explicitly in the PR description ("No visual changes").


### PR DESCRIPTION
Updates the PR screenshot guidance in `CLAUDE.md` to explicitly require that screenshots frame the specific UI component that was changed, not just a page that happens to contain it.

The previous guidance asked for screenshots of "affected routes" but didn't say the changed component had to be visible. This led to PRs embedding screenshots that showed the wrong tab (e.g. General instead of Advanced in Create Game) or the wrong map variant — neither of which lets a reviewer see what actually changed.

Closes #863

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSmu2469rM5Zur3ShqvrfE)_