### PR TITLE
perf(game): optimize GET game/<id>/ retrieve queryset

### DIFF
--- a/service/channel/tests/test_channel.py
+++ b/service/channel/tests/test_channel.py
@@ -5,8 +5,11 @@ from django.apps import apps
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.test import APIRequestFactory
 from channel.models import Channel, ChannelMessage
 from bot.utils import get_bot_user
+from game.models import Game
+from game.serializers import GameRetrieveSerializer
 
 from common.constants import GameStatus
 
@@ -688,6 +691,18 @@ class TestGameRetrieveUnreadCount:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["total_unread_message_count"] == 0
+
+    @pytest.mark.django_db
+    def test_retrieve_serializer_computes_unread_without_annotation(
+        self, game_with_public_channel_and_messages, primary_user
+    ):
+        game = Game.objects.get(pk=game_with_public_channel_and_messages.pk)
+        request = APIRequestFactory().get("/")
+        request.user = primary_user
+
+        data = GameRetrieveSerializer(game, context={"request": request}).data
+
+        assert data["total_unread_message_count"] == 2
 
 
 @pytest.fixture

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -10,6 +10,7 @@ from django.db.models import (
     IntegerField,
     OuterRef,
     Prefetch,
+    Q,
     Subquery,
     Value,
 )
@@ -130,16 +131,29 @@ class GameQuerySet(models.QuerySet):
             queryset=Member.objects.select_related("user__profile", "user__bot_profile", "nation__flag")
         )
 
+        current_phase_ids = (
+            Phase.objects.order_by("game_id", "-ordinal")
+            .distinct("game_id")
+            .values("id")
+        )
+        latest_completed_phase_ids = (
+            Phase.objects.filter(status=PhaseStatus.COMPLETED)
+            .order_by("game_id", "-ordinal")
+            .distinct("game_id")
+            .values("id")
+        )
         phase_states_prefetch = Prefetch(
             "phase_states",
-            queryset=PhaseState.objects.select_related("member__user").annotate(
+            queryset=PhaseState.objects.filter(
+                Q(phase__in=current_phase_ids) | Q(phase__in=latest_completed_phase_ids)
+            ).select_related("member__user").annotate(
                 order_count=Count("orders")
             )
         )
 
         phases_prefetch = Prefetch(
             "phases",
-            queryset=Phase.objects.prefetch_related(phase_states_prefetch)
+            queryset=Phase.objects.defer("options").prefetch_related(phase_states_prefetch)
         )
 
         return self.select_related("variant", "victory", "game_master__profile").prefetch_related(

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 from django.conf import settings
 from rest_framework import serializers
 from django.db import transaction
-from django.db.models import Count, Q, Subquery, OuterRef
+from django.db.models import Subquery, OuterRef
 from django.apps import apps
 from drf_spectacular.utils import extend_schema_field
 from opentelemetry import trace
@@ -273,6 +273,9 @@ class GameRetrieveSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.IntegerField)
     def get_total_unread_message_count(self, obj):
+        annotated = getattr(obj, "total_unread_message_count", None)
+        if annotated is not None:
+            return annotated
         user = self.context["request"].user
         if not user.is_authenticated:
             return 0

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -248,7 +248,7 @@ class TestGameRetrieveViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 5
+        assert query_count == 4
 
     @pytest.mark.django_db
     def test_retrieve_game_query_count_multiple_phases_with_units(
@@ -289,7 +289,7 @@ class TestGameRetrieveViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 5
+        assert query_count == 4
 
     @pytest.mark.django_db
     def test_retrieve_game_query_count_with_multiple_members(
@@ -358,7 +358,7 @@ class TestGameRetrieveViewQueryPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 5
+        assert query_count == 4
 
 
 class TestGameListView:

--- a/service/game/tests/test_game_retrieve_status_fields.py
+++ b/service/game/tests/test_game_retrieve_status_fields.py
@@ -1,0 +1,100 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from common.constants import GameStatus, PhaseStatus
+from game.models import Game
+from phase.models import PhaseState
+
+
+@pytest.mark.django_db
+def test_order_status_reads_current_phase_state(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Retrieve Order Status Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    member = game.members.create(user=primary_user, nation=classical_england_nation)
+    phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=1,
+    )
+    phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_confirmed=False,
+    )
+
+    response = authenticated_client.get(reverse("game-retrieve", args=[game.id]))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["order_status"] == "orders_required"
+
+
+@pytest.mark.django_db
+def test_member_status_reads_latest_completed_phase_state(
+    authenticated_client,
+    db,
+    primary_user,
+    classical_variant,
+    classical_england_nation,
+):
+    game = Game.objects.create(
+        name="Retrieve Member Status Game",
+        variant=classical_variant,
+        status=GameStatus.ACTIVE,
+    )
+    member = game.members.create(user=primary_user, nation=classical_england_nation)
+
+    oldest_phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.COMPLETED,
+        ordinal=1,
+    )
+    oldest_phase.phase_states.create(member=member, has_possible_orders=True)
+
+    latest_completed_phase = game.phases.create(
+        variant=classical_variant,
+        season="Fall",
+        year=1901,
+        type="Movement",
+        status=PhaseStatus.COMPLETED,
+        ordinal=2,
+    )
+    latest_completed_phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_outcome=PhaseState.OrdersOutcome.NMR,
+    )
+
+    current_phase = game.phases.create(
+        variant=classical_variant,
+        season="Spring",
+        year=1902,
+        type="Movement",
+        status=PhaseStatus.ACTIVE,
+        ordinal=3,
+    )
+    current_phase.phase_states.create(
+        member=member,
+        has_possible_orders=True,
+        orders_confirmed=False,
+    )
+
+    response = authenticated_client.get(reverse("game-retrieve", args=[game.id]))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "nmr" in response.data["member_status"]

