### PR TITLE
Fix canvas map base rasterisation offset

### DIFF
--- a/packages/web/src/components/GameMapCanvas/rasterizeSvg.test.ts
+++ b/packages/web/src/components/GameMapCanvas/rasterizeSvg.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { injectSvgDimensions } from "./rasterizeSvg";
+
+describe("injectSvgDimensions", () => {
+  it("stamps width and height onto the root svg tag", () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><g/></svg>';
+    const sized = injectSvgDimensions(svg, 100, 50);
+    expect(sized).toBe(
+      '<svg width="100" height="50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><g/></svg>'
+    );
+  });
+
+  it("preserves the existing viewBox so aspect ratio is unchanged", () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1234.5 987.25"></svg>';
+    const sized = injectSvgDimensions(svg, 1234.5, 987.25);
+    expect(sized).toContain('viewBox="0 0 1234.5 987.25"');
+    expect(sized).toContain('width="1234.5"');
+    expect(sized).toContain('height="987.25"');
+  });
+});

--- a/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
+++ b/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
@@ -1,3 +1,14 @@
+// An SVG with a viewBox but no width/height has no intrinsic size, so a
+// browser can fall back to a default concrete size (300×150) and letterbox
+// the content when it's drawn as an <image>. Stamping the root tag with the
+// same width/height the canvas will use keeps the rasterised base aligned
+// with the vector overlays, which Leaflet positions from the true viewBox.
+export const injectSvgDimensions = (
+  svg: string,
+  width: number,
+  height: number
+): string => svg.replace("<svg ", `<svg width="${width}" height="${height}" `);
+
 // Rasterises an SVG string to a PNG object URL once. Per the map re-architecture
 // proposal, the static base is rasterised a single time and thereafter only
 // moved by the camera, so the ~17k path commands are never repainted per frame.
@@ -9,29 +20,39 @@ export const rasterizeSvg = (
   height: number
 ): Promise<string> =>
   new Promise((resolve, reject) => {
-    const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+    const sizedSvg = injectSvgDimensions(svg, width, height);
+    const blob = new Blob([sizedSvg], { type: "image/svg+xml;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const image = new Image();
 
-    image.onload = () => {
-      const canvas = document.createElement("canvas");
-      canvas.width = Math.max(1, Math.round(width));
-      canvas.height = Math.max(1, Math.round(height));
-      const context = canvas.getContext("2d");
-      if (!context) {
-        URL.revokeObjectURL(url);
-        reject(new Error("Could not acquire a 2D canvas context"));
-        return;
-      }
-      context.drawImage(image, 0, 0, canvas.width, canvas.height);
-      URL.revokeObjectURL(url);
-      canvas.toBlob((png) => {
-        if (!png) {
-          reject(new Error("Failed to rasterise base map to PNG"));
-          return;
+    image.onload = async () => {
+      try {
+        // Decoding is async and cache-dependent; waiting for it to settle
+        // before drawImage avoids racing a partially decoded frame under
+        // rapid successive map loads.
+        if (image.decode) {
+          await image.decode();
         }
-        resolve(URL.createObjectURL(png));
-      }, "image/png");
+        const canvas = document.createElement("canvas");
+        canvas.width = Math.max(1, Math.round(width));
+        canvas.height = Math.max(1, Math.round(height));
+        const context = canvas.getContext("2d");
+        if (!context) {
+          throw new Error("Could not acquire a 2D canvas context");
+        }
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        canvas.toBlob((png) => {
+          if (!png) {
+            reject(new Error("Failed to rasterise base map to PNG"));
+            return;
+          }
+          resolve(URL.createObjectURL(png));
+        }, "image/png");
+      } catch (error) {
+        reject(error);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     };
 
     image.onerror = () => {


### PR DESCRIPTION
## What this PR does

Fixes intermittent misalignment between the rasterised base map and the live vector overlays on the Leaflet canvas map.

`DiplicityMap.render()` emits an SVG with a `viewBox` but no `width`/`height`. `rasterizeSvg` loaded that string into an `Image` and drew it with `drawImage`, but without an intrinsic size the browser can fall back to a default concrete size (300×150) and letterbox the content, which then gets stretched to fill the canvas — offsetting and mis-scaling the base relative to the overlays Leaflet positions from the true viewBox bounds.

The fix stamps the root `<svg>` tag with the same `width`/`height` the canvas uses before rasterising (mirroring the `StaticMap` cover path in `MapView.tsx`), and awaits `image.decode()` before `drawImage` so a partially decoded frame can't race in under rapid successive map loads — matching the intermittent, timing/cache-dependent symptom described in the issue.

Closes #975

---
_Generated by [Claude Code](https://claude.ai/code/session_012KHRDamgq28RMawZJDuVDg)_