### PR TITLE
perf(variant): cache the published GET /variants/ payload

### DIFF
--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -141,8 +141,9 @@ class TestVariantListViewQueryPerformance:
         query_count = len(connection.queries)
 
         # 18 prefetch queries + 2 ETag aggregates (Variant + NationFlag max
-        # updated_at). The ETag is what enables 304 responses on /variants/.
-        assert query_count == 20
+        # updated_at) + 1 published-only gate query (routes the request to the
+        # shared render cache). This is the cache-miss path; hits skip the 18.
+        assert query_count == 21
 
     @pytest.mark.django_db
     def test_list_variants_query_count_with_single_variant(self, authenticated_client, classical_variant):
@@ -177,8 +178,9 @@ class TestVariantListViewQueryPerformance:
         # due to prefetch_related optimization
         query_count = len(connection.queries)
         # 18 prefetch queries + 2 ETag aggregates (Variant + NationFlag max
-        # updated_at). The ETag is what enables 304 responses on /variants/.
-        assert query_count == 20
+        # updated_at) + 1 published-only gate query (routes the request to the
+        # shared render cache). This is the cache-miss path; hits skip the 18.
+        assert query_count == 21
 
 
 class TestPhaseProgressionBackfill:

--- a/service/variant/tests/test_variants_list_performance.py
+++ b/service/variant/tests/test_variants_list_performance.py
@@ -2,14 +2,20 @@ import copy
 import json
 
 import pytest
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 
+from common.constants import VariantStatus
 from variant.models import Variant
 from variant.utils import variant_to_canonical_dict
+
+# The session-wide test cache is a no-op DummyCache; opt individual tests into a
+# real backend so the published-list render cache can actually be exercised.
+_LOCMEM_CACHE = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
 
 @pytest.fixture
@@ -44,7 +50,7 @@ def test_list_variants_baseline_query_count(authenticated_client):
     If this number grows, something added an un-prefetched relation access."""
     query_count, response = _list_query_count(authenticated_client)
     assert len(response.data) >= 2
-    assert query_count <= 20, f"GET /variants/ issued {query_count} queries for {len(response.data)} variants"
+    assert query_count <= 21, f"GET /variants/ issued {query_count} queries for {len(response.data)} variants"
 
 
 @pytest.mark.django_db
@@ -117,3 +123,65 @@ def test_list_variants_etag_changes_when_a_variant_is_uploaded(
     )
     assert after.status_code == status.HTTP_200_OK
     assert after["ETag"] != initial_etag
+
+
+@pytest.mark.django_db
+def test_published_variants_list_served_from_render_cache(authenticated_client):
+    """A second request for the published list skips the heavy prefetch queries
+    and is served from the render cache with byte-identical data."""
+    with override_settings(CACHES=_LOCMEM_CACHE):
+        cache.clear()
+        miss_count, miss_response = _list_query_count(authenticated_client)
+        hit_count, hit_response = _list_query_count(authenticated_client)
+
+    assert hit_response.data == miss_response.data
+    # The hit path runs only the content-version aggregates and the
+    # published-only gate query; the ~18 prefetch queries are skipped.
+    assert hit_count < miss_count
+    assert hit_count <= 5
+
+
+@pytest.mark.django_db
+def test_render_cache_key_isolates_colorblind_mode(user_factory, authenticated_client_factory):
+    """Colorblind and non-colorblind users are published-only, but the cache key
+    encodes the mode so they never receive each other's palette."""
+    normal_user = user_factory()
+    colorblind_user = user_factory()
+    colorblind_user.profile.colorblind_mode = "deuteranopia"
+    colorblind_user.profile.save()
+
+    normal_client = authenticated_client_factory(normal_user)
+    colorblind_client = authenticated_client_factory(colorblind_user)
+
+    with override_settings(CACHES=_LOCMEM_CACHE):
+        cache.clear()
+        normal = normal_client.get(reverse("variant-list"))
+        colorblind = colorblind_client.get(reverse("variant-list"))
+
+    def nation_colors(response):
+        return {nation["color"] for variant in response.data for nation in variant["nations"]}
+
+    assert nation_colors(normal) != nation_colors(colorblind)
+
+
+@pytest.mark.django_db
+def test_draft_owner_is_not_served_published_cache(
+    unauthenticated_client, user_factory, authenticated_client_factory
+):
+    """Warming the shared cache from a published-only request must not cause a
+    draft owner to be served the cached payload in place of their own draft."""
+    owner = user_factory()
+    draft = Variant.objects.create(
+        id="cache-draft", name="Cache Draft", description="",
+        status=VariantStatus.DRAFT, owner=owner,
+    )
+    owner_client = authenticated_client_factory(owner)
+
+    with override_settings(CACHES=_LOCMEM_CACHE):
+        cache.clear()
+        anonymous = unauthenticated_client.get(reverse("variant-list"))
+        assert draft.id not in {v["id"] for v in anonymous.data}
+
+        owned = owner_client.get(reverse("variant-list"))
+
+    assert draft.id in {v["id"] for v in owned.data}

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -2,8 +2,9 @@ import gzip
 import hashlib
 import json
 
