### PR TITLE
Add a chat reply capability to the Diplicity bot

### DIFF
--- a/service/bot/decorators.py
+++ b/service/bot/decorators.py
@@ -52,6 +52,34 @@ def with_bot_members(func):
     return wrapper
 
 
+def on_public_chat_message(func):
+    @functools.wraps(func)
+    def wrapper(sender, instance, created, **kwargs):
+        if not created:
+            return
+        if instance.channel.private:
+            return
+        message_sender = instance.sender
+        if message_sender.user is not None and message_sender.user.email == BOT_USER_EMAIL:
+            return
+        return func(sender=sender, instance=instance, created=created, **kwargs)
+
+    return wrapper
+
+
+def with_bot_channel_members(func):
+    @functools.wraps(func)
+    def wrapper(sender, instance, **kwargs):
+        bot_members = list(
+            instance.channel.members.filter(user__email=BOT_USER_EMAIL).select_related("user")
+        )
+        if not bot_members:
+            return
+        return func(sender=sender, instance=instance, bot_members=bot_members, **kwargs)
+
+    return wrapper
+
+
 def on_orders_confirmed(func):
     @functools.wraps(func)
     def wrapper(sender, instance, **kwargs):

--- a/service/bot/llm.py
+++ b/service/bot/llm.py
@@ -79,6 +79,80 @@ def request_choices(grouped):
     raise ValueError("no submit_order_choices tool use in response")
 
 
+REPLY_TOOL_NAME = "reply_to_chat"
+
+REPLY_TOOL = {
+    "name": REPLY_TOOL_NAME,
+    "description": "Decide whether to reply to the conversation, and provide the reply text.",
+    "strict": True,
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "should_reply": {"type": "boolean"},
+            "message": {"type": "string"},
+        },
+        "required": ["should_reply", "message"],
+        "additionalProperties": False,
+    },
+}
+
+
+def build_chat_prompt(messages):
+    lines = []
+    for message in messages:
+        sender = message["sender"]
+        speaker = "You" if sender["is_current_user"] else sender["name"]
+        lines.append(f"{speaker}: {message['body']}")
+    return (
+        "You are a player in a game of Diplomacy, taking part in the public chat with the "
+        'other players. Below is the conversation so far, where "You" marks your own '
+        "previous messages. Decide whether to send a reply. Only reply if a reply is "
+        "warranted and you have something worth saying; staying silent is a perfectly good "
+        "choice. Keep any reply short, on-topic, and in the spirit of friendly table talk. "
+        "Use the reply_to_chat tool to respond.\n\n" + "\n".join(lines)
+    )
+
+
+def request_reply(messages):
+    client = Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+    message = client.messages.create(
+        model=settings.BOT_LLM_MODEL,
+        max_tokens=1024,
+        tools=[REPLY_TOOL],
+        tool_choice={"type": "tool", "name": REPLY_TOOL_NAME},
+        messages=[{"role": "user", "content": build_chat_prompt(messages)}],
+    )
+    for block in message.content:
+        if block.type == "tool_use" and block.name == REPLY_TOOL_NAME:
+            return block.input
+    raise ValueError("no reply_to_chat tool use in response")
+
+
+def compose_reply(messages):
+    if not settings.ANTHROPIC_API_KEY:
+        logger.info("[bot.llm] no ANTHROPIC_API_KEY set; not replying to chat")
+        return None
+
+    logger.info(
+        f"[bot.llm] asking {settings.BOT_LLM_MODEL} whether to reply to {len(messages)} message(s)"
+    )
+    try:
+        result = request_reply(messages)
+    except Exception as e:
+        logger.error(f"[bot.llm] chat reply failed: {e}; staying silent")
+        return None
+
+    if not result.get("should_reply"):
+        logger.info("[bot.llm] model declined to reply")
+        return None
+    reply = (result.get("message") or "").strip()
+    if not reply:
+        logger.info("[bot.llm] model returned empty reply; staying silent")
+        return None
+    logger.info(f"[bot.llm] composed chat reply ({len(reply)} char(s))")
+    return reply
+
+
 def select_orders(options):
     if not settings.ANTHROPIC_API_KEY:
         logger.info("[bot.llm] no ANTHROPIC_API_KEY set; using first-legal selection")

