### PR TITLE
Add tactical annotations and nation identity to bot context (Gap 03)

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -864,8 +864,16 @@ export interface VictoryConditions {
 export interface VariantProvince {
   id: string;
   name: string;
+  type: string;
+  supplyCenter: boolean;
   /** @nullable */
   parentId: string | null;
+  readonly adjacencies: readonly VariantProvinceAdjacency[];
+}
+
+export interface VariantProvinceAdjacency {
+  to: string;
+  pass: string;
 }
 
 export interface VariantTemplateNationRef {

--- a/packages/web/src/mocks/legacy.ts
+++ b/packages/web/src/mocks/legacy.ts
@@ -10,6 +10,7 @@ import type {
   Province,
   StatusEnum,
   UserProfile,
+  VariantProvince,
 } from "@/api/generated/endpoints";
 
 export const mockNations: Nation[] = [
@@ -130,7 +131,7 @@ export const mockMembers: Member[] = [
   },
 ];
 
-export const mockProvinces: Province[] = [
+export const mockProvinces: (Province & VariantProvince)[] = [
   {
     id: "vie",
     name: "Vienna",
@@ -138,6 +139,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "lon",
@@ -146,6 +148,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "par",
@@ -154,6 +157,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "ber",
@@ -162,6 +166,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "rom",
@@ -170,6 +175,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "mos",
@@ -178,6 +184,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
   {
     id: "con",
@@ -186,6 +193,7 @@ export const mockProvinces: Province[] = [
     supplyCenter: true,
     parentId: null,
     namedCoastIds: [],
+    adjacencies: [],
   },
 ];
 

--- a/packages/web/src/utils/buildOptimisticOrder.test.ts
+++ b/packages/web/src/utils/buildOptimisticOrder.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { buildOptimisticOrder } from "./buildOptimisticOrder";
-import type { Province, Nation, Variant, PhaseRetrieve } from "../api/generated/endpoints";
+import type { Province, Nation, Variant, PhaseRetrieve, VariantProvince } from "../api/generated/endpoints";
 
-const makeProvince = (id: string): Province => ({
+const makeProvince = (id: string): Province & VariantProvince => ({
   id,
   name: id,
   type: "land",
   supplyCenter: false,
   parentId: null,
   namedCoastIds: [],
+  adjacencies: [],
 });
 
 const england: Nation = { nationId: "england", name: "England", color: "rgb(255,0,0)", nonPlayable: false, flagUrl: null };

--- a/service/bot/api_client.py
+++ b/service/bot/api_client.py
@@ -43,6 +43,12 @@ class ApiClient:
             raise ApiClientError(f"game retrieve failed: {response.status_code}")
         return response.data
 
+    def get_variant(self, variant_id):
+        response = self._client.get(reverse("variant-detail", args=[variant_id]))
+        if response.status_code != 200:
+            raise ApiClientError(f"variant retrieve failed: {response.status_code}")
+        return response.data
+
     def get_phase(self, game_id, phase_id):
         response = self._client.get(reverse("phase-retrieve", args=[game_id, phase_id]))
         if response.status_code != 200:

--- a/service/bot/context/builder.py
+++ b/service/bot/context/builder.py
@@ -1,13 +1,20 @@
 import logging
 
+from common.constants import PhaseType
+
+from bot.context.map import build_graph, nearest_enemy_units, nearest_uncontrolled_supply_centers, pass_type_for_unit
 from bot.context.orders import group_options_by_source, order_option_label
-from bot.types import ChannelDict, ChatMessageDict, ContextData
+from bot.types import ChannelDict, ChatMessageDict, ContextData, UnitDict
 
 logger = logging.getLogger(__name__)
 
 
 def _message_role(message: ChatMessageDict) -> str:
     return "assistant" if message["sender"]["is_current_user"] else "user"
+
+
+def _unit_label(unit: UnitDict) -> str:
+    return f"{unit['type'][0].upper()} {unit['province']['id']}"
 
 
 class ContextBuilder:
@@ -24,15 +31,16 @@ class ContextBuilder:
         lines = [f"Current phase: {phase['name']}"]
 
         units_by_nation: dict[str, list[str]] = {}
-        for unit in phase.get("units", []):
-            label = f"{unit['type'][0].upper()} {unit['province']['id']}"
+        for unit in sorted(phase.get("units", []), key=lambda u: u["province"]["id"]):
+            label = _unit_label(unit)
             if unit.get("dislodged"):
                 label += " (dislodged)"
             units_by_nation.setdefault(unit["nation"]["name"], []).append(label)
 
         lines.append("Units:")
         for nation in sorted(units_by_nation):
-            lines.append(f"  {nation}: {', '.join(units_by_nation[nation])}")
+            labels = units_by_nation[nation]
+            lines.append(f"  {nation}: {len(labels)} ({', '.join(labels)})")
 
         centers_by_nation: dict[str, list[str]] = {}
         for center in phase.get("supply_centers", []):
@@ -45,16 +53,131 @@ class ContextBuilder:
             provinces = sorted(centers_by_nation[nation])
             lines.append(f"  {nation}: {len(provinces)} ({', '.join(provinces)})")
 
+        if phase.get("type") == PhaseType.RETREAT:
+            lines.append("")
+            lines.append(self._dislodged_units_line(phase))
+        elif phase.get("type") == PhaseType.ADJUSTMENT:
+            lines.append("")
+            lines.extend(self._adjustments_lines(units_by_nation, centers_by_nation))
+
         self._shared_sections.append("\n".join(lines))
+        return self
+
+    def _dislodged_units_line(self, phase) -> str:
+        dislodged = sorted(
+            (unit for unit in phase.get("units", []) if unit.get("dislodged")),
+            key=lambda u: u["province"]["id"],
+        )
+        if not dislodged:
+            return "Dislodged units: none"
+        entries = [f"{_unit_label(unit)} ({unit['nation']['name']})" for unit in dislodged]
+        return f"Dislodged units: {', '.join(entries)}"
+
+    def _adjustments_lines(self, units_by_nation, centers_by_nation) -> list[str]:
+        lines = ["Adjustments:"]
+        for nation in sorted(set(units_by_nation) | set(centers_by_nation)):
+            delta = len(centers_by_nation.get(nation, [])) - len(units_by_nation.get(nation, []))
+            if delta > 0:
+                summary = f"{delta} build{'s' if delta != 1 else ''} available"
+            elif delta < 0:
+                summary = f"{-delta} disband{'s' if delta != -1 else ''} required"
+            else:
+                summary = "no change"
+            lines.append(f"  {nation}: {summary}")
+        return lines
+
+    def with_tactical_annotations(self) -> "ContextBuilder":
+        provinces = self._data.get("variant", {}).get("provinces", [])
+        units = self._data["phase"].get("units", []) if self._data["phase"] else []
+        if not provinces or not units:
+            return self
+
+        graph = build_graph(provinces)
+        supply_center_ids = {p["id"] for p in provinces if p.get("supply_center") and not p.get("parent_id")}
+        owners = {
+            graph["canonical"].get(c["province"]["id"], c["province"]["id"]): c["nation"]["name"]
+            for c in self._data["phase"].get("supply_centers", [])
+        }
+        occupants: dict[str, list[UnitDict]] = {}
+        for unit in units:
+            province_id = graph["canonical"].get(unit["province"]["id"], unit["province"]["id"])
+            occupants.setdefault(province_id, []).append(unit)
+
+        lines = ["Tactical annotations:"]
+        ordered_units = sorted(
+            units,
+            key=lambda u: (u["province"]["id"], bool(u.get("dislodged")), u["nation"]["name"]),
+        )
+        for unit in ordered_units:
+            header = f"Unit {_unit_label(unit)} ({unit['nation']['name']}"
+            if unit.get("dislodged"):
+                header += ", dislodged"
+            lines.append(f"{header}):")
+            lines.append(f"  Adjacent: {self._adjacent_entries(unit, graph, supply_center_ids, owners, occupants)}")
+            lines.append(f"  Nearest enemy units: {self._nearest_enemy_entries(unit, graph)}")
+            lines.append(
+                f"  Nearest uncontrolled supply centers: {self._nearest_supply_center_entries(unit, graph)}"
+            )
+        self._shared_sections.append("\n".join(lines))
+        return self
+
+    def _adjacent_entries(self, unit, graph, supply_center_ids, owners, occupants) -> str:
+        province_id = graph["canonical"].get(unit["province"]["id"], unit["province"]["id"])
+        neighbours = graph["edges"].get(province_id, {}).get(pass_type_for_unit(unit["type"]), [])
+        if not neighbours:
+            return "none"
+        entries = []
+        for neighbour in neighbours:
+            if neighbour in supply_center_ids:
+                sc_part = f"SC: {owners.get(neighbour, 'unowned')}"
+            else:
+                sc_part = "no SC"
+            entries.append(f"{neighbour} ({sc_part}, {self._occupancy(occupants.get(neighbour, []))})")
+        return ", ".join(entries)
+
+    def _occupancy(self, units: list[UnitDict]) -> str:
+        standing = [unit for unit in units if not unit.get("dislodged")]
+        if standing:
+            unit = standing[0]
+            return f"occupied {_unit_label(unit)} {unit['nation']['name']}"
+        if units:
+            unit = units[0]
+            return f"occupied {_unit_label(unit)} {unit['nation']['name']} (dislodged)"
+        return "empty"
+
+    def _nearest_enemy_entries(self, unit, graph) -> str:
+        nearest = nearest_enemy_units(self._data, graph, unit)
+        if not nearest:
+            return "none"
+        return ", ".join(
+            f"{_unit_label(enemy)} ({enemy['nation']['name']}, dist {distance})"
+            for enemy, distance in nearest
+        )
+
+    def _nearest_supply_center_entries(self, unit, graph) -> str:
+        nearest = nearest_uncontrolled_supply_centers(self._data, graph, unit)
+        if not nearest:
+            return "none"
+        return ", ".join(
+            f"{province_id} ({owner or 'unowned'}, dist {distance})"
+            for province_id, owner, distance in nearest
+        )
+
+    def with_identity(self) -> "ContextBuilder":
+        phase_states = self._data["phase_states"]
+        nation = phase_states[0].get("member", {}).get("nation") if phase_states else None
+        if nation:
+            self._private_sections.append(f"You are playing {nation}.")
         return self
 
     def with_orders(self) -> "ContextBuilder":
         lines = ["Legal orders:"]
-        for source_id, source_options in group_options_by_source(self._data["orders"]).items():
+        options_by_source = group_options_by_source(self._data["orders"])
+        for source_id in sorted(options_by_source):
             lines.append(f"Unit {source_id}:")
-            for index, option in enumerate(source_options):
+            for index, option in enumerate(options_by_source[source_id]):
                 lines.append(f"  {index}. {order_option_label(option)}")
-        self._shared_sections.append("\n".join(lines))
+        self._private_sections.append("\n".join(lines))
         return self
 
     def with_phase_state(self) -> "ContextBuilder":
@@ -62,7 +185,7 @@ class ContextBuilder:
         if phase_states:
             max_orders = phase_states[0].get("max_orders")
             if max_orders is not None:
-                self._shared_sections.append(f"Orders to submit this phase: {max_orders}")
+                self._private_sections.append(f"Orders to submit this phase: {max_orders}")
         return self
 
     def with_conversations(self) -> "ContextBuilder":

--- a/service/bot/context/fetch.py
+++ b/service/bot/context/fetch.py
@@ -1,6 +1,6 @@
 import logging
 
-from bot.api_client import ApiClient
+from bot.api_client import ApiClient, ApiClientError
 from bot.types import ContextData
 
 logger = logging.getLogger(__name__)
@@ -11,7 +11,12 @@ def fetch_context(api: ApiClient, game_id) -> ContextData:
     current_phase_id = game.get("current_phase_id")
     phase = api.get_phase(game_id, current_phase_id) if current_phase_id else {}
     variant_id = game.get("variant_id")
-    variant = api.get_variant(variant_id) if variant_id else {}
+    variant = {}
+    if variant_id:
+        try:
+            variant = api.get_variant(variant_id)
+        except ApiClientError as e:
+            logger.warning(f"[bot.context] variant fetch failed ({e}); continuing without tactical annotations")
     data: ContextData = {
         "orders": api.get_order_options(game_id),
         "phase_states": api.get_phase_states(game_id),

--- a/service/bot/context/fetch.py
+++ b/service/bot/context/fetch.py
@@ -10,16 +10,19 @@ def fetch_context(api: ApiClient, game_id) -> ContextData:
     game = api.get_game(game_id)
     current_phase_id = game.get("current_phase_id")
     phase = api.get_phase(game_id, current_phase_id) if current_phase_id else {}
+    variant_id = game.get("variant_id")
+    variant = api.get_variant(variant_id) if variant_id else {}
     data: ContextData = {
         "orders": api.get_order_options(game_id),
         "phase_states": api.get_phase_states(game_id),
         "game": game,
         "phase": phase,
         "channels": api.get_channels(game_id),
+        "variant": variant,
     }
     logger.info(
         f"[bot.context] fetched context for game {game_id}: "
         f"{len(data['orders'])} order option(s), {len(data['channels'])} channel(s), "
-        f"{len(phase.get('units', []))} unit(s)"
+        f"{len(phase.get('units', []))} unit(s), {len(variant.get('provinces', []))} province(s)"
     )
     return data

--- a/service/bot/context/fetch.py
+++ b/service/bot/context/fetch.py
@@ -1,6 +1,6 @@
 import logging
 
-from bot.api_client import ApiClient, ApiClientError
+from bot.api_client import ApiClient
 from bot.types import ContextData
 
 logger = logging.getLogger(__name__)
@@ -11,12 +11,7 @@ def fetch_context(api: ApiClient, game_id) -> ContextData:
     current_phase_id = game.get("current_phase_id")
     phase = api.get_phase(game_id, current_phase_id) if current_phase_id else {}
     variant_id = game.get("variant_id")
-    variant = {}
-    if variant_id:
-        try:
-            variant = api.get_variant(variant_id)
-        except ApiClientError as e:
-            logger.warning(f"[bot.context] variant fetch failed ({e}); continuing without tactical annotations")
+    variant = api.get_variant(variant_id) if variant_id else {}
     data: ContextData = {
         "orders": api.get_order_options(game_id),
         "phase_states": api.get_phase_states(game_id),

--- a/service/bot/context/map.py
+++ b/service/bot/context/map.py
@@ -21,6 +21,8 @@ def build_graph(provinces: list[VariantProvinceDict]) -> GraphDict:
     }
     for province in provinces:
         source = canonical[province["id"]]
+        if source not in edge_sets:
+            continue
         for adjacency in province.get("adjacencies", []):
             target = canonical.get(adjacency["to"])
             if target is None or target == source:

--- a/service/bot/context/map.py
+++ b/service/bot/context/map.py
@@ -1,0 +1,91 @@
+from collections import deque
+from typing import TypedDict
+
+from common.constants import UnitType
+
+from bot.types import ContextData, UnitDict, VariantProvinceDict
+
+ARMY = "army"
+FLEET = "fleet"
+
+
+class GraphDict(TypedDict):
+    edges: dict[str, dict[str, list[str]]]
+    canonical: dict[str, str]
+
+
+def build_graph(provinces: list[VariantProvinceDict]) -> GraphDict:
+    canonical = {p["id"]: p.get("parent_id") or p["id"] for p in provinces}
+    edge_sets: dict[str, dict[str, set[str]]] = {
+        p["id"]: {ARMY: set(), FLEET: set()} for p in provinces if not p.get("parent_id")
+    }
+    for province in provinces:
+        source = canonical[province["id"]]
+        for adjacency in province.get("adjacencies", []):
+            target = canonical.get(adjacency["to"])
+            if target is None or target == source:
+                continue
+            if adjacency["pass"] in (ARMY, "both"):
+                edge_sets[source][ARMY].add(target)
+            if adjacency["pass"] in (FLEET, "both"):
+                edge_sets[source][FLEET].add(target)
+    edges = {
+        province_id: {pass_type: sorted(targets) for pass_type, targets in sets.items()}
+        for province_id, sets in edge_sets.items()
+    }
+    return {"edges": edges, "canonical": canonical}
+
+
+def pass_type_for_unit(unit_type: str) -> str:
+    return FLEET if unit_type == UnitType.FLEET else ARMY
+
+
+def shortest_distances(graph: GraphDict, start: str, pass_type: str) -> dict[str, int]:
+    start = graph["canonical"].get(start, start)
+    distances = {start: 0}
+    queue = deque([start])
+    while queue:
+        current = queue.popleft()
+        for neighbour in graph["edges"].get(current, {}).get(pass_type, []):
+            if neighbour not in distances:
+                distances[neighbour] = distances[current] + 1
+                queue.append(neighbour)
+    return distances
+
+
+def nearest_enemy_units(
+    data: ContextData, graph: GraphDict, unit: UnitDict, n: int = 3
+) -> list[tuple[UnitDict, int]]:
+    distances = shortest_distances(graph, unit["province"]["id"], pass_type_for_unit(unit["type"]))
+    candidates = []
+    for other in data["phase"].get("units", []):
+        if other["nation"]["name"] == unit["nation"]["name"] or other.get("dislodged"):
+            continue
+        province_id = graph["canonical"].get(other["province"]["id"], other["province"]["id"])
+        distance = distances.get(province_id)
+        if distance is not None and distance >= 1:
+            candidates.append((other, distance, province_id))
+    candidates.sort(key=lambda c: (c[1], c[2]))
+    return [(other, distance) for other, distance, _ in candidates[:n]]
+
+
+def nearest_uncontrolled_supply_centers(
+    data: ContextData, graph: GraphDict, unit: UnitDict, n: int = 3
+) -> list[tuple[str, str | None, int]]:
+    distances = shortest_distances(graph, unit["province"]["id"], pass_type_for_unit(unit["type"]))
+    owners: dict[str, str] = {}
+    for center in data["phase"].get("supply_centers", []):
+        province_id = graph["canonical"].get(center["province"]["id"], center["province"]["id"])
+        owners[province_id] = center["nation"]["name"]
+    candidates = []
+    for province in data["variant"].get("provinces", []):
+        if not province.get("supply_center") or province.get("parent_id"):
+            continue
+        owner = owners.get(province["id"])
+        if owner == unit["nation"]["name"]:
+            continue
+        distance = distances.get(province["id"])
+        if distance is not None:
+            candidates.append((province["id"], owner, distance))
+    candidates.sort(key=lambda c: (c[2], c[0]))
+    return candidates[:n]

--- a/service/bot/prompts/select_orders_system.txt
+++ b/service/bot/prompts/select_orders_system.txt
@@ -1,3 +1,3 @@
-You are playing a game of Diplomacy. The context shows the current board state, listing every nation's units and supply centers. Use it to inform your strategy. For each unit listed in the context, choose one order by its index from the listed legal options. You must choose an order for every unit.
+You are playing a game of Diplomacy. The context shows the current board state, listing every nation's units and supply centers. Tactical annotations list, for each unit, its adjacent provinces, nearest enemy units, and nearest uncontrolled supply centers, with distances in moves for that unit type. Use it to inform your strategy. For each unit listed in the context, choose one order by its index from the listed legal options. You must choose an order for every unit.
 
 Respond with JSON only. Do not include any prose, explanation, or markdown outside the JSON object.

--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -21,6 +21,8 @@ def _submit_orders_from_context(api, data, game_id, label):
     builder = (
         ContextBuilder(data)
         .with_game_state()
+        .with_tactical_annotations()
+        .with_identity()
         .with_orders()
         .with_phase_state()
         .with_conversations()
@@ -100,6 +102,8 @@ def reply(user_id, game_id, channel_id):
     builder = (
         ContextBuilder(data)
         .with_game_state()
+        .with_tactical_annotations()
+        .with_identity()
         .with_messages(channel_id=channel_id)
     )
     system = load_prompt("reply_system.txt")

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -18,9 +18,7 @@ from game.models import Game
 from bot.models import BotProfile, LLMCall
 from bot import decorators, tasks, utils
 from bot.constants import LLMCallStage, LLMCallStatus
-from bot.api_client import ApiClientError
 from bot.context.builder import ContextBuilder
-from bot.context.fetch import fetch_context
 from bot.context.map import (
     build_graph,
     nearest_enemy_units,
@@ -516,29 +514,6 @@ class TestContextBuilder:
     def test_with_messages_missing_channel_is_noop(self):
         private = ContextBuilder(self._data()).with_messages(channel_id=999).build_private()
         assert private == ""
-
-
-class TestFetchContext:
-
-    def _api(self, get_variant):
-        api = Mock()
-        api.get_game.return_value = {"current_phase_id": None, "variant_id": "classical"}
-        api.get_order_options.return_value = []
-        api.get_phase_states.return_value = []
-        api.get_channels.return_value = []
-        api.get_variant.side_effect = get_variant
-        return api
-
-    def test_variant_fetch_failure_degrades_to_empty(self):
-        def raise_error(_variant_id):
-            raise ApiClientError("variant retrieve failed: 500")
-
-        data = fetch_context(self._api(raise_error), "game-1")
-        assert data["variant"] == {}
-
-    def test_variant_fetched_when_available(self):
-        data = fetch_context(self._api(lambda _variant_id: {"provinces": []}), "game-1")
-        assert data["variant"] == {"provinces": []}
 
 
 def _reply_response(should_reply, message=""):

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -18,7 +18,9 @@ from game.models import Game
 from bot.models import BotProfile, LLMCall
 from bot import decorators, tasks, utils
 from bot.constants import LLMCallStage, LLMCallStatus
+from bot.api_client import ApiClientError
 from bot.context.builder import ContextBuilder
+from bot.context.fetch import fetch_context
 from bot.context.map import (
     build_graph,
     nearest_enemy_units,
@@ -514,6 +516,29 @@ class TestContextBuilder:
     def test_with_messages_missing_channel_is_noop(self):
         private = ContextBuilder(self._data()).with_messages(channel_id=999).build_private()
         assert private == ""
+
+
+class TestFetchContext:
+
+    def _api(self, get_variant):
+        api = Mock()
+        api.get_game.return_value = {"current_phase_id": None, "variant_id": "classical"}
+        api.get_order_options.return_value = []
+        api.get_phase_states.return_value = []
+        api.get_channels.return_value = []
+        api.get_variant.side_effect = get_variant
+        return api
+
+    def test_variant_fetch_failure_degrades_to_empty(self):
+        def raise_error(_variant_id):
+            raise ApiClientError("variant retrieve failed: 500")
+
+        data = fetch_context(self._api(raise_error), "game-1")
+        assert data["variant"] == {}
+
+    def test_variant_fetched_when_available(self):
+        data = fetch_context(self._api(lambda _variant_id: {"provinces": []}), "game-1")
+        assert data["variant"] == {"provinces": []}
 
 
 def _reply_response(should_reply, message=""):

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -19,6 +19,12 @@ from bot.models import BotProfile, LLMCall
 from bot import decorators, tasks, utils
 from bot.constants import LLMCallStage, LLMCallStatus
 from bot.context.builder import ContextBuilder
+from bot.context.map import (
+    build_graph,
+    nearest_enemy_units,
+    nearest_uncontrolled_supply_centers,
+    shortest_distances,
+)
 from bot.context.orders import first_legal_selections, option_to_selected
 from bot.context.parsers import parse_order_selections, parse_reply
 from bot.llm_client import LLMClient, LLMError
@@ -154,18 +160,178 @@ class TestLLMClient:
         assert result == "Hello, human!"
 
 
+def _map_province(province_id, type="coastal", supply_center=False, parent_id=None, adjacencies=None):
+    return {
+        "id": province_id,
+        "name": province_id,
+        "type": type,
+        "supply_center": supply_center,
+        "parent_id": parent_id,
+        "adjacencies": adjacencies or [],
+    }
+
+
+def _map_unit(unit_type, nation, province_id, dislodged=False):
+    return {
+        "type": unit_type,
+        "nation": {"nation_id": nation.lower(), "name": nation},
+        "province": {"id": province_id, "name": province_id},
+        "dislodged": dislodged,
+    }
+
+
+class TestMapGraph:
+
+    def _provinces(self):
+        return [
+            _map_province("a", type="land", supply_center=True, adjacencies=[{"to": "b", "pass": "army"}]),
+            _map_province(
+                "b",
+                adjacencies=[
+                    {"to": "a", "pass": "army"},
+                    {"to": "c", "pass": "both"},
+                    {"to": "s", "pass": "fleet"},
+                ],
+            ),
+            _map_province(
+                "c",
+                supply_center=True,
+                adjacencies=[{"to": "b", "pass": "both"}, {"to": "s", "pass": "fleet"}],
+            ),
+            _map_province(
+                "s",
+                type="sea",
+                adjacencies=[
+                    {"to": "b", "pass": "fleet"},
+                    {"to": "c", "pass": "fleet"},
+                    {"to": "c/nc", "pass": "fleet"},
+                ],
+            ),
+            _map_province("c/nc", type="named_coast", parent_id="c", adjacencies=[{"to": "s", "pass": "fleet"}]),
+        ]
+
+    def _data(self, units, supply_centers=None):
+        return {
+            "phase": {"units": units, "supply_centers": supply_centers or []},
+            "variant": {"provinces": self._provinces()},
+        }
+
+    def test_build_graph_typed_edges_collapse_named_coasts(self):
+        graph = build_graph(self._provinces())
+        assert graph["edges"]["a"] == {"army": ["b"], "fleet": []}
+        assert graph["edges"]["b"] == {"army": ["a", "c"], "fleet": ["c", "s"]}
+        assert "c/nc" not in graph["edges"]
+        assert graph["canonical"]["c/nc"] == "c"
+        assert graph["edges"]["s"]["fleet"] == ["b", "c"]
+
+    def test_shortest_distances_respect_pass_type(self):
+        graph = build_graph(self._provinces())
+        assert shortest_distances(graph, "a", "army") == {"a": 0, "b": 1, "c": 2}
+        fleet_from_sea = shortest_distances(graph, "s", "fleet")
+        assert fleet_from_sea == {"s": 0, "b": 1, "c": 1}
+
+    def test_nearest_enemy_units_ties_break_by_province_id(self):
+        graph = build_graph(self._provinces())
+        unit = _map_unit("Army", "England", "b")
+        enemies = [
+            _map_unit("Army", "France", "c"),
+            _map_unit("Army", "France", "a"),
+            _map_unit("Fleet", "France", "s", dislodged=True),
+        ]
+        nearest = nearest_enemy_units(self._data([unit] + enemies), graph, unit)
+        assert [(e["province"]["id"], d) for e, d in nearest] == [("a", 1), ("c", 1)]
+
+    def test_nearest_enemy_units_caps_at_n(self):
+        graph = build_graph(self._provinces())
+        unit = _map_unit("Army", "England", "b")
+        enemies = [_map_unit("Army", "France", "a"), _map_unit("Army", "France", "c")]
+        nearest = nearest_enemy_units(self._data([unit] + enemies), graph, unit, n=1)
+        assert len(nearest) == 1
+
+    def test_nearest_uncontrolled_scs_include_dist_zero_and_filter_owned(self):
+        graph = build_graph(self._provinces())
+        unit = _map_unit("Army", "England", "c")
+        supply_centers = [
+            {
+                "province": {"id": "a", "name": "a"},
+                "nation": {"nation_id": "france", "name": "France"},
+            }
+        ]
+        nearest = nearest_uncontrolled_supply_centers(
+            self._data([unit], supply_centers), graph, unit
+        )
+        assert nearest == [("c", None, 0), ("a", "France", 2)]
+
+        french_unit = _map_unit("Army", "France", "c")
+        nearest = nearest_uncontrolled_supply_centers(
+            self._data([french_unit], supply_centers), graph, french_unit
+        )
+        assert nearest == [("c", None, 0)]
+
+    def test_missing_adjacencies_degrade_gracefully(self):
+        provinces = [
+            _map_province("a", supply_center=True),
+            _map_province("b"),
+        ]
+        graph = build_graph(provinces)
+        assert shortest_distances(graph, "b", "army") == {"b": 0}
+        unit = _map_unit("Army", "England", "b")
+        data = {
+            "phase": {"units": [unit, _map_unit("Army", "France", "a")], "supply_centers": []},
+            "variant": {"provinces": provinces},
+        }
+        assert nearest_enemy_units(data, graph, unit) == []
+        assert nearest_uncontrolled_supply_centers(data, graph, unit) == []
+        assert build_graph([]) == {"edges": {}, "canonical": {}}
+
+
 class TestContextBuilder:
 
-    def _data(self, channels=None, phase=None):
+    def _data(self, channels=None, phase=None, variant=None):
         return {
             "orders": [
                 _option("lon", OrderType.HOLD),
                 _option("lon", OrderType.MOVE, target="nth"),
             ],
-            "phase_states": [{"max_orders": 3}],
+            "phase_states": [{"max_orders": 3, "member": {"nation": "England"}}],
             "game": {"phase_confirmed": False},
             "phase": phase if phase is not None else {},
             "channels": channels or [],
+            "variant": variant or {},
+        }
+
+    def _variant(self):
+        return {
+            "id": "test",
+            "provinces": [
+                _map_province(
+                    "lon",
+                    supply_center=True,
+                    adjacencies=[
+                        {"to": "nth", "pass": "fleet"},
+                        {"to": "wal", "pass": "army"},
+                        {"to": "edi", "pass": "army"},
+                        {"to": "par", "pass": "army"},
+                    ],
+                ),
+                _map_province(
+                    "nth",
+                    type="sea",
+                    adjacencies=[{"to": "lon", "pass": "fleet"}, {"to": "edi", "pass": "fleet"}],
+                ),
+                _map_province(
+                    "edi",
+                    supply_center=True,
+                    adjacencies=[{"to": "lon", "pass": "army"}, {"to": "nth", "pass": "fleet"}],
+                ),
+                _map_province("wal", adjacencies=[{"to": "lon", "pass": "army"}]),
+                _map_province(
+                    "par",
+                    type="land",
+                    supply_center=True,
+                    adjacencies=[{"to": "lon", "pass": "army"}],
+                ),
+            ],
         }
 
     def _phase(self):
@@ -193,23 +359,105 @@ class TestContextBuilder:
     def test_with_game_state_groups_units_and_centers_by_nation(self):
         shared = ContextBuilder(self._data(phase=self._phase())).with_game_state().build_shared()
         assert "Current phase: Spring 1901, Movement" in shared
-        assert "England: A lon, F nth (dislodged)" in shared
-        assert "France: A par" in shared
+        assert "England: 2 (A lon, F nth (dislodged))" in shared
+        assert "France: 1 (A par)" in shared
         assert "England: 2 (edi, lon)" in shared
         assert "France: 1 (par)" in shared
 
     def test_with_game_state_empty_phase_is_noop(self):
         assert ContextBuilder(self._data()).with_game_state().build_shared() == ""
 
+    def test_with_game_state_retreat_phase_lists_dislodged_units(self):
+        phase = self._phase()
+        phase["type"] = "Retreat"
+        shared = ContextBuilder(self._data(phase=phase)).with_game_state().build_shared()
+        assert "Dislodged units: F nth (England)" in shared
+
+    def test_with_game_state_adjustment_phase_frames_per_nation(self):
+        def nation(name):
+            return {"nation_id": name.lower(), "name": name}
+
+        def province(province_id):
+            return {"id": province_id, "name": province_id}
+
+        phase = {
+            "name": "Winter 1901, Adjustment",
+            "type": "Adjustment",
+            "units": [
+                {"type": "Army", "nation": nation("England"), "province": province("lon"), "dislodged": False},
+                {"type": "Army", "nation": nation("France"), "province": province("par"), "dislodged": False},
+                {"type": "Fleet", "nation": nation("France"), "province": province("bre"), "dislodged": False},
+                {"type": "Army", "nation": nation("Germany"), "province": province("mun"), "dislodged": False},
+            ],
+            "supply_centers": [
+                {"province": province("lon"), "nation": nation("England")},
+                {"province": province("edi"), "nation": nation("England")},
+                {"province": province("par"), "nation": nation("France")},
+                {"province": province("mun"), "nation": nation("Germany")},
+            ],
+        }
+        shared = ContextBuilder(self._data(phase=phase)).with_game_state().build_shared()
+        assert "Adjustments:" in shared
+        assert "England: 1 build available" in shared
+        assert "France: 1 disband required" in shared
+        assert "Germany: no change" in shared
+
+    def test_with_tactical_annotations_renders_unit_blocks(self):
+        shared = (
+            ContextBuilder(self._data(phase=self._phase(), variant=self._variant()))
+            .with_tactical_annotations()
+            .build_shared()
+        )
+        assert "Tactical annotations:" in shared
+        assert "Unit A lon (England):" in shared
+        assert (
+            "  Adjacent: edi (SC: England, empty), par (SC: France, occupied A par France), wal (no SC, empty)"
+            in shared
+        )
+        assert "  Nearest enemy units: A par (France, dist 1)" in shared
+        assert "  Nearest uncontrolled supply centers: par (France, dist 1)" in shared
+        assert "Unit F nth (England, dislodged):" in shared
+        assert "Nearest enemy units: none" in shared
+
+    def test_with_tactical_annotations_without_variant_is_noop(self):
+        shared = (
+            ContextBuilder(self._data(phase=self._phase()))
+            .with_tactical_annotations()
+            .build_shared()
+        )
+        assert shared == ""
+
+    def test_shared_block_is_byte_identical_across_builds(self):
+        def build():
+            return (
+                ContextBuilder(self._data(phase=self._phase(), variant=self._variant()))
+                .with_game_state()
+                .with_tactical_annotations()
+                .build_shared()
+            )
+
+        assert build() == build()
+
+    def test_with_identity_names_nation_in_private(self):
+        builder = ContextBuilder(self._data()).with_identity()
+        assert "You are playing England." in builder.build_private()
+        assert builder.build_shared() == ""
+
     def _channel(self, channel_id, name, messages):
         return {"id": channel_id, "name": name, "private": False, "messages": messages}
 
-    def test_with_orders_lists_options_in_shared(self):
+    def test_with_orders_lists_options_in_private(self):
         builder = ContextBuilder(self._data()).with_orders()
-        shared = builder.build_shared()
-        assert "Unit lon:" in shared
-        assert "0. lon Hold" in shared
-        assert "1. lon Move nth" in shared
+        private = builder.build_private()
+        assert "Unit lon:" in private
+        assert "0. lon Hold" in private
+        assert "1. lon Move nth" in private
+        assert "Legal orders:" not in builder.build_shared()
+
+    def test_with_phase_state_is_private(self):
+        builder = ContextBuilder(self._data()).with_phase_state()
+        assert "Orders to submit this phase: 3" in builder.build_private()
+        assert builder.build_shared() == ""
 
     def test_with_conversations_includes_all_channels(self):
         channels = [

--- a/service/bot/types.py
+++ b/service/bot/types.py
@@ -50,6 +50,25 @@ class UnitDict(TypedDict, total=False):
     dislodged: bool
 
 
+# Functional syntax because "pass" is a Python keyword.
+AdjacencyDict = TypedDict("AdjacencyDict", {"to": str, "pass": str})
+
+
+class VariantProvinceDict(TypedDict, total=False):
+    id: str
+    name: str
+    type: str
+    supply_center: bool
+    parent_id: str | None
+    adjacencies: list[AdjacencyDict]
+
+
+class VariantDict(TypedDict, total=False):
+    id: str
+    name: str
+    provinces: list[VariantProvinceDict]
+
+
 class SupplyCenterDict(TypedDict, total=False):
     province: ProvinceDict
     nation: NationDict
@@ -68,3 +87,4 @@ class ContextData(TypedDict):
     game: dict
     phase: PhaseDict
     channels: list[ChannelDict]
+    variant: VariantDict

--- a/service/integration/test_bot.py
+++ b/service/integration/test_bot.py
@@ -77,6 +77,21 @@ def test_bot_game_starts_on_creation_and_plays_phase(
 
 
 @pytest.mark.django_db
+def test_bot_plans_when_variant_has_no_adjacencies(allowlisted_human, italy_vs_germany_variant):
+    from province.models import Province
+
+    Province.objects.filter(variant=italy_vs_germany_variant).update(adjacencies=[])
+    human_client = allowlisted_human
+    game = _create_bot_game(human_client, italy_vs_germany_variant.id)
+
+    bot_user = get_bot_user()
+    tasks.plan(user_id=bot_user.id, game_id=game.id)
+
+    bot_phase_state = game.current_phase.phase_states.get(member__user=bot_user)
+    assert bot_phase_state.orders.exists()
+
+
+@pytest.mark.django_db
 def test_bot_can_play_the_next_phase(allowlisted_human, italy_vs_germany_variant):
     human_client = allowlisted_human
     game = _create_bot_game(human_client, italy_vs_germany_variant.id)

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -3364,13 +3364,35 @@ components:
           type: string
         name:
           type: string
+        type:
+          type: string
+        supplyCenter:
+          type: boolean
         parentId:
           type: string
           nullable: true
+        adjacencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/VariantProvinceAdjacency'
+          readOnly: true
       required:
+      - adjacencies
       - id
       - name
       - parentId
+      - supplyCenter
+      - type
+    VariantProvinceAdjacency:
+      type: object
+      properties:
+        to:
+          type: string
+        pass:
+          type: string
+      required:
+      - pass
+      - to
     VariantTemplateNationRef:
       type: object
       properties:

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from django.db import IntegrityError, transaction
 from django.urls import reverse
+from drf_spectacular.utils import extend_schema_field, inline_serializer
 from lxml import etree
 from rest_framework import serializers
 from nation.serializers import NationSerializer
@@ -28,7 +29,20 @@ class VictoryConditionsSerializer(serializers.Serializer):
 class VariantProvinceSerializer(serializers.Serializer):
     id = serializers.CharField(source="province_id")
     name = serializers.CharField()
+    type = serializers.CharField()
+    supply_center = serializers.BooleanField()
     parent_id = serializers.CharField(source="parent.province_id", allow_null=True)
+    adjacencies = serializers.SerializerMethodField()
+
+    @extend_schema_field(
+        inline_serializer(
+            name="VariantProvinceAdjacency",
+            fields={"to": serializers.CharField(), "pass": serializers.CharField()},
+            many=True,
+        )
+    )
+    def get_adjacencies(self, obj):
+        return obj.adjacencies
 
 
 class VariantTemplateNationRefSerializer(serializers.Serializer):

--- a/service/variant/tests/test_variant_crud.py
+++ b/service/variant/tests/test_variant_crud.py
@@ -472,6 +472,24 @@ def test_dvar_reupload_drops_flags_for_removed_nations(
 
 
 @pytest.mark.django_db
+def test_retrieve_variant_includes_province_map_data(authenticated_client, classical_variant):
+    response = authenticated_client.get(
+        reverse("variant-detail", kwargs={"pk": "classical"}),
+    )
+    assert response.status_code == status.HTTP_200_OK
+    provinces = {province["id"]: province for province in response.data["provinces"]}
+
+    assert provinces["stp"]["type"] == "coastal"
+    assert provinces["stp"]["supply_center"] is True
+    assert {"to": "mos", "pass": "army"} in provinces["stp"]["adjacencies"]
+
+    assert provinces["stp/nc"]["parent_id"] == "stp"
+    assert {"to": "bar", "pass": "fleet"} in provinces["stp/nc"]["adjacencies"]
+
+    assert provinces["wal"]["supply_center"] is False
+
+
+@pytest.mark.django_db
 def test_sandbox_game_accepts_draft_variant(authenticated_client, classical_dvar, classical_dsvg):
     dvar = copy.deepcopy(classical_dvar)
     dvar["id"] = "draft-for-sandbox"


### PR DESCRIPTION
## What this PR does

Closes the game-state serialization gap (`service/bot/docs/GAP_03_GAME_STATE_SERIALIZATION.md`): the bot's context was a bare unit/SC list with no map geometry, so a small model had to re-derive distances and threats itself. This exposes province adjacencies over the variant API and uses them to render per-unit **tactical annotations** — adjacent provinces, nearest enemy units, and nearest uncontrolled supply centers (with distances) — plus names the nation the bot is playing.

**Backend**

- `VariantProvinceSerializer` now serializes `type`, `supply_center`, and the lossless `adjacencies` `[{to, pass}]` shape (via `SerializerMethodField` + `inline_serializer`, since `pass` is a Python keyword).
- `ApiClient.get_variant` + `fetch_context` carry the variant into `ContextData`; a missing `variant_id` degrades gracefully to no annotations rather than failing.

**Bot context**

- New `service/bot/context/map.py` builds a typed (army/fleet) province graph from the `pass` metadata — collapsing named coasts into their parent — and runs BFS for nearest enemy units and nearest uncontrolled supply centers. The graph is internal computation only; the model sees plain prose, never graph structure.
- `ContextBuilder` gains `with_tactical_annotations()` (shared block, all units, deterministic sort by province id) and `with_identity()` (`You are playing <nation>.`, private block). Phase-type framing is added to the shared game-state block: a dislodged-units line for retreats and per-nation build/disband deltas for adjustments.
- Per the Gap 10 correction, legal orders and the per-bot order count move to the **private** block — both are per-bot data (`order-options` only returns the acting user's options), not shared. Every shared section sorts deterministically so the block is byte-identical across bots, which the Gap 10 caching work depends on.

**Codegen**

- Regenerated `service/openapi-schema.yaml` and the TypeScript client for the new `VariantProvince` fields; updated the inline mock provinces (`src/mocks/legacy.ts`, `buildOptimisticOrder.test.ts`) for the now-required `adjacencies` field.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual changes

### Tests

- `variant/tests/test_variant_crud.py`: variant endpoint returns `type`, `supply_center`, and `adjacencies` (incl. `stp` ↔ `mos` and the `stp/nc` named-coast row).
- `bot/tests.py`: new `TestMapGraph` (typed edges, coast collapsing, BFS distances per unit type, tie-breaks, n-capping, empty-adjacency degradation) and expanded `TestContextBuilder` (annotation blocks, identity line, orders/phase-state now private, adjustment/retreat framing, shared-block byte-identity).
- `integration/test_bot.py`: existing bot-plays-phase tests still pass; new `test_bot_plans_when_variant_has_no_adjacencies` asserts graceful degradation.
- Full affected backend suites (bot, variant, province, phase, integration) green — 478 passed. Frontend `tsc -b --noEmit`, `eslint`, and the affected vitest file all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuTX6diksRZVkPgFoWQ7aD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuTX6diksRZVkPgFoWQ7aD)_