### PR TITLE
Start a game on creation when seating the bot fills it

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -634,6 +634,15 @@ class Game(BaseModel):
             self.started_at = timezone.now()
             self.save()
 
+    def start_if_full(self):
+        if self.status != GameStatus.PENDING:
+            return False
+        playable_nations = self.variant.nations.filter(non_playable=False).count()
+        if self.members.count() != playable_nations:
+            return False
+        self.start()
+        return True
+
     def pause(self):
         if self.status != GameStatus.ACTIVE:
             raise ValueError("Can only pause an active game")

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -552,6 +552,8 @@ class GameCreateSerializer(serializers.Serializer):
                 bot_member = game.members.create(user=get_bot_user())
                 public_channel.member_channels.create(member=bot_member)
 
+            game.start_if_full()
+
             if hasattr(game, "_created_phase"):
                 delattr(game, "_created_phase")
 

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1673,7 +1673,7 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 44
+        assert query_count == 46
 
     @pytest.mark.django_db
     def test_create_game_query_count_large_variant(self, authenticated_client, classical_variant):
@@ -1693,7 +1693,7 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 44
+        assert query_count == 46
 
 
 class TestGamePrivateFiltering:

--- a/service/game/tests/test_bot_opponent.py
+++ b/service/game/tests/test_bot_opponent.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from bot.utils import get_bot_user
+from common.constants import GameStatus, PhaseStatus
 from game.models import Game
 
 
@@ -76,6 +77,38 @@ class TestBotOpponentSeating:
         game = Game.objects.get(id=response.data["id"])
         assert game.members.count() == 1
         assert not game.members.filter(user=get_bot_user()).exists()
