### PR TITLE
Stop loading 69KB nation flag SVG blobs in the games list

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -75,12 +75,16 @@ class GameQuerySet(models.QuerySet):
     def with_list_data(self):
         members_prefetch = Prefetch(
             "members",
-            queryset=Member.objects.select_related("nation__flag", "user__profile"),
+            queryset=Member.objects.select_related(
+                "nation__flag", "user__profile"
+            ).defer("nation__flag__svg"),
         )
 
         victory_members_prefetch = Prefetch(
             "victory__members",
-            queryset=Member.objects.select_related("user__profile", "nation__flag")
+            queryset=Member.objects.select_related(
+                "user__profile", "nation__flag"
+            ).defer("nation__flag__svg"),
         )
 
         phase_states_prefetch = Prefetch(
@@ -98,13 +102,15 @@ class GameQuerySet(models.QuerySet):
             "units",
             queryset=Unit.objects.filter(phase__in=current_phase_ids)
             .select_related("nation__flag", "province__parent")
-            .prefetch_related("province__named_coasts"),
+            .prefetch_related("province__named_coasts")
+            .defer("nation__flag__svg"),
         )
         current_supply_centers_prefetch = Prefetch(
             "supply_centers",
             queryset=SupplyCenter.objects.filter(phase__in=current_phase_ids)
             .select_related("nation__flag", "province__parent")
-            .prefetch_related("province__named_coasts"),
+            .prefetch_related("province__named_coasts")
+            .defer("nation__flag__svg"),
         )
         phases_prefetch = Prefetch(
             "phases",

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1192,6 +1192,52 @@ class TestGameListViewQueryPerformance:
         assert "DISTINCT ON" in unit_queries[0]
         assert "DISTINCT ON" in supply_center_queries[0]
 
+    @pytest.mark.django_db
+    def test_list_games_does_not_load_flag_svg(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_edinburgh_province,
+    ):
+        game = Game.objects.create(
+            name="Flag svg game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(user=primary_user, nation=classical_england_nation)
+        phase = game.phases.create(
+            game=game,
+            variant=game.variant,
+            season="Spring",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            status=PhaseStatus.ACTIVE,
+            ordinal=1,
+        )
+        phase.units.create(
+            type=UnitType.FLEET,
+            nation=classical_england_nation,
+            province=classical_edinburgh_province,
+        )
+        phase.supply_centers.create(
+            nation=classical_england_nation,
+            province=classical_edinburgh_province,
+        )
+
+        url = reverse(list_viewname)
+        connection.queries_log.clear()
+
+        with override_settings(DEBUG=True):
+            response = authenticated_client.get(url, {"mine": "true"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert all('"nation_nationflag"."svg"' not in q["sql"] for q in connection.queries)
+
+        result = next(g for g in response.data["results"] if g["id"] == game.id)
+        assert result["current_phase"]["units"][0]["nation"]["flag_url"] is not None
+
 
 class TestGameCreateView:
 


### PR DESCRIPTION
## What this PR does

`GET /games/` p50 is still ~700–800ms+ even after #919. This is the actual cause and the actual fix: the My Games list ships **~185MB of unused nation-flag SVG to Django per request**, and deferring one column removes it.

`with_list_data()` prefetches members, units, and supply centres with `select_related("nation__flag")`. `select_related` pulls *every* column of `nation_nationflag` — including the `svg` blob (**avg ~69KB, max ~1MB** in production) — for every row. But the serializer only ever reads `flag.content_hash` to build `flag_url` (`nation/serializers.py:get_flag_url`); the SVG bytes are never used in the response (the SVG is served separately by the `nation-flag-svg` endpoint).

For a player on a busy My Games page (measured against a real production account, 20 active games), that's:

| Source | Redundant SVG shipped |
|---|---|
| units | ~80 MB |
| supply centres | ~90 MB |
| members | ~15 MB |
| **total per request** | **~185 MB** |

Postgres reads and ships all of it to Django, which materialises it into Python objects — all to read a 40-byte `content_hash` from each. This cost is **invisible to `EXPLAIN ANALYZE`** (it discards output) and to the serializer spans (Honeycomb shows the instrumented Python work summing to ~1ms while the request is ~800ms), which is why it hid behind the query-plan analysis in #886/#919. #919 correctly removed the O(history) board scan that drove the p99 tail/ramp, but each current-phase row still dragged its flag blob across the wire, so the p50 players feel never moved.

## The fix

Add `.defer("nation__flag__svg")` to the four flag-bearing prefetches in `with_list_data` (members, victory members, units, supply centres). `flag_url` still resolves because `content_hash` is still loaded — verified end-to-end. No API/contract change, so **no codegen or frontend changes**. Query count is unchanged.

(Aside: the member serializer renders `nation` as a plain name string and exposes no flag at all in the list, so its flag join was entirely wasted — deferring the blob is the minimal, contract-safe way to reclaim it. Fully dropping `flag_url`/the flag joins from the list contract would save almost nothing further, since `content_hash` is tiny.)

## Tests

- **`test_list_games_does_not_load_flag_svg`** (new) — asserts no list query selects `nation_nationflag.svg`, while `flag_url` stays populated. It **fails before this change and passes after**.
- Existing `TestGameListView` + `TestGameListViewQueryPerformance` suites pass (query count still 9; current-phase board still serialized with a working `flag_url`).

## Notes / follow-ups

- The same `select_related("nation__flag")` pattern exists in `with_retrieve_data` (members) and `with_related_data` (units/supply centres). Those are single-game endpoints so the per-request waste is far smaller (~0.5–1.5MB), but `GET game/<id>/` is the highest-volume endpoint — worth a follow-up to defer there too.

No visual changes (backend only).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6xV5BLyWbCFNgZZs2TKmp)_