### PR TITLE
Optimize GET games/ phase prefetch

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -10,6 +10,7 @@ from django.db.models import (
     IntegerField,
     OuterRef,
     Prefetch,
+    Q,
     Subquery,
     Value,
 )
@@ -83,16 +84,28 @@ class GameQuerySet(models.QuerySet):
             queryset=Member.objects.select_related("user__profile", "user__bot_profile", "nation"),
         )
 
-        phase_states_prefetch = Prefetch(
-            "phase_states",
-            queryset=PhaseState.objects.select_related("member").annotate(
-                order_count=Count("orders")
-            ),
-        )
         current_phase_ids = (
             Phase.objects.order_by("game_id", "-ordinal")
             .distinct("game_id")
             .values("id")
+        )
+        latest_completed_phase_ids = (
+            Phase.objects.filter(status=PhaseStatus.COMPLETED)
+            .order_by("game_id", "-ordinal")
+            .distinct("game_id")
+            .values("id")
+        )
+        # The list serializer only reads phase states for the current phase
+        # (order_status, phase_confirmed) and the latest completed phase
+        # (member_status), so scope the prefetch to those rather than loading
+        # every historical phase's states.
+        phase_states_prefetch = Prefetch(
+            "phase_states",
+            queryset=PhaseState.objects.filter(
+                Q(phase__in=current_phase_ids) | Q(phase__in=latest_completed_phase_ids)
+            )
+            .select_related("member")
+            .annotate(order_count=Count("orders")),
         )
         current_units_prefetch = Prefetch(
             "units",
@@ -104,9 +117,22 @@ class GameQuerySet(models.QuerySet):
             queryset=SupplyCenter.objects.filter(phase__in=current_phase_ids)
             .select_related("nation", "province"),
         )
