### PR TITLE
Use a lean board serializer for the games list

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -409,6 +409,26 @@ export interface SupplyCenter {
   nation: Nation;
 }
 
+export interface GameListBoardNation {
+  readonly name: string;
+}
+
+export interface GameListBoardProvince {
+  readonly id: string;
+}
+
+export interface GameListUnit {
+  readonly type: string;
+  readonly nation: GameListBoardNation;
+  readonly province: GameListBoardProvince;
+  readonly dislodged: boolean;
+}
+
+export interface GameListSupplyCenter {
+  readonly nation: GameListBoardNation;
+  readonly province: GameListBoardProvince;
+}
+
 export interface GameListCurrentPhase {
   readonly id: number;
   readonly ordinal: number;
@@ -420,8 +440,8 @@ export interface GameListCurrentPhase {
   /** @nullable */
   readonly scheduledResolution: string | null;
   readonly remainingTime: number;
-  readonly units: readonly Unit[];
-  readonly supplyCenters: readonly SupplyCenter[];
+  readonly units: readonly GameListUnit[];
+  readonly supplyCenters: readonly GameListSupplyCenter[];
 }
 
 /**

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -75,16 +75,12 @@ class GameQuerySet(models.QuerySet):
     def with_list_data(self):
         members_prefetch = Prefetch(
             "members",
-            queryset=Member.objects.select_related(
-                "nation__flag", "user__profile"
-            ).defer("nation__flag__svg"),
+            queryset=Member.objects.select_related("nation", "user__profile"),
         )
 
         victory_members_prefetch = Prefetch(
             "victory__members",
-            queryset=Member.objects.select_related(
-                "user__profile", "nation__flag"
-            ).defer("nation__flag__svg"),
+            queryset=Member.objects.select_related("user__profile", "nation"),
         )
 
         phase_states_prefetch = Prefetch(
@@ -101,16 +97,12 @@ class GameQuerySet(models.QuerySet):
         current_units_prefetch = Prefetch(
             "units",
             queryset=Unit.objects.filter(phase__in=current_phase_ids)
-            .select_related("nation__flag", "province__parent")
-            .prefetch_related("province__named_coasts")
-            .defer("nation__flag__svg"),
+            .select_related("nation", "province"),
         )
         current_supply_centers_prefetch = Prefetch(
             "supply_centers",
             queryset=SupplyCenter.objects.filter(phase__in=current_phase_ids)
-            .select_related("nation__flag", "province__parent")
-            .prefetch_related("province__named_coasts")
-            .defer("nation__flag__svg"),
+            .select_related("nation", "province"),
         )
         phases_prefetch = Prefetch(
             "phases",

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -12,9 +12,7 @@ from user_profile.utils import get_player_stats, tier_allows_min_reliability
 from bot.utils import get_bot_user, user_can_use_bot_opponent
 from member.serializers import MemberSerializer
 from unit.models import Unit
-from unit.serializers import UnitSerializer
 from supply_center.models import SupplyCenter
-from supply_center.serializers import SupplyCenterSerializer
 from notification import utils as notification_utils
 from phase.utils import format_deadline
 
@@ -55,6 +53,26 @@ class GameMasterSerializer(serializers.Serializer):
     picture = serializers.CharField(source="profile.picture", read_only=True, allow_null=True)
 
 
+class GameListBoardNationSerializer(serializers.Serializer):
+    name = serializers.CharField(read_only=True)
+
+
+class GameListBoardProvinceSerializer(serializers.Serializer):
+    id = serializers.CharField(source="province_id", read_only=True)
+
+
+class GameListUnitSerializer(serializers.Serializer):
+    type = serializers.CharField(read_only=True)
+    nation = GameListBoardNationSerializer(read_only=True)
+    province = GameListBoardProvinceSerializer(read_only=True)
+    dislodged = serializers.BooleanField(read_only=True)
+
+
+class GameListSupplyCenterSerializer(serializers.Serializer):
+    nation = GameListBoardNationSerializer(read_only=True)
+    province = GameListBoardProvinceSerializer(read_only=True)
+
+
 class GameListCurrentPhaseSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     ordinal = serializers.IntegerField(read_only=True)
@@ -65,8 +83,8 @@ class GameListCurrentPhaseSerializer(serializers.Serializer):
     status = serializers.CharField(read_only=True)
     scheduled_resolution = serializers.DateTimeField(read_only=True, allow_null=True)
     remaining_time = serializers.IntegerField(source="remaining_time_seconds", read_only=True)
-    units = UnitSerializer(many=True, read_only=True)
-    supply_centers = SupplyCenterSerializer(many=True, read_only=True)
+    units = GameListUnitSerializer(many=True, read_only=True)
+    supply_centers = GameListSupplyCenterSerializer(many=True, read_only=True)
 
 
 class GameListSerializer(serializers.Serializer):

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -927,7 +927,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 9
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_phases_and_units(
@@ -968,7 +968,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 9
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_different_nations(
@@ -1019,7 +1019,7 @@ class TestGameListViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 9
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_games_query_count_with_phase_states(
@@ -1068,7 +1068,7 @@ class TestGameListViewQueryPerformance:
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
 
-        assert query_count == 9
+        assert query_count == 7
 
     @pytest.mark.django_db
     def test_list_games_hydrates_units_for_current_phase_only(
@@ -1193,7 +1193,7 @@ class TestGameListViewQueryPerformance:
         assert "DISTINCT ON" in supply_center_queries[0]
 
     @pytest.mark.django_db
-    def test_list_games_does_not_load_flag_svg(
+    def test_list_games_board_is_lean(
         self,
         authenticated_client,
         primary_user,
@@ -1202,7 +1202,7 @@ class TestGameListViewQueryPerformance:
         classical_edinburgh_province,
     ):
         game = Game.objects.create(
-            name="Flag svg game",
+            name="Lean board game",
             variant=classical_variant,
             status=GameStatus.ACTIVE,
         )
@@ -1233,10 +1233,18 @@ class TestGameListViewQueryPerformance:
             response = authenticated_client.get(url, {"mine": "true"})
 
         assert response.status_code == status.HTTP_200_OK
-        assert all('"nation_nationflag"."svg"' not in q["sql"] for q in connection.queries)
+        assert all("nation_nationflag" not in q["sql"] for q in connection.queries)
 
         result = next(g for g in response.data["results"] if g["id"] == game.id)
-        assert result["current_phase"]["units"][0]["nation"]["flag_url"] is not None
+        unit = result["current_phase"]["units"][0]
+        assert set(unit.keys()) == {"type", "nation", "province", "dislodged"}
+        assert set(unit["nation"].keys()) == {"name"}
+        assert set(unit["province"].keys()) == {"id"}
+        assert unit["type"] == UnitType.FLEET
+        assert unit["province"]["id"] == classical_edinburgh_province.province_id
+
+        supply_center = result["current_phase"]["supply_centers"][0]
+        assert set(supply_center.keys()) == {"nation", "province"}
 
 
 class TestGameCreateView:

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -2217,6 +2217,22 @@ components:
       - totalUnreadMessageCount
       - variantId
       - victory
+    GameListBoardNation:
+      type: object
+      properties:
+        name:
+          type: string
+          readOnly: true
+      required:
+      - name
+    GameListBoardProvince:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+      required:
+      - id
     GameListCurrentPhase:
       type: object
       properties:
@@ -2252,12 +2268,12 @@ components:
         units:
           type: array
           items:
-            $ref: '#/components/schemas/Unit'
+            $ref: '#/components/schemas/GameListUnit'
           readOnly: true
         supplyCenters:
           type: array
           items:
-            $ref: '#/components/schemas/SupplyCenter'
+            $ref: '#/components/schemas/GameListSupplyCenter'
           readOnly: true
       required:
       - id
@@ -2271,6 +2287,42 @@ components:
       - type
       - units
       - year
+    GameListSupplyCenter:
+      type: object
+      properties:
+        nation:
+          allOf:
+          - $ref: '#/components/schemas/GameListBoardNation'
+          readOnly: true
+        province:
+          allOf:
+          - $ref: '#/components/schemas/GameListBoardProvince'
+          readOnly: true
+      required:
+      - nation
+      - province
+    GameListUnit:
+      type: object
+      properties:
+        type:
+          type: string
+          readOnly: true
+        nation:
+          allOf:
+          - $ref: '#/components/schemas/GameListBoardNation'
+          readOnly: true
+        province:
+          allOf:
+          - $ref: '#/components/schemas/GameListBoardProvince'
+          readOnly: true
+        dislodged:
+          type: boolean
+          readOnly: true
+      required:
+      - dislodged
+      - nation
+      - province
+      - type
     GameMaster:
       type: object
       properties:
@@ -2845,8 +2897,8 @@ components:
           readOnly: true
         maxOrders:
           type: integer
-          readOnly: true
           nullable: true
+          readOnly: true
     PatchedUserProfile:
       type: object
       properties:
@@ -2990,8 +3042,8 @@ components:
           readOnly: true
         maxOrders:
           type: integer
-          readOnly: true
           nullable: true
+          readOnly: true
       required:
       - eliminated
       - id


### PR DESCRIPTION
## What this PR does

After the two prior DB fixes (#919, #920), `GET /games/` p50 was still ~670ms. Production tracing shows the remaining cost is **serialization, not SQL** — and this addresses it.

`#857` embeds each game's current-phase board in the list and serializes every unit and supply centre through the **full** `UnitSerializer`/`SupplyCenterSerializer`: nested `NationSerializer` (which calls `reverse()` + `build_absolute_uri()` for `flag_url` and a colorblind-palette transform **per object**) and `ProvinceSerializer` (parent lookup + `named_coast_ids`). For a busy My Games page that's ~1,100 board objects, each with several nested method fields, and then the whole structure is camel-cased.

Evidence it's serialization: instrumented Python spans sum to ~1–2ms/request while the request is ~670ms; DB+transfer measured at ~150–200ms (post-#920). The ~450ms gap is uninstrumented DRF serialization + rendering of this nested payload.

## The fix

The map preview consumes only a small subset of the board, defined by the frontend's `toRenderState`:
- unit: `{ type, province.id, nation.name, dislodged }`
- supply centre: `{ province.id, nation.name }`
- nation **colours come from `variant.nations`**, not the board

Add lean `GameListUnit`/`GameListSupplyCenter` serializers (with minimal `nation` = `{name}` and `province` = `{id}` sub-serializers) for the list's current phase, and drop the now-unused `nation__flag` / `province__parent` / `province__named_coasts` joins from the board prefetch. Members/victory members only render `nation.name` too, so their unused flag join is dropped as well — the list no longer touches the nation-flag table at all.

- **Query count: 9 → 7** (the two named-coast prefetches are gone).
- `Unit`/`SupplyCenter`/`Nation`/`Province` serializers are unchanged — `PhaseRetrieve`/`PhaseList` still use the full shapes.

## API change + frontend

This changes the shape of `GameListCurrentPhase.units` / `supply_centers`, so the OpenAPI schema and generated client are regenerated (`GameListUnit`, `GameListSupplyCenter`, `GameListBoardNation`, `GameListBoardProvince`). The frontend renderer already consumed only the retained fields (`toRenderState`), so **no frontend source changes** and **no rendering change** — `npx tsc -b --noEmit` is clean and `GameCard` tests pass.

> Note on the generated client: cloud codegen runs without Firebase/DEBUG, which would otherwise strip the `FCMDevice`/`/devices/`/`apiTestSentry` exports (documented in CLAUDE.md). To avoid that environmental churn, only the board-related additions were applied to `endpoints.ts`; the devices/sentry hooks are preserved.

## Tests

- Updated the four query-count assertions 9 → 7.
- Replaced the flag-svg test with **`test_list_games_board_is_lean`**, asserting the minimal board shape (`unit` keys = `{type, nation, province, dislodged}`, `nation` = `{name}`, `province` = `{id}`) and that no list query references the flag table.
- Full `game` app suite green (203 passed); `GameCard`/`util` frontend tests pass.

## Screenshots

No visual change — included to confirm the My Games map previews still render (units placed, supply centres coloured) with the trimmed payload:

![My Games list with map previews](https://raw.githubusercontent.com/johnpooch/diplicity-react/411fb32d7e931b18409295cca02908856665e388/shots/my-games.png)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6xV5BLyWbCFNgZZs2TKmp)_