### PR TITLE
Fix canvas map hover highlight for provinces with named coasts

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapController.ts
+++ b/packages/web/src/components/GameMapCanvas/GameMapController.ts
@@ -316,7 +316,7 @@ export class GameMapController {
         this.polygonsByProvince.set(ring.id, [polygon]);
       }
     }
-    this.updateCursors();
+    this.updateHitTargets();
   }
 
   private handleClick(province: string, event: L.LeafletMouseEvent): void {
@@ -337,7 +337,7 @@ export class GameMapController {
 
   setStyleState(style: StyleState): void {
     this.style = style;
-    this.updateCursors();
+    this.updateHitTargets();
     this.renderHighlight();
   }
 
@@ -365,7 +365,13 @@ export class GameMapController {
     this.highlightLayer = next;
   }
 
-  private updateCursors(): void {
+  // Mirrors the SVG map (InteractiveMap), where every hit path is given
+  // pointer-events only when its province is renderable. Named coasts are not
+  // renderable by default and their hit shapes overlap the parent province, so
+  // leaving them interactive would let them intercept the hover and suppress the
+  // highlight. Disabling pointer events on non-renderable shapes lets the hover
+  // fall through to the renderable province beneath.
+  private updateHitTargets(): void {
     for (const [province, polygons] of this.polygonsByProvince) {
       const renderable = this.style.renderable.has(province);
       const cursor =
@@ -374,6 +380,7 @@ export class GameMapController {
         const element = polygon.getElement();
         if (element instanceof SVGElement || element instanceof HTMLElement) {
           element.style.cursor = cursor;
+          element.style.pointerEvents = renderable ? "" : "none";
         }
       }
     }


### PR DESCRIPTION
## What this PR does

In the canvas (Leaflet) map (`?map=canvas`), hovering a province that has a named coast did not highlight it. Reported on Cold War for **Paris** and **Leningrad**; it also affects **St. Petersburg**, **Spain** and **Bulgaria** in classical (and any province with a named coast).

### Root cause

The canvas map turns every province **and** every named coast into an interactive Leaflet hit-test polygon, merged with named coasts last (`GameMapCanvas.tsx`), so the named-coast polygon is stacked on top. In these variants' SVGs the named-coast shapes are large enough to cover the parent province's interior — verified geometrically: `par/nc`, `len/nc` (Cold War) and `stp/nc`, `spa/sc`, `bul/ec` (classical) all contain their province's centroid.

So hovering the middle of the province fired `mouseover` on the named-coast polygon, not the province. Named coasts are not "renderable" by default (`determineRenderableProvinces` returns only the main province), and the highlight builder only paints a hovered shape that is renderable (`highlightSvg.ts`), so nothing was painted — the province looked dead.

The default **SVG** map doesn't have this bug because it sets `pointer-events: none` on every non-renderable hit path (`InteractiveMap.tsx`), letting the pointer fall through to the renderable province beneath.

### The fix

Make the canvas hit layer mirror the SVG map: when applying style state, set `pointer-events: none` on hit polygons whose province is not renderable, so the hover falls through to the renderable province underneath. Applied in the same per-province loop that already sets the cursor (`GameMapController.updateHitTargets`).

## Verification

Reproduced and verified with a Playwright harness in canvas mode that reads which province the highlight overlay actually paints (deterministic, not pixel-squinting):

| Hover | Before | After |
|---|---|---|
| **St. Petersburg** (named coast) | no highlight painted | paints the `stp` province path |
| **Moscow** (control, no coast) | paints `mos` | paints `mos` (unchanged) |

Hovering St. Petersburg in classical, `?map=canvas` — before (no highlight) vs after (whole province highlights):

![before](https://raw.githubusercontent.com/johnpooch/diplicity-react/538e1b0aa8a5b98fd08feb79e774229be45ba57e/shots/before-stp-hover.png)
![after](https://raw.githubusercontent.com/johnpooch/diplicity-react/538e1b0aa8a5b98fd08feb79e774229be45ba57e/shots/after-stp-hover.png)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — verified by reproduction (before/after); the `GameMapController` is Leaflet/DOM-driven and has no existing unit tests, consistent with the rest of the canvas map
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018G4iYtWvnTAhVci3FjcW1h)_