+        # The serializer never reads the large per-phase `options` blob on the
+        # list path; restrict the prefetch to the slim fields it does read so
+        # cost no longer grows with game age.
         phases_prefetch = Prefetch(
             "phases",
-            queryset=Phase.objects.prefetch_related(
+            queryset=Phase.objects.only(
+                "id",
+                "ordinal",
+                "season",
+                "year",
+                "type",
+                "status",
+                "scheduled_resolution",
+                "game_id",
+                "variant_id",
+            ).prefetch_related(
                 phase_states_prefetch,
                 current_units_prefetch,
                 current_supply_centers_prefetch,

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -95,10 +95,6 @@ class GameQuerySet(models.QuerySet):
             .distinct("game_id")
             .values("id")
         )
-        # The list serializer only reads phase states for the current phase
-        # (order_status, phase_confirmed) and the latest completed phase
-        # (member_status), so scope the prefetch to those rather than loading
-        # every historical phase's states.
         phase_states_prefetch = Prefetch(
             "phase_states",
             queryset=PhaseState.objects.filter(
@@ -117,9 +113,6 @@ class GameQuerySet(models.QuerySet):
             queryset=SupplyCenter.objects.filter(phase__in=current_phase_ids)
             .select_related("nation", "province"),
         )
-        # The serializer never reads the large per-phase `options` blob on the
-        # list path; restrict the prefetch to the slim fields it does read so
-        # cost no longer grows with game age.
         phases_prefetch = Prefetch(
             "phases",
             queryset=Phase.objects.only(

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1336,8 +1336,6 @@ class TestGameListViewQueryPerformance:
                 for phase in game_obj.phases.all()
             }
 
-        # Only the current phase (ordinal 5) and the latest completed phase
-        # (ordinal 4) carry hydrated phase states; older phases are empty.
         assert states_by_ordinal == {1: 0, 2: 0, 3: 0, 4: 2, 5: 2}
 
 

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1246,6 +1246,100 @@ class TestGameListViewQueryPerformance:
         supply_center = result["current_phase"]["supply_centers"][0]
         assert set(supply_center.keys()) == {"nation", "province"}
 
+    @pytest.mark.django_db
+    def test_list_games_does_not_fetch_phase_options(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_edinburgh_province,
+    ):
+        game = Game.objects.create(
+            name="Options game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(user=primary_user, nation=classical_england_nation)
+        for ordinal in range(1, 4):
+            phase = game.phases.create(
+                game=game,
+                variant=game.variant,
+                season="Spring",
+                year=1900 + ordinal,
+                type=PhaseType.MOVEMENT,
+                status=PhaseStatus.ACTIVE if ordinal == 3 else PhaseStatus.COMPLETED,
+                ordinal=ordinal,
+                options={"England": {"lon": {"Move": {}}}},
+            )
+            phase.units.create(
+                type=UnitType.FLEET,
+                nation=classical_england_nation,
+                province=classical_edinburgh_province,
+            )
+
+        url = reverse(list_viewname)
+        connection.queries_log.clear()
+
+        with override_settings(DEBUG=True):
+            response = authenticated_client.get(url, {"mine": "true"})
+
+        assert response.status_code == status.HTTP_200_OK
+        phase_queries = [
+            q["sql"] for q in connection.queries if 'FROM "phase_phase"' in q["sql"]
+        ]
+        assert phase_queries
+        assert all('"phase_phase"."options"' not in sql for sql in phase_queries)
+
+    @pytest.mark.django_db
+    def test_list_games_scopes_phase_states_to_current_and_latest_completed(
+        self,
+        django_assert_num_queries,
+        primary_user,
+        secondary_user,
+        classical_variant,
+        classical_england_nation,
+        classical_france_nation,
+        classical_edinburgh_province,
+    ):
+        phases_per_game = 5
+        game = Game.objects.create(
+            name="Phase state scope game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        member1 = game.members.create(user=primary_user, nation=classical_england_nation)
+        member2 = game.members.create(user=secondary_user, nation=classical_france_nation)
+        phases = []
+        for ordinal in range(1, phases_per_game + 1):
+            phase = game.phases.create(
+                game=game,
+                variant=game.variant,
+                season="Spring",
+                year=1900 + ordinal,
+                type=PhaseType.MOVEMENT,
+                status=PhaseStatus.ACTIVE if ordinal == phases_per_game else PhaseStatus.COMPLETED,
+                ordinal=ordinal,
+            )
+            phase.phase_states.create(member=member1, has_possible_orders=True)
+            phase.phase_states.create(member=member2, has_possible_orders=True)
+            phases.append(phase)
+
+        hydrated = list(
+            Game.objects.filter(id=game.id).with_list_data()
+        )
+        game_obj = hydrated[0]
+
+        with django_assert_num_queries(0):
+            states_by_ordinal = {
+                phase.ordinal: len(phase.phase_states.all())
+                for phase in game_obj.phases.all()
+            }
+
+        # Only the current phase (ordinal 5) and the latest completed phase
+        # (ordinal 4) carry hydrated phase states; older phases are empty.
+        assert states_by_ordinal == {1: 0, 2: 0, 3: 0, 4: 2, 5: 2}
+
 
 class TestGameCreateView:
 


### PR DESCRIPTION
## What this PR does

`GET games/` (the home-screen game list — 66k req/wk, P95 2.1s) degrades linearly with game age because `GameQuerySet.with_list_data()` over-fetches phase data. This trims that fetch to what the list serializers actually read, so old games stop dragging the tail. Implements Priority 1 from the endpoint-performance analysis.

Two changes in `with_list_data()`:

- **Stop loading the `options` blob.** The phases prefetch now uses `.only(...)` restricted to the slim fields the list serializers read (`id`, `ordinal`, `season`, `year`, `type`, `status`, `scheduled_resolution`, plus `game_id`/`variant_id` for joins). The large per-phase `options` JSON (the full adjudication options tree) was previously loaded for every historical phase of every listed game and never read on this path.
- **Scope phase states to the current + latest completed phase.** The serializer only reads phase states for the current phase (`order_status`, `phase_confirmed`) and the most recent completed phase (`member_status`). The prefetch now filters to those two per game via `DISTINCT ON` subqueries, mirroring the existing units/supply-center scoping, instead of hydrating states for every phase.

Both are behaviour-preserving: the same response is produced, but cost no longer grows with the number of historical phases.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only query change

Added `test_list_games_does_not_fetch_phase_options` (asserts the phases prefetch query never selects the `options` column) and `test_list_games_scopes_phase_states_to_current_and_latest_completed` (asserts only the current and latest-completed phases carry hydrated states). The full `game/tests.py` suite (205 tests) plus the list status-field, unread-count, deadline-ordering, and perf-harness suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5cL8q4h6H2iSpkTXs89yz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5cL8q4h6H2iSpkTXs89yz)_