### PR TITLE
Fix GameCard height and desktop padding

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -283,7 +283,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
         {map}
       </button>
 
-      <div className="flex flex-col flex-grow gap-2 p-4 min-w-0">
+      <div className="flex flex-col flex-grow gap-2 p-4 md:py-2 min-w-0">
         <CardHeader className="p-0 gap-2">
           <div className="flex items-center justify-between gap-2">
             <button
@@ -345,10 +345,8 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
 
         {(game.sandbox || isActive || isFinished) && badgeCluster}
 
-        <div className="flex-grow" />
-
         {showAvatars && (
-          <CardFooter className="p-0 flex-col items-stretch gap-2">
+          <CardFooter className="p-0 mt-auto flex-col items-stretch gap-2">
             <div className="flex items-center justify-between gap-2">
               <button
                 onClick={handleClickPlayerInfo}


### PR DESCRIPTION
## What this PR does

The `GameCard` content column rendered an empty `<div class="flex-grow" />` spacer between the badge cluster and the footer. Combined with the column's `gap-2`, this added two redundant 8px gaps and forced extra vertical height. This replaces the spacer by pushing the footer down with `mt-auto`, and reduces the desktop content padding from 16px to 8px 16px (`p-4 md:py-2`). Mobile padding is unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

### Screenshots (desktop, "Started" games)

Before — note the empty space below the avatars and taller cards:

![before](https://raw.githubusercontent.com/johnpooch/diplicity-react/fbca78335902685df04436da73a7efed78c3e616/shots/before-desktop.png)

After — compact cards, tighter top padding, footer pinned to the bottom:

![after](https://raw.githubusercontent.com/johnpooch/diplicity-react/fbca78335902685df04436da73a7efed78c3e616/shots/after-desktop.png)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb1pF37BTptUBDXjnGQEya)_