+
+
+class TestBotGameStart:
+
+    @pytest.mark.django_db
+    def test_full_bot_game_starts_on_creation(
+        self, authenticated_client, italy_vs_germany_variant, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        response = authenticated_client.post(
+            reverse(create_viewname),
+            bot_payload(italy_vs_germany_variant.id, True),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        game = Game.objects.get(id=response.data["id"])
+        assert game.status == GameStatus.ACTIVE
+        assert game.current_phase.status == PhaseStatus.ACTIVE
+
+    @pytest.mark.django_db
+    def test_partial_bot_game_stays_pending(
+        self, authenticated_client, classical_variant, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        response = authenticated_client.post(
+            reverse(create_viewname),
+            bot_payload(classical_variant.id, True),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        game = Game.objects.get(id=response.data["id"])
+        assert game.status == GameStatus.PENDING
 
 
 class TestCanCreateBotGamesFlag:

--- a/service/integration/test_bot.py
+++ b/service/integration/test_bot.py
@@ -1,12 +1,9 @@
-from unittest.mock import patch
-
 import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from adjudication import service as adjudication_service
-from common.constants import DeadlineMode, MovementPhaseDuration, NationAssignment, PhaseStatus
+from common.constants import DeadlineMode, GameStatus, NationAssignment, PhaseStatus
 from game.models import Game
 from bot import tasks
 from bot.utils import first_legal_selections, get_bot_user
@@ -19,34 +16,41 @@ def _submit_first_legal_orders(client, game_id):
         client.post(create_url, {"selected": selected}, format="json")
 
 
-@pytest.fixture
-def bot_game(db, primary_user, italy_vs_germany_variant, adjudication_data_italy_vs_germany):
-    game = Game.objects.create_from_template(
-        italy_vs_germany_variant,
-        name="Bot Integration Game",
-        nation_assignment=NationAssignment.ORDERED,
-        movement_phase_duration=MovementPhaseDuration.TWENTY_FOUR_HOURS,
-        deadline_mode=DeadlineMode.DURATION,
-        created_by=primary_user,
+def _create_bot_game(client, variant_id):
+    response = client.post(
+        reverse("game-create"),
+        {
+            "name": "Bot Integration Game",
+            "variant_id": variant_id,
+            "nation_assignment": NationAssignment.ORDERED,
+            "private": False,
+            "deadline_mode": DeadlineMode.DURATION,
+            "include_bot_opponent": True,
+        },
+        format="json",
     )
-    game.members.create(user=primary_user)
-    game.members.create(user=get_bot_user())
-    with patch.object(
-        adjudication_service, "start", return_value=adjudication_data_italy_vs_germany
-    ):
-        game.start()
-    return game
+    assert response.status_code == status.HTTP_201_CREATED
+    return Game.objects.get(id=response.data["id"])
+
+
+@pytest.fixture
+def allowlisted_human(authenticated_client, primary_user, settings):
+    settings.BOT_OPPONENT_ALLOWLIST = [primary_user.email.lower()]
+    return authenticated_client
 
 
 @pytest.mark.django_db
-def test_bot_plays_phase_and_game_advances(bot_game):
-    game = bot_game
-    bot_user = get_bot_user()
+def test_bot_game_starts_on_creation_and_plays_phase(
+    allowlisted_human, italy_vs_germany_variant
+):
+    human_client = allowlisted_human
+    game = _create_bot_game(human_client, italy_vs_germany_variant.id)
+
+    assert game.status == GameStatus.ACTIVE
     first_phase = game.current_phase
+    assert first_phase.status == PhaseStatus.ACTIVE
 
-    human_client = APIClient()
-    human_client.force_authenticate(user=game.created_by)
-
+    bot_user = get_bot_user()
     tasks.plan(user_id=bot_user.id, game_id=game.id)
 
     bot_phase_state = first_phase.phase_states.get(member__user=bot_user)
@@ -72,13 +76,11 @@ def test_bot_plays_phase_and_game_advances(bot_game):
 
 
 @pytest.mark.django_db
-def test_bot_can_play_the_next_phase(bot_game):
-    game = bot_game
+def test_bot_can_play_the_next_phase(allowlisted_human, italy_vs_germany_variant):
+    human_client = allowlisted_human
+    game = _create_bot_game(human_client, italy_vs_germany_variant.id)
     bot_user = get_bot_user()
     first_phase = game.current_phase
-
-    human_client = APIClient()
-    human_client.force_authenticate(user=game.created_by)
 
     tasks.plan(user_id=bot_user.id, game_id=game.id)
     _submit_first_legal_orders(human_client, game.id)

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -24,8 +24,7 @@ class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
 
     def perform_create(self, serializer):
         member = serializer.save()
-        if member.game.variant.nations.filter(non_playable=False).count() == member.game.members.count():
-            member.game.start()
+        member.game.start_if_full()
 
 
 class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):


### PR DESCRIPTION
## What this PR does

Fixes a bug where a game seated with the bot at creation never started. For a variant where the creator plus the bot fills every seat (e.g. Italy vs Germany — 2/2), the game was full but stayed `PENDING` forever, because the only fullness-and-start check lived in the join view (`MemberCreateView.perform_create`) and ran only when a *human* joined.

- Extracts the logic into `Game.start_if_full()` — it starts the game when the member count equals the playable-nation count, and is a no-op otherwise (and on non-pending games).
- Calls it from `GameCreateSerializer.create()` after seating members, and replaces the inline check in `MemberCreateView.perform_create()` with it (removing the duplicated business logic from the view).

This is forward compatible with the eventual invite flow: when bots are invited and join through the normal path, that path already calls `start_if_full()`, so nothing here needs unwinding. The create-time call is a no-op for any game that isn't full at creation (every normal human game, since the creator is one of N seats).

## Checklist

- [x] This PR does one thing — start a game when seating the bot fills it
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes — **N/A, no visual changes** (backend-only)

## Tests

- `game/tests/test_bot_opponent.py` — a full bot game (Italy vs Germany) starts on creation (`status == ACTIVE`, opening phase active); a partial bot game (classical, 7 nations, only creator + bot) stays `PENDING`.
- `integration/test_bot.py` is rewritten to **create the bot game through the `game-create` API** (with `include_bot_opponent`) rather than a fixture that called `game.start()` directly. The old fixture bypassed exactly this gap, so it could never have caught the bug; the API path does, and it then drives the full plan → human confirm → finalize → resolve → next-phase loop.
- One game-create query-count assertion gains two queries from the `start_if_full()` member/nation counts. Full backend suite passes (1660).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHr91Pe52JxFpEP5edLh6q)_