### PR TITLE
Cap bot adjustment orders up front using the API order limit

### DIFF
--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -23,16 +23,21 @@ def plan(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
+    selections = first_legal_selections(options_response.data["orders"])
+
+    phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
+    if phase_states_response.status_code != 200:
+        logger.error(f"[{label}] phase states request failed: {phase_states_response.status_code}")
+        return
+    max_orders = phase_states_response.data[0]["max_orders"] if phase_states_response.data else None
+    if max_orders is not None:
+        selections = selections[:max_orders]
 
     create_url = reverse("order-create", args=[game_id])
-    for selected in first_legal_selections(options_response.data["orders"]):
+    for selected in selections:
         response = client.post(create_url, {"selected": selected}, format="json")
         if response.status_code not in (200, 201):
-            logger.info(
-                f"[{label}] order {selected} rejected ({response.status_code}); "
-                f"order limit reached, stopping"
-            )
-            break
+            logger.error(f"[{label}] create order failed ({response.status_code}) for {selected}")
 
     logger.info(f"[{label}] completed")
 
@@ -58,16 +63,21 @@ def finalize(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
+    selections = first_legal_selections(options_response.data["orders"])
+
+    phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
+    if phase_states_response.status_code != 200:
+        logger.error(f"[{label}] phase states request failed: {phase_states_response.status_code}")
+        return
+    max_orders = phase_states_response.data[0]["max_orders"] if phase_states_response.data else None
+    if max_orders is not None:
+        selections = selections[:max_orders]
 
     create_url = reverse("order-create", args=[game_id])
-    for selected in first_legal_selections(options_response.data["orders"]):
+    for selected in selections:
         response = client.post(create_url, {"selected": selected}, format="json")
         if response.status_code not in (200, 201):
-            logger.info(
-                f"[{label}] order {selected} rejected ({response.status_code}); "
-                f"order limit reached, stopping"
-            )
-            break
+            logger.error(f"[{label}] create order failed ({response.status_code}) for {selected}")
 
     confirm_response = client.put(reverse("game-confirm-phase", args=[game_id]))
     if confirm_response.status_code != 200:

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -76,28 +76,47 @@ class TestFirstLegalSelections:
 
 class TestAdjustmentOrderLimit:
 
-    @pytest.mark.django_db
-    def test_plan_stops_submitting_when_an_order_is_rejected(self):
-        bot_user = get_bot_user()
-        options = {
+    def _options_with_three_builds(self):
+        return {
             "orders": [
                 _option("lon", OrderType.BUILD, unit_type="Army"),
                 _option("edi", OrderType.BUILD, unit_type="Fleet"),
                 _option("lvp", OrderType.BUILD, unit_type="Army"),
             ]
         }
-        fake_client = MagicMock()
-        fake_client.get.return_value = Mock(status_code=200, data=options)
-        fake_client.post.side_effect = [
-            Mock(status_code=201),
-            Mock(status_code=400),
-            Mock(status_code=400),
-        ]
+
+    def _fake_client(self, max_orders):
+        options = self._options_with_three_builds()
+
+        def fake_get(url, *args, **kwargs):
+            if "phase-states" in url:
+                return Mock(status_code=200, data=[{"max_orders": max_orders}])
+            return Mock(status_code=200, data=options)
+
+        client = MagicMock()
+        client.get.side_effect = fake_get
+        client.post.return_value = Mock(status_code=201)
+        return client
+
+    @pytest.mark.django_db
+    def test_plan_caps_orders_at_max_orders(self):
+        bot_user = get_bot_user()
+        fake_client = self._fake_client(max_orders=1)
 
         with patch("bot.tasks.APIClient", return_value=fake_client):
             tasks.plan(user_id=bot_user.id, game_id="some-game")
 
-        assert fake_client.post.call_count == 2
+        assert fake_client.post.call_count == 1
+
+    @pytest.mark.django_db
+    def test_plan_submits_all_orders_when_no_limit(self):
+        bot_user = get_bot_user()
+        fake_client = self._fake_client(max_orders=None)
+
+        with patch("bot.tasks.APIClient", return_value=fake_client):
+            tasks.plan(user_id=bot_user.id, game_id="some-game")
+
+        assert fake_client.post.call_count == 3
 
 
 @pytest.fixture


### PR DESCRIPTION
## What this PR does

The bot follow-up enabled by #911 / #914: now that the adjustment order limit is exposed on the phase-state endpoint as `max_orders`, the bot checks it **up front** instead of submitting one order per source and stopping at the first rejection.

In both `plan` and `finalize`, after fetching the order options the bot fetches its own phase state from the `phase-state-list` endpoint and, when `max_orders` is set (adjustment phases), slices the selections to that many before creating them. For non-adjustment phases `max_orders` is `null`, so every legal order is submitted. The create loop now logs a failure rather than treating a rejection as "limit reached", since the count is known before submitting.

This replaces the stop-on-reject behaviour from the bot skeleton, which was a deliberate stopgap pending the exposed count.

## Checklist

- [x] This PR does one thing — use the API order limit to cap bot orders
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes — **N/A, no visual changes** (backend-only)

## Tests

`bot/tests.py` `TestAdjustmentOrderLimit` is reworked to verify the cap: with `max_orders: 1` and three legal build options the bot creates exactly one order; with `max_orders: null` it creates all three. The existing in-process `plan`/`finalize` tests still pass (movement phases report `max_orders: null`, so nothing is capped). Full backend suite passes (1663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHr91Pe52JxFpEP5edLh6q)_