### PR TITLE
Fix bot tasks failing in production with DisallowedHost

### DIFF
--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from procrastinate.contrib.django import app
 from rest_framework.test import APIClient
 
-from bot.utils import first_legal_selections
+from bot.utils import bot_request_host, first_legal_selections
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def plan(user_id, game_id):
     logger.info(f"[{label}] invoked")
 
     user = get_user_model().objects.get(id=user_id)
-    client = APIClient()
+    client = APIClient(SERVER_NAME=bot_request_host())
     client.force_authenticate(user=user)
 
     options_response = client.get(reverse("order-options", args=[game_id]))
@@ -43,7 +43,7 @@ def finalize(user_id, game_id):
     logger.info(f"[{label}] invoked")
 
     user = get_user_model().objects.get(id=user_id)
-    client = APIClient()
+    client = APIClient(SERVER_NAME=bot_request_host())
     client.force_authenticate(user=user)
 
     game_response = client.get(reverse("game-retrieve", args=[game_id]))

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -141,6 +141,35 @@ class TestPlanTask:
         assert all(order.complete for order in bot_phase_state.orders.all())
         assert bot_phase_state.orders_confirmed is False
 
+    @pytest.mark.django_db
+    def test_plan_creates_orders_when_testserver_not_allowed(
+        self, bot_game_factory, in_memory_procrastinate, settings
+    ):
+        settings.ALLOWED_HOSTS = ["example.com"]
+        game = bot_game_factory()
+        bot_user = get_bot_user()
+        bot_phase_state = game.current_phase.phase_states.get(member__user=bot_user)
+
+        tasks.plan(user_id=bot_user.id, game_id=game.id)
+
+        bot_phase_state.refresh_from_db()
+        assert bot_phase_state.orders.count() > 0
+
+
+class TestBotRequestHost:
+
+    def test_returns_first_concrete_host(self, settings):
+        settings.ALLOWED_HOSTS = ["example.com", "localhost"]
+        assert utils.bot_request_host() == "example.com"
+
+    def test_strips_leading_dot(self, settings):
+        settings.ALLOWED_HOSTS = [".railway.app"]
+        assert utils.bot_request_host() == "railway.app"
+
+    def test_falls_back_to_testserver_for_wildcard(self, settings):
+        settings.ALLOWED_HOSTS = ["*"]
+        assert utils.bot_request_host() == "testserver"
+
 
 class TestFinalizeTask:
 

--- a/service/bot/utils.py
+++ b/service/bot/utils.py
@@ -17,6 +17,13 @@ def user_can_use_bot_opponent(user):
     return user.email.lower() in settings.BOT_OPPONENT_ALLOWLIST
 
 
+def bot_request_host():
+    for host in settings.ALLOWED_HOSTS:
+        if host and host != "*":
+            return host.lstrip(".")
+    return "testserver"
+
+
 def option_to_selected(option):
     order_type = option["order_type"]["id"]
     selected = [option["source"]["id"], order_type]


### PR DESCRIPTION
## What this PR does

Hotfix: the bot does nothing in production. Its in-process `APIClient` sends every request with the host `testserver`. Django's **test** environment auto-allows that host (so all the bot tests pass), but production `ALLOWED_HOSTS` rejects it, so every bot API call returns 400 and both `plan` and `finalize` bail at the first request — the bot creates no orders and never confirms.

Confirmed from production worker logs:

```
[bot.finalize ...] invoked
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'testserver'.
[bot.finalize ...] game retrieve failed: 400
```

…and the production DB showed the bot member with `order_count=0`, `orders_confirmed=False` in an active Movement phase.

**Fix:** set the client's `SERVER_NAME` to a host drawn from `ALLOWED_HOSTS` (`bot_request_host()`), so the in-process requests pass host validation in every environment — the first concrete host, with a leading-dot wildcard stripped, falling back to `testserver` only when `ALLOWED_HOSTS` is `*` (which allows anything anyway).

## Checklist

- [x] This PR does one thing — make the bot's in-process API calls pass host validation
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes — **N/A, no visual changes** (backend-only)

## Tests

- `TestPlanTask.test_plan_creates_orders_when_testserver_not_allowed` runs the plan task with `ALLOWED_HOSTS = ["example.com"]` (i.e. `testserver` excluded, as in production) and asserts the bot still creates orders. Verified it **fails without the fix** and passes with it.
- `TestBotRequestHost` unit-tests the host helper (concrete host, leading-dot stripping, wildcard fallback).
- Full backend suite passes (1666).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHr91Pe52JxFpEP5edLh6q)_