--- a/service/bot/signals.py
+++ b/service/bot/signals.py
@@ -3,17 +3,21 @@ import logging
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
+from channel.models import ChannelMessage
 from phase.models import Phase, PhaseState
 
 from bot.decorators import (
     capture_phase_status,
     on_orders_confirmed,
     on_phase_activated,
+    on_public_chat_message,
     when_humans_confirmed,
+    with_bot_channel_members,
     with_bot_members,
 )
 from bot.tasks import finalize as finalize_task
 from bot.tasks import plan as plan_task
+from bot.tasks import reply as reply_task
 
 logger = logging.getLogger(__name__)
 
@@ -49,4 +53,23 @@ def finalize(sender, instance, phase, bot_phase_states, **kwargs):
         logger.info(
             f"[bot.finalize signal] queued finalize for member {phase_state.member_id} "
             f"(phase {phase.id})"
+        )
+
+
+@receiver(post_save, sender=ChannelMessage)
+@on_public_chat_message
+@with_bot_channel_members
+def reply(sender, instance, bot_members, **kwargs):
+    logger.info(
+        f"[bot.reply signal] message {instance.id} in public channel {instance.channel_id} "
+        f"(game {instance.channel.game_id})"
+    )
+    for member in bot_members:
+        reply_task.configure(lock=f"reply-{instance.id}-{member.id}").defer(
+            user_id=member.user_id,
+            game_id=instance.channel.game_id,
+            channel_id=instance.channel_id,
+        )
+        logger.info(
+            f"[bot.reply signal] queued reply for member {member.id} (message {instance.id})"
         )

--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from procrastinate.contrib.django import app
 from rest_framework.test import APIClient
 
-from bot.llm import select_orders
+from bot.llm import compose_reply, select_orders
 from bot.utils import bot_request_host
 
 logger = logging.getLogger(__name__)
@@ -93,5 +93,38 @@ def finalize(user_id, game_id):
         logger.error(f"[{label}] confirm failed: {confirm_response.status_code}")
         return
     logger.info(f"[{label}] confirmed phase")
+
+    logger.info(f"[{label}] completed")
+
+
+@app.task(name="bot.reply", retry=3)
+def reply(user_id, game_id, channel_id):
+    label = f"bot.reply user={user_id} game={game_id} channel={channel_id}"
+    logger.info(f"[{label}] invoked")
+
+    user = get_user_model().objects.get(id=user_id)
+    client = APIClient(SERVER_NAME=bot_request_host())
+    client.force_authenticate(user=user)
+
+    channels_response = client.get(reverse("channel-list", args=[game_id]))
+    if channels_response.status_code != 200:
+        logger.error(f"[{label}] channel list request failed: {channels_response.status_code}")
+        return
+    channel = next((c for c in channels_response.data if c["id"] == channel_id), None)
+    if channel is None:
+        logger.error(f"[{label}] channel {channel_id} not found")
+        return
+
+    reply_text = compose_reply(channel["messages"])
+    if not reply_text:
+        logger.info(f"[{label}] no reply composed; staying silent")
+        return
+
+    create_url = reverse("channel-message-create", args=[game_id, channel_id])
+    response = client.post(create_url, {"body": reply_text}, format="json")
+    if response.status_code not in (200, 201):
+        logger.error(f"[{label}] post reply failed ({response.status_code})")
+        return
+    logger.info(f"[{label}] posted reply")
 
     logger.info(f"[{label}] completed")

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -12,6 +12,7 @@ from common.constants import (
     NationAssignment,
     OrderType,
 )
+from channel.models import ChannelMessage
 from game.models import Game
 from bot import llm, tasks, utils
 from bot.utils import get_bot_user
@@ -333,3 +334,181 @@ class TestFinalizeTrigger:
         assert len(jobs) == 1
         assert jobs[0]["lock"] == f"finalize-{game.current_phase.id}-{bot_member.id}"
         assert jobs[0]["args"] == {"user_id": get_bot_user().id, "game_id": game.id}
