### PR TITLE
Allow anonymous read access to variant list and phase retrieve

### DIFF
--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -772,6 +772,7 @@ paths:
       - game
       security:
       - jwtAuth: []
+      - {}
       responses:
         '200':
           content:
@@ -1381,6 +1382,7 @@ paths:
       - variants
       security:
       - jwtAuth: []
+      - {}
       responses:
         '200':
           content:

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -1524,7 +1524,8 @@ class TestPhaseRetrieveView:
         phase = game.current_phase
         url = reverse("phase-retrieve", args=[game.id, phase.id])
         response = unauthenticated_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["id"] == phase.id
 
     @pytest.mark.django_db
     def test_retrieve_phase_not_found(self, authenticated_client, active_game_with_phase_state):

--- a/service/phase/views.py
+++ b/service/phase/views.py
@@ -92,7 +92,7 @@ class PhaseListView(SelectedGameMixin, generics.ListAPIView):
 
 
 class PhaseRetrieveView(generics.RetrieveAPIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
     serializer_class = PhaseRetrieveSerializer
     lookup_field = 'id'
     lookup_url_kwarg = 'phase_id'

--- a/service/variant/models.py
+++ b/service/variant/models.py
@@ -34,6 +34,8 @@ def default_phase_progression():
 class VariantQuerySet(models.QuerySet):
 
     def visible_to(self, user):
+        if not user.is_authenticated:
+            return self.filter(status=VariantStatus.PUBLISHED)
         return self.filter(
             Q(status=VariantStatus.PUBLISHED)
             | Q(status=VariantStatus.DRAFT, owner=user)

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -55,10 +55,17 @@ def test_list_variants_success(authenticated_client, classical_variant):
 
 
 @pytest.mark.django_db
-def test_list_variants_unauthenticated(unauthenticated_client):
+def test_list_variants_unauthenticated(unauthenticated_client, classical_variant, user_factory):
+    draft_variant = Variant.objects.create(
+        id="vis-draft", name="Visibility Draft", description="",
+        status=VariantStatus.DRAFT, owner=user_factory(),
+    )
     url = reverse(viewname)
     response = unauthenticated_client.get(url)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_200_OK
+    ids = {v["id"] for v in response.data}
+    assert classical_variant.id in ids
+    assert draft_variant.id not in ids
 
 
 @pytest.mark.django_db

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse, HttpResponseNotFound
 from django.views import View
 from rest_framework import generics, permissions, status
 from rest_framework.parsers import MultiPartParser
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from common.constants import VariantStatus
@@ -47,8 +47,12 @@ def _variants_list_etag(user):
 
 
 class VariantListCreateView(generics.ListCreateAPIView):
-    permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser]
+
+    def get_permissions(self):
+        if self.request.method == "POST":
+            return [IsAuthenticated()]
+        return [AllowAny()]
 
     def get_queryset(self):
         return Variant.objects.visible_to(self.request.user).with_related_data()


### PR DESCRIPTION
## What this PR does

Opens two read-only endpoints to unauthenticated users so the upcoming logged-out web experience (Find Games landing + pending Game Info) can render without auth. This is the backend prerequisite; the frontend logged-out shell will follow in a separate PR.

- **`VariantListCreateView`**: GET (list) is now `AllowAny`; POST (create) stays `IsAuthenticated` via a `get_permissions()` override. `VariantQuerySet.visible_to` returns only **published** variants for anonymous users, so drafts and members-only variants stay hidden. (Needed because `FindGames` and the Game Info screen fetch the variant list for card maps, the variant filter, and metadata.)
- **`PhaseRetrieveView`**: now `AllowAny`. `PhaseRetrieveSerializer` exposes only board state (units, supply centers, province ownership, phase metadata) — no per-user fields — so nothing user-specific is leaked. Per-user order/phase-state data lives in a separate `IsAuthenticated` view and is unaffected. This also lays groundwork for a future spectator mode on the game detail screen.

Game list and game retrieve were already `AllowAny` with every user-dependent serializer field guarded, so no change was needed there.

The OpenAPI schema is regenerated, adding the `- {}` (no-auth-allowed) security option to the two affected operations. No change to the generated TypeScript client, since per-operation security is not encoded in the orval hooks.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only, no visual changes

### Tests

Updated the two existing unauthenticated tests to assert the new behavior and verified the create endpoint stays protected:

- `variant/tests.py::test_list_variants_unauthenticated` — now asserts `200`, published variant present, draft hidden.
- `variant/tests/test_variant_crud.py::test_create_variant_unauthenticated` — still asserts `401` for POST (unchanged, now exercises the `get_permissions` split).
- `phase/tests.py::TestPhaseRetrieveView::test_retrieve_phase_unauthenticated` — now asserts `200` with the phase payload.

Full `variant` and `phase` retrieve suites pass (60 tests), and `manage.py check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmzcTGbL5y2XyVZ2odfnQs)_