### PR TITLE
Restore always-loaded guardrails demoted by the CLAUDE.md refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,11 @@ python -m pytest -n auto --reuse-db # full suite
    - `npx tsc -b --noEmit` in `packages/web` (required after codegen or type changes)
 4. **Run tests to validate changes** — single file at a time for faster feedback.
 5. **Never suppress lint/type violations** — no `eslint-disable`, `@ts-ignore`, `# noqa`, `pytest.mark.skip`. The only exception is the documented mutation-in-`useEffect` pattern (see the `frontend` skill).
-6. **Prefer derived state over effects** — minimise `useEffect` usage in React.
-7. **Write tests alongside features** — not as an afterthought.
-8. **Self-review non-trivial PRs with `/review-pr`** before requesting human review. Address or explicitly respond to all findings. Trivial PRs (typo fixes, dep bumps, doc-only) are exempt.
-9. **PR description must match the diff** — run `git diff main` and confirm every described change is visible. Do not describe work from a prior PR or session.
+6. **No comments or docstrings** — do not add code comments or docstrings, including in tests; do not annotate assertions to explain their values. The only exceptions are DRF view docstrings (extracted for OpenAPI) and the `eslint-disable` comment on the documented mutation-in-`useEffect` pattern.
+7. **Prefer derived state over effects** — minimise `useEffect` usage in React.
+8. **Write tests alongside features** — not as an afterthought.
+9. **Self-review non-trivial PRs with `/review-pr`** before requesting human review. Address or explicitly respond to all findings. Trivial PRs (typo fixes, dep bumps, doc-only) are exempt.
+10. **PR description must match the diff** — run `git diff main` and confirm every described change is visible. Do not describe work from a prior PR or session.
 
 ---
 
@@ -111,6 +112,9 @@ Before creating an issue where the right approach is unclear, open a [GitHub Dis
 
 ### Issue format
 Three sections (enforced by the `create-issue` skill): **Goal** (always), **Context** (when useful), **Approach** (when discussed). No acceptance criteria, implementation checklists, or sub-issues. If work is too large for one PR, split into two issues.
+
+### PR screenshots
+If a PR changes anything visible in the web app — new screens, layout, styling, copy, empty/error states — you MUST take screenshots of the changed component and embed them in the PR description. This is a completion criterion, not optional polish; the reviewer should see what changed without pulling the branch. See the `frontend` skill for the screenshot and attachment workflow.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Fixes two behavioral regressions introduced by #829 (CLAUDE.md monolith → lean core + skills). That refactor was right to move *reference material* (iOS/Android/Metabase/production) into on-demand skills, but it also moved two cross-cutting *behavioral guardrails* out — and those now only fire when a skill happens to be invoked, which isn't reliable:

- **Inline comments crept back in.** The no-comments/no-docstrings rule ended up only in the `backend` skill (not even `frontend`), so frontend and general work no longer saw it.
- **Screenshots stopped appearing on PRs.** The "always screenshot visual PRs" directive ended up only in the `frontend` skill, so any PR that didn't trigger a frontend-skill load skipped screenshots — and attaching a screenshot is a PR-completion behavior, not something a skill load reliably precedes.

This promotes both directives back into the always-loaded core, while leaving the *how-to* mechanics in the skills:

- New **"No comments or docstrings"** development guideline (with the DRF-docstring and `eslint-disable`-on-`useEffect` exceptions).
- New **"PR screenshots"** completion criterion under GitHub Workflow, pointing to the `frontend` skill for the workflow.

Net addition is a handful of lines, so #829's baseline token saving is preserved — this corrects *what* got demoted, not the refactor itself.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — N/A, docs-only change
- [ ] Tests cover the change — N/A, documentation-only
- [ ] Screenshots embedded in the PR description for any visual changes — N/A, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5xrezoGstu5jgGbJ9miA7)_