### PR TITLE
Bot selects orders via Claude Haiku among enumerated legal options

### DIFF
--- a/service/bot/llm.py
+++ b/service/bot/llm.py
@@ -81,13 +81,15 @@ def request_choices(grouped):
 
 def select_orders(options):
     if not settings.ANTHROPIC_API_KEY:
+        logger.info("[bot.llm] no ANTHROPIC_API_KEY set; using first-legal selection")
         return first_legal_selections(options)
 
     grouped = group_by_source(options)
+    logger.info(f"[bot.llm] asking {settings.BOT_LLM_MODEL} to choose orders for {len(grouped)} unit(s)")
     try:
         choices = request_choices(grouped)
     except Exception as e:
-        logger.error(f"[bot.llm] order selection failed: {e}")
+        logger.error(f"[bot.llm] order selection failed: {e}; falling back to first-legal")
         return first_legal_selections(options)
 
     selections = []
@@ -95,7 +97,10 @@ def select_orders(options):
         index = choices.get(source_id)
         if index is None or not (0 <= index < len(source_options)):
             chosen = source_options[0]
+            logger.info(f"[bot.llm] {source_id}: invalid/missing choice {index}; using first legal option {option_label(chosen)}")
         else:
             chosen = source_options[index]
+            logger.info(f"[bot.llm] {source_id}: chose {option_label(chosen)}")
         selections.append(option_to_selected(chosen))
+    logger.info(f"[bot.llm] selected {len(selections)} order(s) via {settings.BOT_LLM_MODEL}")
     return selections

--- a/service/bot/llm.py
+++ b/service/bot/llm.py
@@ -1,0 +1,101 @@
+import logging
+
+from anthropic import Anthropic
+from django.conf import settings
+
+from bot.utils import first_legal_selections, option_to_selected
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = "submit_order_choices"
+
+TOOL = {
+    "name": TOOL_NAME,
+    "description": "Submit the chosen order index for each unit.",
+    "strict": True,
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "choices": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "source_id": {"type": "string"},
+                        "option_index": {"type": "integer"},
+                    },
+                    "required": ["source_id", "option_index"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["choices"],
+        "additionalProperties": False,
+    },
+}
+
+
+def group_by_source(options):
+    grouped = {}
+    for option in options:
+        grouped.setdefault(option["source"]["id"], []).append(option)
+    return grouped
+
+
+def option_label(option):
+    parts = [option["source"]["id"], option["order_type"]["id"]]
+    for key in ("aux", "target", "unit_type", "named_coast"):
+        value = option.get(key)
+        if value:
+            parts.append(value["id"])
+    return " ".join(parts)
+
+
+def build_prompt(grouped):
+    lines = []
+    for source_id, source_options in grouped.items():
+        lines.append(f"Unit {source_id}:")
+        for index, option in enumerate(source_options):
+            lines.append(f"  {index}. {option_label(option)}")
+    return (
+        "You are playing a game of Diplomacy. For each unit below, choose one order "
+        "by its index from the listed legal options. Submit a choice for every unit "
+        "using the submit_order_choices tool.\n\n" + "\n".join(lines)
+    )
+
+
+def request_choices(grouped):
+    client = Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+    message = client.messages.create(
+        model=settings.BOT_LLM_MODEL,
+        max_tokens=1024,
+        tools=[TOOL],
+        tool_choice={"type": "tool", "name": TOOL_NAME},
+        messages=[{"role": "user", "content": build_prompt(grouped)}],
+    )
+    for block in message.content:
+        if block.type == "tool_use" and block.name == TOOL_NAME:
+            return {choice["source_id"]: choice["option_index"] for choice in block.input["choices"]}
+    raise ValueError("no submit_order_choices tool use in response")
+
+
+def select_orders(options):
+    if not settings.ANTHROPIC_API_KEY:
+        return first_legal_selections(options)
+
+    grouped = group_by_source(options)
+    try:
+        choices = request_choices(grouped)
+    except Exception as e:
+        logger.error(f"[bot.llm] order selection failed: {e}")
+        return first_legal_selections(options)
+
+    selections = []
+    for source_id, source_options in grouped.items():
+        index = choices.get(source_id)
+        if index is None or not (0 <= index < len(source_options)):
+            chosen = source_options[0]
+        else:
+            chosen = source_options[index]
+        selections.append(option_to_selected(chosen))
+    return selections

