### PR TITLE
Heal stale-chunk failures that resolve a lazy import to undefined

### DIFF
--- a/packages/web/src/screens/GameDetail/index.ts
+++ b/packages/web/src/screens/GameDetail/index.ts
@@ -1,42 +1,32 @@
-import { lazy } from "react";
+import { lazyScreen } from "../../utils/lazyScreen";
 
 export const GameDetail = {
-  MapScreen: lazy(() =>
-    import("./MapScreen").then((m) => ({ default: m.MapScreen }))
+  MapScreen: lazyScreen(() => import("./MapScreen"), "MapScreen"),
+  OrdersScreen: lazyScreen(() => import("./OrdersScreen"), "OrdersScreen"),
+  ChannelListScreen: lazyScreen(
+    () => import("./ChannelListScreen"),
+    "ChannelListScreen"
   ),
-  OrdersScreen: lazy(() =>
-    import("./OrdersScreen").then((m) => ({ default: m.OrdersScreen }))
+  ChannelCreateScreen: lazyScreen(
+    () => import("./ChannelCreateScreen"),
+    "ChannelCreateScreen"
   ),
-  ChannelListScreen: lazy(() =>
-    import("./ChannelListScreen").then((m) => ({ default: m.ChannelListScreen }))
+  ChannelScreen: lazyScreen(() => import("./ChannelScreen"), "ChannelScreen"),
+  GameInfoScreen: lazyScreen(() => import("./GameInfoScreen"), "GameInfoScreen"),
+  PlayerInfoScreen: lazyScreen(
+    () => import("./PlayerInfoScreen"),
+    "PlayerInfoScreen"
   ),
-  ChannelCreateScreen: lazy(() =>
-    import("./ChannelCreateScreen").then((m) => ({
-      default: m.ChannelCreateScreen,
-    }))
+  ProposeDrawScreen: lazyScreen(
+    () => import("./ProposeDrawScreen"),
+    "ProposeDrawScreen"
   ),
-  ChannelScreen: lazy(() =>
-    import("./ChannelScreen").then((m) => ({ default: m.ChannelScreen }))
+  DrawProposalsScreen: lazyScreen(
+    () => import("./DrawProposalsScreen"),
+    "DrawProposalsScreen"
   ),
-  GameInfoScreen: lazy(() =>
-    import("./GameInfoScreen").then((m) => ({ default: m.GameInfoScreen }))
-  ),
-  PlayerInfoScreen: lazy(() =>
-    import("./PlayerInfoScreen").then((m) => ({ default: m.PlayerInfoScreen }))
-  ),
-  ProposeDrawScreen: lazy(() =>
-    import("./ProposeDrawScreen").then((m) => ({
-      default: m.ProposeDrawScreen,
-    }))
-  ),
-  DrawProposalsScreen: lazy(() =>
-    import("./DrawProposalsScreen").then((m) => ({
-      default: m.DrawProposalsScreen,
-    }))
-  ),
-  PlayerProfileScreen: lazy(() =>
-    import("./PlayerProfileScreen").then((m) => ({
-      default: m.PlayerProfileScreen,
-    }))
+  PlayerProfileScreen: lazyScreen(
+    () => import("./PlayerProfileScreen"),
+    "PlayerProfileScreen"
   ),
 };

--- a/packages/web/src/screens/Home/index.ts
+++ b/packages/web/src/screens/Home/index.ts
@@ -1,34 +1,17 @@
-import { lazy } from "react";
+import { lazyScreen } from "../../utils/lazyScreen";
 
 export const Home = {
-  MyGames: lazy(() => import("./MyGames").then((m) => ({ default: m.MyGames }))),
-  FindGames: lazy(() =>
-    import("./FindGames").then((m) => ({ default: m.FindGames }))
-  ),
-  CreateGame: lazy(() =>
-    import("./CreateGame").then((m) => ({ default: m.CreateGame }))
-  ),
-  Account: lazy(() =>
-    import("./Account").then((m) => ({ default: m.Account }))
-  ),
-  GameInfoScreen: lazy(() =>
-    import("./GameInfo").then((m) => ({ default: m.GameInfoScreen }))
-  ),
-  PlayerInfoScreen: lazy(() =>
-    import("./PlayerInfo").then((m) => ({ default: m.PlayerInfoScreen }))
-  ),
-  Community: lazy(() =>
-    import("./Community").then((m) => ({ default: m.Community }))
-  ),
-  DeleteAccount: lazy(() =>
-    import("./DeleteAccount").then((m) => ({ default: m.DeleteAccount }))
-  ),
-  LearnToPlay: lazy(() =>
-    import("./LearnToPlay").then((m) => ({ default: m.LearnToPlay }))
-  ),
-  PlayerProfileScreen: lazy(() =>
-    import("./PlayerProfile").then((m) => ({
-      default: m.PlayerProfileScreen,
-    }))
+  MyGames: lazyScreen(() => import("./MyGames"), "MyGames"),
+  FindGames: lazyScreen(() => import("./FindGames"), "FindGames"),
+  CreateGame: lazyScreen(() => import("./CreateGame"), "CreateGame"),
+  Account: lazyScreen(() => import("./Account"), "Account"),
+  GameInfoScreen: lazyScreen(() => import("./GameInfo"), "GameInfoScreen"),
+  PlayerInfoScreen: lazyScreen(() => import("./PlayerInfo"), "PlayerInfoScreen"),
+  Community: lazyScreen(() => import("./Community"), "Community"),
+  DeleteAccount: lazyScreen(() => import("./DeleteAccount"), "DeleteAccount"),
+  LearnToPlay: lazyScreen(() => import("./LearnToPlay"), "LearnToPlay"),
+  PlayerProfileScreen: lazyScreen(
+    () => import("./PlayerProfile"),
+    "PlayerProfileScreen"
   ),
 };

--- a/packages/web/src/utils/lazyScreen.test.ts
+++ b/packages/web/src/utils/lazyScreen.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ComponentType } from "react";
+
+const reloadForStaleChunk = vi.fn();
+
+vi.mock("./staleChunk", () => ({
+  reloadForStaleChunk: () => reloadForStaleChunk(),
+  isStaleChunkError: (error: unknown) =>
+    error instanceof Error && error.message.includes("dynamically imported"),
+}));
+
+import { resolveScreenModule } from "./lazyScreen";
+
+const Screen: ComponentType = () => null;
+
+describe("resolveScreenModule", () => {
+  beforeEach(() => {
+    reloadForStaleChunk.mockClear();
+  });
+
+  it("returns the named export when the module loads", async () => {
+    const result = await resolveScreenModule(
+      () => Promise.resolve({ Screen }),
+      "Screen"
+    );
+
+    expect(result.default).toBe(Screen);
+    expect(reloadForStaleChunk).not.toHaveBeenCalled();
+  });
+
+  it("reloads when the module resolves to undefined (WebKit/Android stale chunk)", async () => {
+    const result = await resolveScreenModule(
+      () => Promise.resolve(undefined as unknown as { Screen: ComponentType }),
+      "Screen"
+    );
+
+    expect(reloadForStaleChunk).toHaveBeenCalledOnce();
+    expect(result.default).toBeTypeOf("function");
+  });
+
+  it("reloads when the named export is missing", async () => {
+    const result = await resolveScreenModule(
+      () =>
+        Promise.resolve({} as unknown as { Screen: ComponentType }),
+      "Screen"
+    );
+
+    expect(reloadForStaleChunk).toHaveBeenCalledOnce();
+    expect(result.default).toBeTypeOf("function");
+  });
+
+  it("reloads when the import rejects with a stale-chunk error", async () => {
+    const result = await resolveScreenModule(
+      () =>
+        Promise.reject(
+          new Error("Failed to fetch dynamically imported module")
+        ) as Promise<{ Screen: ComponentType }>,
+      "Screen"
+    );
+
+    expect(reloadForStaleChunk).toHaveBeenCalledOnce();
+    expect(result.default).toBeTypeOf("function");
+  });
+
+  it("rethrows errors that are not stale-chunk errors", async () => {
+    await expect(
+      resolveScreenModule(
+        () => Promise.reject(new Error("a real bug")) as Promise<{
+          Screen: ComponentType;
+        }>,
+        "Screen"
+      )
+    ).rejects.toThrow("a real bug");
+    expect(reloadForStaleChunk).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/utils/lazyScreen.ts
+++ b/packages/web/src/utils/lazyScreen.ts
@@ -1,0 +1,46 @@
+import { lazy } from "react";
+import type { ComponentType } from "react";
+import { isStaleChunkError, reloadForStaleChunk } from "./staleChunk";
+
+// Rendered for the instant before reloadForStaleChunk() navigates to the fresh
+// deploy, instead of crashing into the error boundary.
+const StaleChunkFallback: ComponentType = () => null;
+
+// Resolves a screen's lazy module, healing the stale-chunk failure modes that
+// the global `vite:preloadError` handler misses. On WebKit (Safari) and some
+// Android Chrome builds, a dynamic import for a chunk that no longer exists
+// after a deploy neither fires `vite:preloadError` nor rejects with a known
+// message — it resolves to `undefined`, so `module.ScreenName` throws a
+// TypeError ("undefined is not an object (evaluating 't.PlayerInfoScreen')")
+// that lands in the error boundary and Sentry. Here we detect the undefined
+// module / missing export and the known rejection messages, and reload to the
+// latest deploy instead. reloadForStaleChunk() debounces via sessionStorage,
+// so this cannot loop.
+export const resolveScreenModule = async <
+  K extends string,
+  M extends Record<K, ComponentType>,
+>(
+  factory: () => Promise<M>,
+  name: K
+): Promise<{ default: ComponentType }> => {
+  try {
+    const module: M | undefined = await factory();
+    const component = module?.[name];
+    if (!component) {
+      reloadForStaleChunk();
+      return { default: StaleChunkFallback };
+    }
+    return { default: component };
+  } catch (error) {
+    if (isStaleChunkError(error)) {
+      reloadForStaleChunk();
+      return { default: StaleChunkFallback };
+    }
+    throw error;
+  }
+};
+
+export const lazyScreen = <K extends string, M extends Record<K, ComponentType>>(
+  factory: () => Promise<M>,
+  name: K
+) => lazy(() => resolveScreenModule(factory, name));


### PR DESCRIPTION
## What this PR does

Fixes a class of post-deploy crashes seen in Sentry on Safari/Android (e.g. `TypeError: undefined is not an object (evaluating 't.PlayerInfoScreen')` on `/player-info/...`, `Cannot read properties of undefined (reading 'ChannelListScreen')` on `/game/.../chat`).

**Root cause:** after a deploy, a user still running the previous `index.html` requests chunk filenames that the new build re-hashed and no longer exist. On most browsers Vite fires `vite:preloadError`, which `main.tsx` already handles by calling `reloadForStaleChunk()`. But on **WebKit (Safari) and some Android Chrome builds**, the failed dynamic import neither fires that event nor rejects with a known message — it resolves to **`undefined`**. The screen barrels then run `module.PlayerInfoScreen` on `undefined`, throwing a `TypeError` that slips past the existing handler and lands in the error boundary + Sentry. This is why it couldn't be reproduced locally (you have to span a deploy with a stale tab) and why it looked OS-specific (the undefined-module behaviour is WebKit/Android-specific).

This is a pre-existing gap in the stale-chunk handling, surfaced — like after any deploy — by a recent merge. It is unrelated to the screens involved (player-info, chat are not where the deploy churn originated).

**The fix:** a `lazyScreen` helper wraps the screen lazy-imports and heals the failure modes the global handler misses — when the resolved module or its named export is `undefined`, or the import rejects with a known stale-chunk message, it calls the existing debounced `reloadForStaleChunk()` (10s `sessionStorage` guard, so no reload loops) and renders nothing for the instant before the reload, instead of crashing. The `Home` and `GameDetail` screen barrels are converted to it.

### Changes
- `src/utils/lazyScreen.ts` (new) — `lazyScreen` / `resolveScreenModule`, reusing the existing `isStaleChunkError` + `reloadForStaleChunk` from `utils/staleChunk.ts`.
- `src/utils/lazyScreen.test.ts` (new) — covers the undefined-module, missing-export, stale-reject, happy-path, and rethrow-real-error cases.
- `src/screens/Home/index.ts`, `src/screens/GameDetail/index.ts` — converted from `lazy(() => import(...).then(m => ({ default: m.X })))` to `lazyScreen(() => import(...), "X")`.

Out of scope: the backend `postgres.railway.internal` DNS errors (Railway infra) and the Instagram in-app-browser noise (`iabjs://...`) reported in the same Sentry digest are not code issues. `Router.tsx`'s `CardGallery` lazy (a dev-only default-export route) is left unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual changes (error-recovery behaviour only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhHRRtTsAFTiwg9bRh74MG)_