### PR TITLE
Wait for migrations before starting the procrastinate worker

### DIFF
--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -7,6 +7,16 @@ PROCESS_ROLE="${PROCESS_ROLE:-web}"
 echo "Starting entrypoint script (role: $PROCESS_ROLE)..."
 
 if [ "$PROCESS_ROLE" = "worker" ]; then
+    echo "Waiting for migrations to complete before starting Procrastinate worker..."
+    attempt=0
+    until python manage.py migrate --check; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge 60 ]; then
+            echo "Timed out waiting for migrations to complete." >&2
+            exit 1
+        fi
+        sleep 5
+    done
     echo "Starting Procrastinate worker..."
     exec python manage.py procrastinate worker
 fi


### PR DESCRIPTION
Closes #942

## What broke

Sentry [DIPLICITY-API-8D](https://johnpooch.sentry.io/issues/DIPLICITY-API-8D): `ProgrammingError: column variant_variant.dominance_rules does not exist`, raised from `phase.sweep_due_phases` (the procrastinate worker), culprit `phase/models.py:122` in `get_phases_to_resolve`. 9 occurrences over 26 days. This is a regression of #737, which had closed this issue as "no code change needed" after verifying via pgweb that migration `variant/0021_add_dominance_rules` was applied and the column exists in production — a correct but incomplete diagnosis, since the errors continued recurring afterward (most recently 2026-06-30).

## Root cause

`service/entrypoint.sh`'s `worker` role starts the procrastinate worker immediately with no migration step — only the `web` role runs `manage.py migrate` before starting Gunicorn. On deploy, the new worker container (already running code referencing new model fields) can start querying the database while the web container's `migrate` is still in flight, producing a transient "column does not exist" error for whatever field the in-progress migration touches.

**Evidence pinning this to a race rather than a permanently missing column:** a sibling event in the same Sentry issue group, `column game_game.created_by_id does not exist`, fired at `2026-06-12T22:10:00Z` — exactly **one second before** migration `game/0016_game_created_by` completed in production (`2026-06-12T22:10:01.613365Z`, per `django_migrations`, verified via pgweb). The column exists in production today; the errors were all transient deploy-window races, not missing schema.

This affects both production and PR staging deploys, since both share `entrypoint.sh`.

## The fix

The worker entrypoint now polls `manage.py migrate --check` (bounded to 60 attempts, 5s apart = 5 minutes) before starting the procrastinate worker, so it never queries the database mid-migration.

## Test plan

- [x] `sh -n service/entrypoint.sh` — shell syntax check passes
- [x] Manually exercised the wait loop against the local fully-migrated database — passes immediately with 0 retries
- No application code changed (shell script only); no relevant Python/TS test suite applies

No visual changes — this is a deployment/infrastructure fix with no user-facing surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MUrJvVqzXejwQ44xEGXLrv)_