+from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Max
+from django.db.models import Max, Q
 from django.http import HttpResponse, HttpResponseNotFound
 from django.views import View
 from rest_framework import generics, permissions, status
@@ -17,6 +18,11 @@ from province.models import Province
 from .models import Variant, VariantSvg
 from .serializers import VariantSerializer, VariantWriteSerializer
 from .utils import variant_to_canonical_dict
+
+# Rendered published-variant lists are cached under a key that encodes the
+# content-version inputs, so entries self-invalidate whenever a variant or flag
+# changes. The timeout only bounds memory for keys that are never re-requested.
+_VARIANTS_LIST_CACHE_TIMEOUT = 60 * 60 * 24
 
 
 class IsOwnedDraftForWrite(permissions.BasePermission):
@@ -32,18 +38,45 @@ class IsOwnedDraftForWrite(permissions.BasePermission):
         )
 
 
-def _variants_list_etag(user):
-    variant_max = Variant.objects.aggregate(Max("updated_at"))["updated_at__max"]
-    flag_max = NationFlag.objects.aggregate(Max("updated_at"))["updated_at__max"]
-    mode = None
+def _colorblind_mode(user):
     if user.is_authenticated:
         profile = getattr(user, "profile", None)
         if profile is not None:
-            mode = profile.colorblind_mode
+            return profile.colorblind_mode
+    return None
+
+
+def _variants_list_cache_inputs(user):
+    variant_max = Variant.objects.aggregate(Max("updated_at"))["updated_at__max"]
+    flag_max = NationFlag.objects.aggregate(Max("updated_at"))["updated_at__max"]
+    return variant_max, flag_max, _colorblind_mode(user)
+
+
+def _variants_list_etag(variant_max, flag_max, user, mode):
     digest = hashlib.sha256(
         f"{variant_max}|{flag_max}|{user.id}|{mode}".encode()
     ).hexdigest()
     return f'"{digest[:32]}"'
+
+
+def _user_sees_only_published_variants(user):
+    """Whether ``visible_to(user)`` returns exactly the published variants.
+
+    True for anonymous users and for authenticated users who neither own a
+    draft nor belong to a game running a non-published variant — the common
+    case, and the only one whose payload can be served from the shared cache.
+    Mirrors the non-published clauses of ``VariantQuerySet.visible_to``.
+    """
+    if not user.is_authenticated:
+        return True
+    return not (
+        Variant.objects.filter(
+            Q(status=VariantStatus.DRAFT, owner=user)
+            | Q(games__members__user=user)
+        )
+        .exclude(status=VariantStatus.PUBLISHED)
+        .exists()
+    )
 
 
 class VariantListCreateView(generics.ListCreateAPIView):
