### PR TITLE
Add BotProfile model and identify bots via attribute check

### DIFF
--- a/service/bot/constants.py
+++ b/service/bot/constants.py
@@ -1,3 +1,2 @@
-BOT_USER_EMAIL = "bot@diplicity.com"
 BOT_USER_USERNAME = "diplicitybot"
 BOT_USER_NAME = "Diplicity Bot"

--- a/service/bot/decorators.py
+++ b/service/bot/decorators.py
@@ -57,8 +57,7 @@ def on_public_chat_message(func):
             return
         if instance.channel.private:
             return
-        message_sender = instance.sender
-        if message_sender.user is not None and hasattr(message_sender.user, "bot_profile"):
+        if Member.objects.filter(pk=instance.sender_id, user__bot_profile__isnull=False).exists():
             return
         return func(sender=sender, instance=instance, created=created, **kwargs)
 

--- a/service/bot/decorators.py
+++ b/service/bot/decorators.py
@@ -4,15 +4,13 @@ from common.constants import PhaseStatus
 from member.models import Member
 from phase.models import Phase
 
-from bot.constants import BOT_USER_EMAIL
-
 _previous_phase_status = {}
 
 
 def _bot_user_ids_for_phase(phase_id):
     return set(
         Member.objects.filter(
-            game__phases=phase_id, user__email=BOT_USER_EMAIL
+            game__phases=phase_id, user__bot_profile__isnull=False
         ).values_list("user_id", flat=True)
     )
 
@@ -42,7 +40,7 @@ def with_bot_members(func):
     def wrapper(sender, instance, **kwargs):
         bot_members = list(
             Member.objects.filter(
-                game_id=instance.game_id, user__email=BOT_USER_EMAIL
+                game_id=instance.game_id, user__bot_profile__isnull=False
             ).select_related("user")
         )
         if not bot_members:
@@ -60,7 +58,7 @@ def on_public_chat_message(func):
         if instance.channel.private:
             return
         message_sender = instance.sender
-        if message_sender.user is not None and message_sender.user.email == BOT_USER_EMAIL:
+        if message_sender.user is not None and hasattr(message_sender.user, "bot_profile"):
             return
         return func(sender=sender, instance=instance, created=created, **kwargs)
 
@@ -71,7 +69,9 @@ def with_bot_channel_members(func):
     @functools.wraps(func)
     def wrapper(sender, instance, **kwargs):
         bot_members = list(
-            instance.channel.members.filter(user__email=BOT_USER_EMAIL).select_related("user")
+            instance.channel.members.filter(
+                user__bot_profile__isnull=False
+            ).select_related("user")
         )
         if not bot_members:
             return

--- a/service/bot/migrations/0002_create_bot_profile.py
+++ b/service/bot/migrations/0002_create_bot_profile.py
@@ -1,0 +1,55 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+BOT_USER_EMAIL = "bot@diplicity.com"
+BOT_DISPOSITION = "Balanced and pragmatic; willing to ally or betray as the board demands."
+BOT_VOICE = "Plain and direct."
+
+
+def create_bot_profile(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    BotProfile = apps.get_model("bot", "BotProfile")
+
+    user = User.objects.filter(email=BOT_USER_EMAIL).first()
+    if user is None:
+        return
+    BotProfile.objects.get_or_create(
+        user=user,
+        defaults={"disposition": BOT_DISPOSITION, "voice": BOT_VOICE},
+    )
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ("bot", "0001_create_bot_user"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="BotProfile",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("disposition", models.TextField()),
+                ("voice", models.TextField()),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="bot_profile",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.RunPython(create_bot_profile, migrations.RunPython.noop),
+    ]

--- a/service/bot/models.py
+++ b/service/bot/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+from common.models import BaseModel
+
+
+class BotProfileQuerySet(models.QuerySet):
+    def with_related_data(self):
+        return self.select_related("user")
+
+
+class BotProfileManager(models.Manager):
+    def get_queryset(self):
+        return BotProfileQuerySet(self.model, using=self._db)
+
+    def with_related_data(self):
+        return self.get_queryset().with_related_data()
+
+
+class BotProfile(BaseModel):
+    objects = BotProfileManager()
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="bot_profile")
+    disposition = models.TextField()
+    voice = models.TextField()

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -15,7 +15,7 @@ from common.constants import (
 )
 from channel.models import ChannelMessage
 from game.models import Game
-from bot import tasks, utils
+from bot import decorators, tasks, utils
 from bot.context.builder import ContextBuilder
 from bot.context.orders import first_legal_selections, option_to_selected
 from bot.context.parsers import parse_order_selections, parse_reply
@@ -407,6 +407,28 @@ class TestBotRequestHost:
     def test_falls_back_to_testserver_for_wildcard(self, settings):
         settings.ALLOWED_HOSTS = ["*"]
         assert utils.bot_request_host() == "testserver"
+
+
+class TestBotIdentificationByProfile:
+
+    @pytest.mark.django_db
+    def test_get_bot_user_ignores_email(self):
+        bot_user = get_bot_user()
+        bot_user.email = "not-the-magic-email@example.com"
+        bot_user.save()
+
+        assert get_bot_user() == bot_user
+
+    @pytest.mark.django_db
+    def test_bot_user_ids_for_phase_ignores_email(self, phase_factory, classical_england_nation):
+        bot_user = get_bot_user()
+        bot_user.email = "not-the-magic-email@example.com"
+        bot_user.save()
+        phase = phase_factory(
+            phase_states_config=[{"nation": classical_england_nation, "user": bot_user}]
+        )
+
+        assert decorators._bot_user_ids_for_phase(phase.id) == {bot_user.id}
 
 
 class TestFinalizeTask:

--- a/service/bot/utils.py
+++ b/service/bot/utils.py
@@ -1,12 +1,10 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
-from bot.constants import BOT_USER_EMAIL
-
 
 def get_bot_user():
     User = get_user_model()
-    return User.objects.get(email=BOT_USER_EMAIL)
+    return User.objects.get(bot_profile__isnull=False)
 
 
 def user_can_use_bot_opponent(user):


### PR DESCRIPTION
## What this PR does

Adds a `BotProfile` model (`disposition`, `voice`) as the foundational persona model for bot users, and switches bot identification off the hardcoded `bot@diplicity.com` email onto a `bot_profile` attribute check. `service/bot/decorators.py` and `service/bot/utils.py` (`get_bot_user`) now check `user__bot_profile__isnull=False` / `hasattr(user, "bot_profile")` instead of matching the magic email string. A migration (`bot/0002_create_bot_profile`) creates the model and backfills a `BotProfile` for the existing bot user.

The now-unused `BOT_USER_EMAIL` constant was removed from `bot/constants.py` since nothing references it outside the frozen `0001` migration (which already hardcodes its own copy, per the existing pattern).

Scope is limited to the model and the identification switch, per the issue — adding more bot users to the pool, the add-bot endpoint, and staging-screen UI are follow-up issues.

Closes #944

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] No visual changes — backend-only model/migration change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WSeoTVEDe2mCnQDwx13N4J)_