### PR TITLE
Add bot-research skill cataloguing LLM Diplomacy prior art

### DIFF
--- a/.claude/skills/bot-research/SKILL.md
+++ b/.claude/skills/bot-research/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: bot-research
+description: Prior-art catalogue and research playbook for the LLM-driven Diplomacy bot. Use when researching how to build or improve the bot — evals, the phase loop, board representation, when/how the bot talks, memory/trust, or baseline opponents — or when studying how other open-source Diplomacy / LLM-agent projects structure their code. Knows which projects and papers to read and where the relevant code lives in each.
+allowed-tools: Task, WebSearch, WebFetch, Read, Grep, Glob, Bash
+---
+
+# Bot Research
+
+This skill is the standing knowledge base for building the **LLM-driven Diplomacy
+bot** for diplicity. The aim of the bot is **to be fun to play against**, not to be
+maximally strong — almost all prior art optimises for strength, so its machinery is
+reusable but its goal is not ours. Keep that distinction in mind when reading anything
+linked here.
+
+It exists so that recurring research questions ("how does Cicero ground dialogue?",
+"what does Every's diary look like?", "how do we measure play quality?") can be
+answered by reading a known source rather than re-discovering it from scratch.
+
+## When to use this
+
+- Studying how an existing project (Cicero, Every's AI_Diplomacy, etc.) structures its
+  code — which files to open and what each one does.
+- Looking for prior art on a specific bot design question (evals, negotiation timing,
+  board representation, trust/memory, baseline bots).
+- Kicking off a new round of deeper research on any of these topics.
+
+## Index
+
+- **[resources.md](./resources.md)** — annotated catalogue of every project and paper,
+  with URLs, what each is good for, and **the specific files to read** inside the
+  open-source repos. Start here for "where do I look for X".
+
+## How to do a round of bot research
+
+The catalogue was built by fanning out parallel research agents, one per topic. Repeat
+that pattern for new questions:
+
+1. Scope each question tightly and give one agent per topic (`Task`, `general-purpose`,
+   run in background for concurrency).
+2. Tell each agent to **fetch primary sources directly** (the repo code and model
+   cards, the paper PDFs), **cross-check** claims across sources, and **tag confidence**
+   (fact / inference / speculation).
+3. Have each agent **write a cited markdown report** to a scratch dir and return a short
+   summary. Fold durable findings back into `resources.md` / `findings.md` here.
+
+### Egress caveat (important)
+
+In cloud sessions the proxy frequently **blocks `arxiv.org`, `science.org`,
+`ai.meta.com`, and `aclanthology.org`** (403), while **`github.com` and
+`raw.githubusercontent.com` are reachable**. So:
+
+- Prefer reading the **open-source repo code and model cards** — they are reachable and
+  are the highest-confidence source anyway.
+- Any figure quoted from a *blocked* paper (e.g. Cicero's league results, Richelieu /
+  DipLLM win rates) currently comes from **search snippets, not primary text** — treat
+  those numbers as unverified and re-check before quoting externally.
+- To try to unblock a host, see `/root/.ccr/README.md` and
+  `curl -sS "$HTTPS_PROXY/__agentproxy/status"` for per-tool fixes. Never disable TLS
+  verification.
+
+## Our own bot code
+
+Don't forget the code already in this repo — it is the most relevant resource of all:
+
+- `service/bot/llm.py` — already implements **per-unit, index-constrained selection
+  from engine-computed legal moves** (illegal moves impossible by construction; fully
+  variant-agnostic). This is the orders core other projects converge on.
+- `NationView` (`service/adjudicator/types.py`) — already computes the per-nation board
+  context the bot needs as prompt input.
+
+(Paths verified at time of writing; re-check with `grep`/`glob` if the bot app moves.)

--- a/.claude/skills/bot-research/resources.md
+++ b/.claude/skills/bot-research/resources.md
@@ -1,0 +1,144 @@
+# Bot Research — Resource Catalogue
+
+Annotated index of prior art for the LLM Diplomacy bot. Grouped by the question it
+helps answer. For each open-source project, the **files worth opening** are listed so a
+code-structure study can go straight to the relevant code.
+
+> Confidence: repo code and model cards were read directly and are high-confidence.
+> Figures from papers on blocked hosts (arxiv / science / meta / aclanthology) are
+> snippet-sourced — see the egress caveat in `SKILL.md` and re-verify before quoting.
+
+---
+
+## The two reference implementations (read these first)
+
+### Cicero — `facebookresearch/diplomacy_cicero`
+Meta's human-level Diplomacy agent. **Not** our architecture (classical-map-only
+training, an RL planner rather than a general LLM), but the source of the
+plan-then-speak, draft-then-filter, and when-to-speak ideas. Best for: dialogue
+grounding, message filtering, chattiness control.
+
+Files to open:
+- `fairdiplomacy/pseudo_orders.py` — the "intent" representation (`PseudoOrders` /
+  `JointAction`): a structured per-power set of intended orders, generated *before* prose.
+- `fairdiplomacy/agents/parlai_message_handler.py` — the **sleep gate** (when/whom to
+  message, per-recipient; `INF` = stay silent; separate initiate-vs-reply thresholds),
+  pseudo-order caching, and filter orchestration.
+- `parlai_diplomacy/utils/game2seq/format_helpers/message_editing.py` —
+  `MessageFiltering` / `FilterReasons`: the generate-then-filter battery (grounding /
+  consistency / nonsense / toxicity).
+- `fairdiplomacy/agents/br_corr_bilateral_search.py` — the strategic planner.
+- `fairdiplomacy/annotate/lie_detection.py` — broken-commitment / honesty annotation
+  (communicated intent vs final action).
+- `model_cards/` — `imitation_intent.md`, `dialogue.md`, `sleep_classifier.md`,
+  `nonsense_ensemble/README.md`. The model cards state the designs plainly and are the
+  most reachable, highest-signal read.
+
+Papers (often blocked — snippet-sourced figures): Science 2022,
+`https://www.science.org/doi/10.1126/science.ade9097`; TR PDF
+`https://noambrown.github.io/papers/22-Science-Diplomacy-TR.pdf`.
+
+### Every's AI_Diplomacy — `EveryInc/AI_Diplomacy` (also `Alx-AI/AI_Diplomacy`)
+Off-the-shelf prompted LLMs that negotiate in chat and emit engine-validated legal
+orders, no fine-tuning. **This is the closest existing implementation of our design** —
+the best starting point for code structure. Backed the 2025 frontier-model tournament
+(Twitch + GoodStartLabs leaderboard).
+
+What it contains (confirm exact paths in-repo):
+- BFS-pathfinding board context (its answer to board representation).
+- Multi-round private + global negotiation.
+- A three-tier per-power **diary** with **yearly summarization** (= our "consolidate"
+  phase).
+- A 5-level **Enemy↔Ally trust scale** (= the trust registry).
+- Order validation against the `diplomacy` engine's `get_all_possible_orders()`.
+
+---
+
+## Q: How do we measure quality of play? (evals)
+
+- **Sum-of-Squares game score** — outcome metric; an equal-skill agent baselines at
+  **1/7 ≈ 14%** board share. Use share-of-board, not win-rate (outright wins are rare).
+- **Frozen-baseline self-play** — 1v6 / 6v1 against DumbBot or DipNet; the standard
+  cheap comparison. (DumbBot source below.)
+- **TrueSkill / Elo pools** for ranking many variants (watch the league "flat Elo" trap
+  — keep a frozen suite).
+- **Normalized-rank-among-top-N** (our idea) — sound, effectively unpublished for
+  Diplomacy; precedent is **ChessBench Action-Ranking** (Kendall's τ vs. engine). Do it
+  **per-unit** (joint action space ~10²⁰).
+- **Maia** chess work — evidence that move-matching accuracy is **decoupled from**
+  strength; don't optimise "matches best/human move".
+- **SPIN-Bench** — LLM-judge rubric for negotiation quality.
+- **Landmine:** the **webDiplomacy / DipNet corpus (~156k games)** license **forbids
+  training website-deployed bots** — conflicts with our use case. Offline eval only, or
+  self-generated labels.
+
+## Q: How does a phase work?
+
+See Cicero above (`pseudo_orders.py`, `parlai_message_handler.py`,
+`br_corr_bilateral_search.py`): structured intent first, prose conditioned on it,
+**continuous re-planning** around each message, final orders at the deadline.
+
+## Q: How do we represent the board / how much do we help the LLM?
+
+- **"Democratizing Diplomacy: A Harness for Evaluating Any LLM on Full-Press
+  Diplomacy"** — arXiv 2508.07485. Data-driven *textual* board representation that lets
+  any off-the-shelf LLM play full-press with no fine-tuning. Most relevant to our
+  variant-agnostic, no-training constraint.
+- **DipLLM** (ICML 2025) — fine-tunes; **no-press only**; transferable gem is **per-unit
+  autoregressive order selection** (mirrors our `bot/llm.py`).
+- **DAIDE press language** — a proven, variant-agnostic **commitment ontology**
+  (`PRP`, `ALY/VSS`, `DMZ`, `XDO`, `PCE`, `DRW`, …) for a structured-commitments chat
+  side-channel.
+- **godip** (diplicity's engine) exposes legal orders as a recursive
+  `Options map[OptionValue]Options` tree; diplicity flattens it into indexed legal
+  options — what `bot/llm.py` selects from.
+- ML feature tensors (DipNet / Cicero strategic core) are per-province and map-specific
+  — useful only as a checklist of which facts matter, not as a representation to copy.
+
+## Q: When / how should the bot talk?
+
+- **Cicero** `sleep_classifier.md` + `parlai_message_handler.py` — first-class "stay
+  silent" action, per-recipient gate, separate initiate-vs-reply thresholds.
+- **Cicero** `message_editing.py` (`MessageFiltering`) — draft → check → send/resample.
+- **ReCon — "Avalon's Game of Thoughts"** — ACL Findings 2024, arXiv 2310.01320, code
+  `github.com/Shenzhi-Wang/recon`. Draft→self-critique loop with explicit 1st/2nd-order
+  theory-of-mind (what does X believe about the board / about me?).
+- Per-recipient intents = the deception/persuasion lever (Cicero conditions prose on a
+  per-pair intent; the gap between *claimed* and *actual* intent is the deception dial).
+
+## Q: How does the bot remember betrayal? (memory / journal)
+
+- **Every's diary + trust scale** (above) — the working reference: per-player trust
+  level + promise-vs-action checks + yearly summarization.
+- **"Trust, Lies, and Long Memories"** (Multi-Round Avalon) — arXiv 2604.20582.
+  Reputation emerges from cross-game memory; strong agents build trust early to spend it
+  on a late betrayal ("trust as a resource").
+- **WOLF** — arXiv 2512.09187. LLMs deceive well but **detect deception poorly** → the
+  bot needs explicit help noticing it's being lied to.
+- Honesty/broken-commitment definition: compare communicated intent to final action
+  (Cicero `lie_detection.py`; the ACL follow-up below formalises it).
+
+## Q: Baseline opponents (eval floor/ceiling + fallback)
+
+- **DumbBot** — source + exact tuning constants in `github.com/diplomacy/daide-client`.
+  Two-stage: value every province (supply-centre worth + proximity diffusion over the
+  adjacency graph), then greedily assign each unit to its best reachable destination.
+  Adjacency-driven, so it ports to variants. Reimplementable in ~1–3 days; serves as
+  **both** the deterministic fallback and the frozen eval floor.
+- **Albert** (van Hal) — strongest classic bot; **closed-source Windows binary**;
+  best-reply search + opponent modelling. Eval *ceiling* only; wire in later via the
+  `diplomacy` Python package's **DAIDE adapter** (which runs Albert/DumbBot).
+
+## Other LLM-Diplomacy agents & negotiation research
+
+- **Richelieu** (NeurIPS 2024) — LLM agent with planning + social reasoning + self-play;
+  reportedly matches Cicero without human data (figure snippet-sourced).
+- **Welfare Diplomacy** — variant + finding: honest/cooperative bots are exploitable
+  (relevant to the fun objective — exploitable-but-characterful may be a feature).
+- **"More Victories, Less Cooperation: Assessing Cicero's Diplomacy Play"** — ACL 2024,
+  arXiv 2406.04643. Defines reusable, human-rater-free metrics computable from logs:
+  **broken-commitment rate** and **persuasion success**.
+- Negotiation/deception/ToM: "Werewolf agent that does not truly trust LLMs"
+  (arXiv 2409.01575); MultiMind (arXiv 2504.18039); "Cheap Talk, Empty Promise"
+  (arXiv 2604.04782); NegotiationToM (arXiv 2404.13627); TERMS-BENCH (arXiv 2605.13909).
+- Survey index: `github.com/git-disl/awesome-LLM-game-agent-papers`.


### PR DESCRIPTION
## What this PR does

Adds a `bot-research` Claude Code skill: a standing knowledge base for building the LLM-driven Diplomacy bot, so recurring research questions can be answered by reading a known source rather than re-discovering prior art each time. Distilled from a round of parallel research into how existing Diplomacy / LLM-agent projects are built.

The skill (`.claude/skills/bot-research/`) contains:

- **`SKILL.md`** — when to use it, a research playbook (the parallel-agent fan-out pattern, plus the cloud egress caveat that arxiv/science/meta are often proxy-blocked while GitHub is reachable), and pointers to this repo's own bot code (`service/bot/llm.py`, `NationView` in `service/adjudicator/types.py`).
- **`resources.md`** — an annotated catalogue of prior art grouped by design question (evals, the phase loop, board representation, when/how the bot talks, memory/trust, baseline opponents), with URLs and **the specific files to open** inside the Cicero (`facebookresearch/diplomacy_cicero`) and Every (`EveryInc/AI_Diplomacy`) repos so future code-structure studies go straight to the relevant code.

Documentation only — no application code, no API changes.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — N/A, docs-only skill addition
- [ ] Tests cover the change — N/A, no code
- [x] Screenshots embedded in the PR description for any visual changes — N/A, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBaBh2bbfuEs68tExaTYxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBaBh2bbfuEs68tExaTYxJ)_