+
+
+def _llm_reply(should_reply, message=""):
+    block = Mock()
+    block.type = "tool_use"
+    block.name = llm.REPLY_TOOL_NAME
+    block.input = {"should_reply": should_reply, "message": message}
+    return Mock(content=[block])
+
+
+class TestComposeReply:
+
+    def _messages(self):
+        return [
+            {
+                "sender": {"name": "England", "is_current_user": False},
+                "body": "Hi bot, want to ally?",
+            },
+        ]
+
+    def test_returns_reply_when_model_replies(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.return_value = _llm_reply(
+                True, "Sure, let's talk."
+            )
+            assert llm.compose_reply(self._messages()) == "Sure, let's talk."
+
+    def test_returns_none_when_model_declines(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.return_value = _llm_reply(False, "")
+            assert llm.compose_reply(self._messages()) is None
+
+    def test_returns_none_for_empty_message(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.return_value = _llm_reply(True, "   ")
+            assert llm.compose_reply(self._messages()) is None
+
+    def test_returns_none_without_key(self, settings):
+        settings.ANTHROPIC_API_KEY = ""
+        assert llm.compose_reply(self._messages()) is None
+
+    def test_returns_none_when_client_raises(self, settings):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        with patch("bot.llm.Anthropic") as mock_anthropic:
+            mock_anthropic.return_value.messages.create.side_effect = RuntimeError("boom")
+            assert llm.compose_reply(self._messages()) is None
+
+
+@pytest.fixture
+def bot_public_channel_factory(bot_game_factory):
+    def _create():
+        game = bot_game_factory()
+        channel = game.channels.create(name="Public Press", private=False)
+        for member in game.members.all():
+            channel.member_channels.create(member=member)
+        return game, channel
+
+    return _create
+
+
+class TestReplyTask:
+
+    @pytest.mark.django_db
+    def test_reply_posts_message_when_model_replies(
+        self, bot_public_channel_factory, in_memory_procrastinate
+    ):
+        game, channel = bot_public_channel_factory()
+        bot_user = get_bot_user()
+        bot_member = game.members.get(user=bot_user)
+        human_member = game.members.get(user=game.created_by)
+        ChannelMessage.objects.create(channel=channel, sender=human_member, body="Hi bot")
+
+        with patch("bot.tasks.compose_reply", return_value="Hello, human!"):
+            tasks.reply(user_id=bot_user.id, game_id=game.id, channel_id=channel.id)
+
+        assert channel.messages.filter(sender=bot_member, body="Hello, human!").exists()
+
+    @pytest.mark.django_db
+    def test_reply_posts_nothing_when_model_declines(
+        self, bot_public_channel_factory, in_memory_procrastinate
+    ):
+        game, channel = bot_public_channel_factory()
+        bot_user = get_bot_user()
+        human_member = game.members.get(user=game.created_by)
+        ChannelMessage.objects.create(channel=channel, sender=human_member, body="Hi bot")
+
+        with patch("bot.tasks.compose_reply", return_value=None):
+            tasks.reply(user_id=bot_user.id, game_id=game.id, channel_id=channel.id)
+
+        assert channel.messages.filter(sender__user=bot_user).count() == 0
+
+
+def _bot_reply_jobs(connector):
+    return [j for j in connector.jobs.values() if j["task_name"] == "bot.reply"]
+
+
+class TestReplyTrigger:
+
+    @pytest.mark.django_db
+    def test_human_public_message_defers_reply(
+        self, bot_public_channel_factory, in_memory_procrastinate
+    ):
+        game, channel = bot_public_channel_factory()
+        bot_member = game.members.get(user=get_bot_user())
+
+        human_client = APIClient()
+        human_client.force_authenticate(user=game.created_by)
+        response = human_client.post(
+            reverse("channel-message-create", args=[game.id, channel.id]),
+            {"body": "Hello bot"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        jobs = _bot_reply_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        assert jobs[0]["lock"] == f"reply-{response.data['id']}-{bot_member.id}"
+        assert jobs[0]["args"] == {
+            "user_id": get_bot_user().id,
+            "game_id": game.id,
+            "channel_id": channel.id,
+        }
+
+    @pytest.mark.django_db
+    def test_bot_own_message_does_not_defer_reply(
+        self, bot_public_channel_factory, in_memory_procrastinate
+    ):
+        game, channel = bot_public_channel_factory()
+        bot_member = game.members.get(user=get_bot_user())
+
+        ChannelMessage.objects.create(channel=channel, sender=bot_member, body="Hi all")
+
+        assert len(_bot_reply_jobs(in_memory_procrastinate)) == 0
+
+    @pytest.mark.django_db
+    def test_private_channel_message_does_not_defer_reply(
+        self, bot_public_channel_factory, in_memory_procrastinate
+    ):
+        game, _ = bot_public_channel_factory()
+        bot_member = game.members.get(user=get_bot_user())
+        human_member = game.members.get(user=game.created_by)
+        private = game.channels.create(name="Private", private=True)
+        private.member_channels.create(member=bot_member)
+        private.member_channels.create(member=human_member)
+
+        human_client = APIClient()
+        human_client.force_authenticate(user=game.created_by)
+        response = human_client.post(
+            reverse("channel-message-create", args=[game.id, private.id]),
+            {"body": "Just between us"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        assert len(_bot_reply_jobs(in_memory_procrastinate)) == 0
+
+    @pytest.mark.django_db
+    def test_non_bot_game_does_not_defer_reply(
+        self, active_game_factory, in_memory_procrastinate
+    ):
+        game = active_game_factory()
+        channel = game.channels.create(name="Public Press", private=False)
+        member = game.members.get(user=game.created_by)
+        channel.member_channels.create(member=member)
+
+        human_client = APIClient()
+        human_client.force_authenticate(user=game.created_by)
+        response = human_client.post(
+            reverse("channel-message-create", args=[game.id, channel.id]),
+            {"body": "Anyone there?"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        assert len(_bot_reply_jobs(in_memory_procrastinate)) == 0


### PR DESCRIPTION
## What this PR does

Gives the LLM-backed bot a presence in chat: it can now **reply to messages humans send in a game's public press channel**. It is reply-only and never proactive, and the model itself decides whether a reply is even warranted — staying silent is the default outcome.

The implementation mirrors the bot's existing order-taking architecture (`post_save` signal → decorators → Procrastinate task → internal `APIClient` → Claude Haiku with graceful fallback):

- **`bot/signals.py`** — a `post_save` receiver on `ChannelMessage` defers a `bot.reply` task for each bot member of the channel, gated by two new decorators in **`bot/decorators.py`**: `on_public_chat_message` (a newly-created message, in a public channel, not sent by the bot) and `with_bot_channel_members` (the channel actually has a bot member). Because the bot's own replies have the bot as sender, they're filtered out — no reply loop.
- **`bot/tasks.py`** — `bot.reply(user_id, game_id, channel_id)` authenticates as the bot, reads the conversation via the existing `channel-list` API (so it sees exactly what the bot is allowed to, including anonymity masking), calls `compose_reply(...)`, and posts through the normal `channel-message-create` endpoint only if a non-empty reply comes back.
- **`bot/llm.py`** — `compose_reply(messages)` uses Claude Haiku (same model/key as order selection) with a forced `reply_to_chat` tool returning `should_reply` + `message`. It reasons only over the conversation transcript — no board or game state. **Silence is the safe default:** it returns `None` (post nothing) when the model declines, when the message is empty, when `ANTHROPIC_API_KEY` is unset, or when the API call raises. It never crashes or blocks chat flow.

No DB migration and no API-shape change, so no codegen is required.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only, no visual changes

### Tests

Added to `bot/tests.py`:
- `TestComposeReply` — returns the reply when the model replies; returns `None` when it declines, when the message is empty/whitespace, when the key is unset, and when the client raises.
- `TestReplyTask` — posts a bot message when the model replies; posts nothing when it declines.
- `TestReplyTrigger` — a human public-channel message defers one `bot.reply` job (correct lock/args); the bot's own message does not; a private-channel message does not; a non-bot game does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9CGYEh9yjkb7hd4q6oqcJ)_