### PR TITLE
Fix games-list current-phase prefetch: set-based subquery instead of correlated

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -89,20 +89,20 @@ class GameQuerySet(models.QuerySet):
                 order_count=Count("orders")
             ),
         )
-        current_phase_id = (
-            Phase.objects.filter(game=OuterRef("phase__game_id"))
-            .order_by("-ordinal")
-            .values("id")[:1]
+        current_phase_ids = (
+            Phase.objects.order_by("game_id", "-ordinal")
+            .distinct("game_id")
+            .values("id")
         )
         current_units_prefetch = Prefetch(
             "units",
-            queryset=Unit.objects.filter(phase=Subquery(current_phase_id))
+            queryset=Unit.objects.filter(phase__in=current_phase_ids)
             .select_related("nation__flag", "province__parent")
             .prefetch_related("province__named_coasts"),
         )
         current_supply_centers_prefetch = Prefetch(
             "supply_centers",
-            queryset=SupplyCenter.objects.filter(phase=Subquery(current_phase_id))
+            queryset=SupplyCenter.objects.filter(phase__in=current_phase_ids)
             .select_related("nation__flag", "province__parent")
             .prefetch_related("province__named_coasts"),
         )

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1135,6 +1135,63 @@ class TestGameListViewQueryPerformance:
         assert hydrated_units == games_count * units_per_phase
         assert hydrated_supply_centers == games_count * supply_centers_per_phase
 
+    @pytest.mark.django_db
+    def test_list_games_scopes_board_with_set_based_subquery(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_edinburgh_province,
+    ):
+        games_count = 2
+        phases_per_game = 8
+
+        for i in range(games_count):
+            game = Game.objects.create(
+                name=f"Set based game {i}",
+                variant=classical_variant,
+                status=GameStatus.ACTIVE,
+            )
+            game.members.create(user=primary_user, nation=classical_england_nation)
+            for ordinal in range(1, phases_per_game + 1):
+                phase = game.phases.create(
+                    game=game,
+                    variant=game.variant,
+                    season="Spring",
+                    year=1900 + ordinal,
+                    type=PhaseType.MOVEMENT,
+                    status=PhaseStatus.ACTIVE if ordinal == phases_per_game else PhaseStatus.COMPLETED,
+                    ordinal=ordinal,
+                )
+                phase.units.create(
+                    type=UnitType.FLEET,
+                    nation=classical_england_nation,
+                    province=classical_edinburgh_province,
+                )
+                phase.supply_centers.create(
+                    nation=classical_england_nation,
+                    province=classical_edinburgh_province,
+                )
+
+        url = reverse(list_viewname)
+        connection.queries_log.clear()
+
+        with override_settings(DEBUG=True):
+            response = authenticated_client.get(url, {"mine": "true"})
+
+        assert response.status_code == status.HTTP_200_OK
+
+        unit_queries = [q["sql"] for q in connection.queries if 'FROM "unit_unit"' in q["sql"]]
+        supply_center_queries = [
+            q["sql"] for q in connection.queries if 'FROM "supply_center_supplycenter"' in q["sql"]
+        ]
+
+        assert len(unit_queries) == 1
+        assert len(supply_center_queries) == 1
+        assert "DISTINCT ON" in unit_queries[0]
+        assert "DISTINCT ON" in supply_center_queries[0]
+
 
 class TestGameCreateView:
 


### PR DESCRIPTION
## What this PR does

`GET /games/` p50 has kept climbing (now ~777ms, up from a ~135ms baseline) and #886 did **not** stop it. This finishes the job #886 started: it replaces the per-row correlated current-phase subquery with a non-correlated set-based filter, eliminating a database scan whose cost grows with game history.

### Why #886 didn't help

#886 scoped the My Games board prefetch to the current phase with `Unit.objects.filter(phase=Subquery(current_phase_id))`, where `current_phase_id` uses `OuterRef("phase__game_id")`. That correctly cut Python-side hydration (35k objects → ~600) and query count (15 → 9) — which is exactly what its tests assert — but the prefetch's candidate set is still **every historical phase** of the page's games, and the correlated subquery is evaluated **once per historical unit row**.

Evidence (Honeycomb): the regression is a continuous upward ramp, not a step that got fixed. #857 merged Jun 23 23:36 → p50 steps 135ms→~300ms; #886 merged Jun 25 00:00 → p50 keeps climbing to ~777ms by Jun 27.

Evidence (EXPLAIN ANALYZE on production, worst-case 20-game page, all three return the identical 604 current-phase units):

| Strategy | DB time | Buffer hits |
|---|---|---|
| #857 plain prefetch (all units hydrated) | 68 ms | 8.5K |
| **#886 correlated subquery (current)** | **1,370 ms** | **1,794,217** |
| **This PR (set-based subquery)** | **75 ms** | 8.5K |

The #886 form runs the correlated subquery 35,283 times (once per candidate unit). Because that candidate set grows as games accumulate phases, the cost grows daily — the ramp.

### The fix

Filter units/supply centres on a non-correlated set of current-phase ids computed once via `DISTINCT ON (game_id) ... ORDER BY game_id, ordinal DESC`. Identical serialized response; query count stays at 9.

### Tests

- **`test_list_games_scopes_board_with_set_based_subquery`** (new) — asserts the board is hydrated by a single set-based subquery per relation (`DISTINCT ON`), not a correlated per-row lookup. It **fails against #886's prefetch and passes with this change**. The existing hydration-count test could not tell the two apart because hydration was already correct under #886 — the waste was internal DB scanning. At test-data scale, row/buffer counts can't distinguish the plans (Postgres seq-scans tiny tables either way), so the query *shape* is the meaningful regression guard; the row/buffer evidence lives in the EXPLAIN analysis above.
- Existing `TestGameListView` + `TestGameListViewQueryPerformance` suites pass (33 tests), including the 15→9... now unchanged-at-9 query-count assertions and the current-phase board functional test.

No API/schema change, so no codegen or frontend changes. No visual changes (backend only).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6xV5BLyWbCFNgZZs2TKmp)_