--- a/service/game/views.py
+++ b/service/game/views.py
@@ -33,10 +33,13 @@ class GameRetrieveView(generics.RetrieveAPIView):
     permission_classes = [permissions.AllowAny]
     serializer_class = GameRetrieveSerializer
 
-    queryset = Game.objects.all().with_retrieve_data()
-
     def get_object(self):
-        return get_object_or_404(self.queryset, id=self.kwargs.get("game_id"))
+        queryset = (
+            Game.objects.all()
+            .with_retrieve_data()
+            .with_total_unread_counts(self.request.user)
+        )
+        return get_object_or_404(queryset, id=self.kwargs.get("game_id"))
 
 
 class GameListView(generics.ListAPIView):


### PR DESCRIPTION
## What this PR does

Implements Priority 2 from the endpoint-performance analysis (`GET game/<id>/`) — the highest-volume route (~410k req/wk) and the #1 consumer of total server time. It eliminates over-fetching whose cost grows linearly with game age. Three changes:

- **Defer the `options` blob.** The phases prefetch in `with_retrieve_data()` now `.defer("options")`, so the large per-phase adjudication-options JSON is no longer loaded for every phase. The retrieve serializer only reads phase ids, ordinals, statuses and phase states — never `options`.
- **Scope the phase-states prefetch.** Phase states are now prefetched only for each game's current phase and latest completed phase (the only phases the serializer reads phase states from), mirroring how `current_units_prefetch` already scopes units. Confirmed in generated SQL to use `DISTINCT ON` plus the current/latest-completed union.
- **Annotate the unread count on the hot path.** The retrieve queryset now calls `with_total_unread_counts(user)` (already used by the list path) and the serializer reads that annotation when present — dropping the hand-rolled per-request count query on the GET. `request.user` is plumbed into `get_object`. The serializer falls back to computing the count only when the annotation is absent, so paths that reuse `GameRetrieveSerializer` with an unannotated instance (pause / unpause / extend-deadline) keep returning the correct count.

Net effect: the retrieve endpoint drops from 5 to 4 queries and the query count no longer grows with the number of phases in a game.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only

### Notes
- Query-count assertion for the retrieve endpoint updated `5 → 4` (the eliminated per-request unread query on the annotated GET path). Create/sandbox counts are unchanged — those paths serialize an unannotated instance and correctly fall back to the count query.
- New tests: `service/game/tests/test_game_retrieve_status_fields.py` guards `order_status` (current phase) and `member_status`/NMR (latest completed phase) on the retrieve path — the fields most affected by the phase-states scoping. `test_channel.py` adds a serializer test asserting the unread count is still computed correctly on an unannotated instance (the pause/unpause/extend reuse path).
- No `openapi-schema.yaml` change — the serializer's public shape is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)