### PR TITLE
Add Android release CI/CD workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,73 @@
+name: Android Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/web/**"
+
+concurrency:
+  group: android-release
+  cancel-in-progress: false
+
+env:
+  PLAY_TRACK: beta
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: packages/web
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses || true
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: packages/web/package-lock.json
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          working-directory: packages/web
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build web app
+        run: npm run build
+        env:
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          VITE_DIPLICITY_API_BASE_URL: ${{ vars.SERVICE_BASE_URL }}
+          VITE_MAINTENANCE_MODE: ${{ vars.MAINTENANCE_MODE }}
+
+      - name: Sync Capacitor
+        run: npx cap sync android
+
+      - name: Write google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
+
+      - name: Build and upload to Play Console beta track
+        run: bundle exec fastlane android release
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/packages/web/fastlane/Fastfile
+++ b/packages/web/fastlane/Fastfile
@@ -201,18 +201,8 @@ platform :android do
     end
   end
 
-  private_lane :bump_patch_version do
-    package_json_path = File.join(WEB_ROOT, "package.json")
-    package = JSON.parse(File.read(package_json_path))
-    major, minor, patch = package["version"].split(".").map(&:to_i)
-    package["version"] = "#{major}.#{minor}.#{patch + 1}"
-    File.write(package_json_path, JSON.pretty_generate(package) + "\n")
-    UI.success("Bumped version to #{package["version"]}")
-  end
-
   desc "Build signed AAB and upload to Play Console internal testing track"
   lane :release do
-    bump_patch_version
     build_aab
     upload_to_play
   end


### PR DESCRIPTION
## What this PR does

Adds `android-release.yml`, mirroring the existing `ios-release.yml`: on every push to `main` that touches `packages/web/**`, it builds a signed Android AAB and uploads it to the Play Store **beta** track via the existing `bundle exec fastlane android release` lane. It runs on `ubuntu-latest` (no macOS needed for Android), sets up JDK 21 and the Android SDK, and explicitly accepts SDK licenses — otherwise Gradle silently stalls waiting for license acceptance.

It also writes the `GOOGLE_SERVICES_JSON` secret to `packages/web/android/app/google-services.json` before the Fastlane step. That file is gitignored and `build.gradle` applies the Firebase plugin conditionally, so without this step the build would succeed silently without Firebase and the beta release would ship with push notifications broken (flagged in issue comments).

Per feedback on the issue, this also removes `bump_patch_version` from the `android release` Fastlane lane (and the now-unused private lane itself) — version bumps should be a deliberate developer action, not a CI side effect, and `versionCode` (already a Unix timestamp) lets Play Console accept every upload regardless of `versionName`.

**Note for reviewer:** the first CI run will only succeed once the required secrets (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`, `PLAY_SERVICE_ACCOUNT_JSON`, `GOOGLE_SERVICES_JSON`) are set in the repo, at least one manual AAB has been uploaded to the Play Console beta track, and the Play service account has the Release Manager role — all called out in the issue thread.

Closes #925


---
_Generated by [Claude Code](https://claude.ai/code/session_0157u8SxvGdcNbxGPJ9Xp2Ya)_