--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -24,6 +24,7 @@ def plan(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
+    logger.info(f"[{label}] fetched {len(options_response.data['orders'])} order option(s)")
     selections = select_orders(options_response.data["orders"])
 
     phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
@@ -31,7 +32,8 @@ def plan(user_id, game_id):
         logger.error(f"[{label}] phase states request failed: {phase_states_response.status_code}")
         return
     max_orders = phase_states_response.data[0]["max_orders"] if phase_states_response.data else None
-    if max_orders is not None:
+    if max_orders is not None and len(selections) > max_orders:
+        logger.info(f"[{label}] capping {len(selections)} selection(s) to max_orders={max_orders}")
         selections = selections[:max_orders]
 
     create_url = reverse("order-create", args=[game_id])
@@ -39,6 +41,8 @@ def plan(user_id, game_id):
         response = client.post(create_url, {"selected": selected}, format="json")
         if response.status_code not in (200, 201):
             logger.error(f"[{label}] create order failed ({response.status_code}) for {selected}")
+        else:
+            logger.info(f"[{label}] created order {selected}")
 
     logger.info(f"[{label}] completed")
 
@@ -64,6 +68,7 @@ def finalize(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
+    logger.info(f"[{label}] fetched {len(options_response.data['orders'])} order option(s)")
     selections = select_orders(options_response.data["orders"])
 
     phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
@@ -71,7 +76,8 @@ def finalize(user_id, game_id):
         logger.error(f"[{label}] phase states request failed: {phase_states_response.status_code}")
         return
     max_orders = phase_states_response.data[0]["max_orders"] if phase_states_response.data else None
-    if max_orders is not None:
+    if max_orders is not None and len(selections) > max_orders:
+        logger.info(f"[{label}] capping {len(selections)} selection(s) to max_orders={max_orders}")
         selections = selections[:max_orders]
 
     create_url = reverse("order-create", args=[game_id])
@@ -79,10 +85,13 @@ def finalize(user_id, game_id):
         response = client.post(create_url, {"selected": selected}, format="json")
         if response.status_code not in (200, 201):
             logger.error(f"[{label}] create order failed ({response.status_code}) for {selected}")
+        else:
+            logger.info(f"[{label}] created order {selected}")
 
     confirm_response = client.put(reverse("game-confirm-phase", args=[game_id]))
     if confirm_response.status_code != 200:
         logger.error(f"[{label}] confirm failed: {confirm_response.status_code}")
         return
+    logger.info(f"[{label}] confirmed phase")
 
     logger.info(f"[{label}] completed")

--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -5,7 +5,8 @@ from django.urls import reverse
 from procrastinate.contrib.django import app
 from rest_framework.test import APIClient
 
-from bot.utils import bot_request_host, first_legal_selections
+from bot.llm import select_orders
+from bot.utils import bot_request_host
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def plan(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
-    selections = first_legal_selections(options_response.data["orders"])
+    selections = select_orders(options_response.data["orders"])
 
     phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
     if phase_states_response.status_code != 200:
@@ -63,7 +64,7 @@ def finalize(user_id, game_id):
     if options_response.status_code != 200:
         logger.error(f"[{label}] options request failed: {options_response.status_code}")
         return
-    selections = first_legal_selections(options_response.data["orders"])
+    selections = select_orders(options_response.data["orders"])
 
     phase_states_response = client.get(reverse("phase-state-list", args=[game_id]))
     if phase_states_response.status_code != 200:

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -13,7 +13,7 @@ from common.constants import (
     OrderType,
 )
 from game.models import Game
-from bot import tasks, utils
+from bot import llm, tasks, utils
 from bot.utils import get_bot_user
 
 
@@ -71,6 +71,66 @@ class TestFirstLegalSelections:
         assert utils.first_legal_selections(options) == [
             ["lon", OrderType.HOLD],
             ["edi", OrderType.MOVE, "nwg"],
+        ]
+
+
+def _llm_message(choices):
+    block = Mock()
+    block.type = "tool_use"
+    block.name = llm.TOOL_NAME
+    block.input = {"choices": choices}
+    return Mock(content=[block])
+
+
+class TestSelectOrders:
+
+    def _options(self):
+        return [
+            _option("lon", OrderType.HOLD),
+            _option("lon", OrderType.MOVE, target="nth"),
+            _option("edi", OrderType.HOLD),
+            _option("edi", OrderType.MOVE, target="nwg"),
+        ]
+
+    def test_returns_llm_choice_per_source(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        choices = [
+            {"source_id": "lon", "option_index": 1},
+            {"source_id": "edi", "option_index": 1},
+        ]
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.return_value = _llm_message(choices)
+            selections = llm.select_orders(self._options())
+
+        assert selections == [
+            ["lon", OrderType.MOVE, "nth"],
+            ["edi", OrderType.MOVE, "nwg"],
+        ]
+
+    def test_falls_back_to_first_legal_without_key(self, settings):
+        settings.ANTHROPIC_API_KEY = ""
+        options = self._options()
+        assert llm.select_orders(options) == utils.first_legal_selections(options)
+
+    def test_falls_back_to_first_legal_when_client_raises(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        options = self._options()
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.side_effect = RuntimeError("boom")
+            selections = llm.select_orders(options)
+
+        assert selections == utils.first_legal_selections(options)
+
+    def test_invalid_or_missing_index_falls_back_per_source(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        choices = [{"source_id": "lon", "option_index": 9}]
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.return_value = _llm_message(choices)
+            selections = llm.select_orders(self._options())
+
+        assert selections == [
+            ["lon", OrderType.HOLD],
+            ["edi", OrderType.HOLD],
         ]
 
 

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -258,6 +258,9 @@ BOT_OPPONENT_ALLOWLIST = [
     if email.strip()
 ]
 
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+BOT_LLM_MODEL = os.getenv("BOT_LLM_MODEL", "claude-haiku-4-5")
+
 
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -26,5 +26,6 @@ opentelemetry-instrumentation-psycopg2>=0.63b1,<1.0
 opentelemetry-instrumentation-requests>=0.63b1,<1.0
 resend>=2.32.2,<3.0
 jsonschema>=4.26.0,<5.0
+anthropic>=0.69.0,<1.0
 PyYAML>=6.0.3,<7.0
 lxml>=6.1.1,<7.0


### PR DESCRIPTION
## What this PR does

The bot walking skeleton ([#908](https://github.com/johnpooch/diplicity-react/pull/908)) plays every phase by picking orders deterministically (`first_legal_selections` — first legal option per unit), with **no LLM invoked anywhere**. This is the first real LLM call, the minimal viable step from [discussion #907](https://github.com/johnpooch/diplicity-react/discussions/907): Claude **Haiku** (`claude-haiku-4-5`) chooses among the already-enumerated legal options, with **no game-state context** — it sees only the list of legal options and picks one per source unit, for every phase (movement, retreat, adjustment).

Because the backend still enumerates the legal moves, the LLM can only *choose* among them — structurally illegal orders remain impossible. Every failure mode falls back to the existing first-legal behaviour, so the bot never NMRs:

- `ANTHROPIC_API_KEY` not set → fallback (also keeps CI/tests green without an API key)
- network error, refusal, or malformed response → caught, logged, fallback
- an out-of-range / missing index for a source → that source falls back to its first legal option

New `bot/llm.py` isolates the one `client.messages.create(...)` call behind `select_orders(options)`, which returns the same shape as `first_legal_selections`, so `bot/tasks.py` only swaps the call site in `plan` and `finalize`. Selection uses a single **strict tool call** (`tool_choice` forced) returning a chosen index per unit. `ANTHROPIC_API_KEY` and `BOT_LLM_MODEL` are read from the environment following the existing settings pattern; the key will be set in Railway.

Out of scope (later steps): feeding board/phase state to the LLM, chat/negotiation, personas, memory, per-game budgets, observability.

No visual changes — backend only; no serializer/view/OpenAPI shape change, so no codegen and no frontend edits.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual changes

## Tests

- `bot/tests.py::TestSelectOrders` — returns the LLM-chosen option per source; falls back to first-legal without a key; falls back when the client raises; out-of-range / missing index falls back per source.
- Existing `bot/tests.py` (`plan`/`finalize`/triggers, `TestAdjustmentOrderLimit`) and `integration/test_bot.py` (end-to-end bot play) pass unchanged via the no-key fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmWjWUSSU2jdFXQ2dV8fum)_