### PR TITLE
perf: fetch only latest phase in Game.current_phase fallback

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -447,16 +447,10 @@ class Game(BaseModel):
             if hasattr(self, "active_phases_list"):
                 return self.active_phases_list[-1] if self.active_phases_list else None
 
-            # If phases were prefetched (e.g. the list/retrieve querysets),
-            # read from the cache rather than issuing another query.
             if "phases" in getattr(self, "_prefetched_objects_cache", {}):
                 phases = list(self.phases.all())
                 return phases[-1] if phases else None
 
-            # Non-prefetched path (e.g. CurrentPhaseMixin on order submission,
-            # order options, phase-state confirm): fetch only the latest phase
-            # instead of loading every phase of the game, including each
-            # historical `options` blob.
             return self.phases.order_by("ordinal").last()
 
     @property

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -447,8 +447,17 @@ class Game(BaseModel):
             if hasattr(self, "active_phases_list"):
                 return self.active_phases_list[-1] if self.active_phases_list else None
 
-            phases = list(self.phases.all())
-            return phases[-1] if phases else None
+            # If phases were prefetched (e.g. the list/retrieve querysets),
+            # read from the cache rather than issuing another query.
+            if "phases" in getattr(self, "_prefetched_objects_cache", {}):
+                phases = list(self.phases.all())
+                return phases[-1] if phases else None
+
+            # Non-prefetched path (e.g. CurrentPhaseMixin on order submission,
+            # order options, phase-state confirm): fetch only the latest phase
+            # instead of loading every phase of the game, including each
+            # historical `options` blob.
+            return self.phases.order_by("ordinal").last()
 
     @property
     def movement_phase_duration_seconds(self):

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -361,6 +361,53 @@ class TestGameRetrieveViewQueryPerformance:
         assert query_count == 5
 
 
+class TestGameCurrentPhase:
+
+    @pytest.mark.django_db
+    def test_current_phase_returns_highest_ordinal(self, active_game_with_phase_state):
+        game = active_game_with_phase_state
+        for i in range(3):
+            game.phases.create(
+                game=game,
+                variant=game.variant,
+                season="Fall",
+                year=1901 + i,
+                type="Movement",
+                status=PhaseStatus.COMPLETED,
+                ordinal=2 + i,
+            )
+
+        assert game.current_phase.ordinal == 4
+
+    @pytest.mark.django_db
+    def test_current_phase_fetches_single_row(self, active_game_with_phase_state):
+        """The non-prefetched fallback must not load every phase of the game
+        to return the latest one — it issues a single ORDER BY / LIMIT query
+        regardless of how many phases exist."""
+        game = active_game_with_phase_state
+        for i in range(5):
+            game.phases.create(
+                game=game,
+                variant=game.variant,
+                season="Fall",
+                year=1901 + i,
+                type="Movement",
+                status=PhaseStatus.COMPLETED,
+                ordinal=2 + i,
+            )
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            phase = game.current_phase
+
+        assert phase.ordinal == 6
+        assert len(connection.queries) == 1
+
+    @pytest.mark.django_db
+    def test_current_phase_none_when_no_phases(self, base_active_game_for_primary_user):
+        assert base_active_game_for_primary_user.current_phase is None
+
+
 class TestGameListView:
 
     @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does

Implements Priority 3 of the endpoint-performance plan. `Game.current_phase`'s non-prefetched fallback executed `list(self.phases.all())` — loading **every** phase of the game, each with its large `options` JSON blob, just to return the last element. This path runs on every request through `CurrentPhaseMixin` (order submission `POST orders/`, order options `GET options/`, phase-state `confirm-phase` PATCH), so it degraded linearly with game age and drove the multi-second P95/max tails on those core gameplay endpoints.

The fallback now fetches a single row via `self.phases.order_by("ordinal").last()` — O(1) instead of O(phases). The prefetched list/retrieve path is preserved: when `phases` is already in the prefetch cache, we read from the cache rather than issuing a fresh query, keeping the game list/retrieve query counts unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

<sub>Tests: new `TestGameCurrentPhase` (highest-ordinal correctness, single-query fetch, empty-game `None`); existing list/retrieve/create/admin query-count guards still pass. Ran `game/`, `order/tests`, `phase/tests.py`, `draw_proposal/tests.py`, `adjudication/tests.py` — all green. No visual changes.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Apk8PEVdu8BH3f1Kkhj6qW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Apk8PEVdu8BH3f1Kkhj6qW)_