@@ -64,24 +97,35 @@ class VariantListCreateView(generics.ListCreateAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        user = self.request.user
-        mode = None
-        if user.is_authenticated:
-            profile = getattr(user, "profile", None)
-            if profile is not None:
-                mode = profile.colorblind_mode
-        context["colorblind_mode"] = mode
+        context["colorblind_mode"] = _colorblind_mode(self.request.user)
         return context
 
     def list(self, request, *args, **kwargs):
-        etag = _variants_list_etag(request.user)
+        variant_max, flag_max, mode = _variants_list_cache_inputs(request.user)
+        etag = _variants_list_etag(variant_max, flag_max, request.user, mode)
         if request.headers.get("If-None-Match") == etag:
             response = Response(status=status.HTTP_304_NOT_MODIFIED)
+        elif _user_sees_only_published_variants(request.user):
+            response = Response(self._published_variants_data(variant_max, flag_max, mode))
         else:
             response = super().list(request, *args, **kwargs)
         response["ETag"] = etag
         response["Cache-Control"] = "private, no-cache"
         return response
+
+    def _published_variants_data(self, variant_max, flag_max, mode):
+        digest = hashlib.sha256(f"{variant_max}|{flag_max}|{mode}".encode()).hexdigest()
+        cache_key = f"variants-list:published:{digest}"
+        data = cache.get(cache_key)
+        if data is None:
+            queryset = Variant.objects.filter(
+                status=VariantStatus.PUBLISHED
+            ).with_related_data()
+            serialized = self.get_serializer(queryset, many=True).data
+            # Strip DRF's request-bound wrappers so the payload pickles cleanly.
+            data = json.loads(json.dumps(serialized))
+            cache.set(cache_key, data, _VARIANTS_LIST_CACHE_TIMEOUT)
+        return data
 
 
 class VariantDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -93,13 +137,7 @@ class VariantDetailView(generics.RetrieveUpdateDestroyAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        user = self.request.user
-        mode = None
-        if user.is_authenticated:
-            profile = getattr(user, "profile", None)
-            if profile is not None:
-                mode = profile.colorblind_mode
-        context["colorblind_mode"] = mode
+        context["colorblind_mode"] = _colorblind_mode(self.request.user)
         return context
 
     def get_serializer_class(self):


### PR DESCRIPTION
## What this PR does

`GET /variants/` has the worst P50 (806ms) of any real-traffic user-facing route and is fetched on app start, so it delays first paint of anything variant-dependent. An ETag already exists, but the P50 shows most requests still pay the full board-definition build, and the ETag hashes `user.id`, needlessly fragmenting a payload that is identical across users (the only user-dependent inputs are colorblind mode and draft/member visibility).

This adds a **server-side render cache** for the common published-variants case (Priority 4 / §4 of the endpoint-performance docs):

- The cache key encodes only the content-version inputs the ETag already computes **minus `user.id`** — `variant`/`flag` max `updated_at` plus colorblind mode — so entries are shared across users and self-invalidate whenever a variant or flag changes (near-100% hit rate, since variants change rarely).
- A cheap gate query (`_user_sees_only_published_variants`) routes only requests whose visible set is exactly the published set — anonymous users, and authenticated users with no drafts and no non-published game memberships — to the shared cache. It mirrors the non-published clauses of `VariantQuerySet.visible_to`. Everyone else keeps the existing per-user path, unchanged.
- On a cache hit, the ~18 board-definition prefetch queries collapse to the two content-version aggregates plus the gate query.
- `ETag` and `Cache-Control: private, no-cache` behaviour is preserved on every response branch (304, cached 200, uncached 200).

Also folds the three duplicated `colorblind_mode` lookups in the view module into a single `_colorblind_mode` helper.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend-only

### Tests

- `test_published_variants_list_served_from_render_cache` — a second published-list request is served from cache with byte-identical data and skips the heavy prefetch queries.
- `test_render_cache_key_isolates_colorblind_mode` — colorblind and non-colorblind users never receive each other's palette (key encodes the mode).
- `test_draft_owner_is_not_served_published_cache` — warming the shared cache from a published-only request never leaks the cached payload to a draft owner in place of their own draft.
- Existing query-count guards updated from 20 → 21 (the added published-only gate query, measured on the cache-miss path that tests exercise under `DummyCache`); comments updated to explain it.

Full `service/variant/` suite passes (162 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYdKwc8UN5HzVz4F4hveT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYdKwc8UN5HzVz4F4hveT8)_