### PR TITLE
Let bots reply in private channels

### DIFF
--- a/service/bot/decorators.py
+++ b/service/bot/decorators.py
@@ -50,12 +50,10 @@ def with_bot_members(func):
     return wrapper
 
 
-def on_public_chat_message(func):
+def on_human_chat_message(func):
     @functools.wraps(func)
     def wrapper(sender, instance, created, **kwargs):
         if not created:
-            return
-        if instance.channel.private:
             return
         if Member.objects.filter(pk=instance.sender_id, user__bot_profile__isnull=False).exists():
             return

--- a/service/bot/signals.py
+++ b/service/bot/signals.py
@@ -8,9 +8,9 @@ from phase.models import Phase, PhaseState
 
 from bot.decorators import (
     capture_phase_status,
+    on_human_chat_message,
     on_orders_confirmed,
     on_phase_activated,
-    on_public_chat_message,
     when_humans_confirmed,
     with_bot_channel_members,
     with_bot_members,
@@ -57,11 +57,11 @@ def finalize(sender, instance, phase, bot_phase_states, **kwargs):
 
 
 @receiver(post_save, sender=ChannelMessage)
-@on_public_chat_message
+@on_human_chat_message
 @with_bot_channel_members
 def reply(sender, instance, bot_members, **kwargs):
     logger.info(
-        f"[bot.reply signal] message {instance.id} in public channel {instance.channel_id} "
+        f"[bot.reply signal] message {instance.id} in channel {instance.channel_id} "
         f"(game {instance.channel.game_id})"
     )
     for member in bot_members:

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -898,7 +898,35 @@ def bot_public_channel_factory(bot_game_factory):
     return _create
 
 
+@pytest.fixture
+def bot_private_channel_factory(bot_game_factory):
+    def _create():
+        game = bot_game_factory()
+        channel = game.channels.create(name="Private", private=True)
+        for member in game.members.all():
+            channel.member_channels.create(member=member)
+        return game, channel
+
+    return _create
+
+
 class TestReplyTask:
+
+    @pytest.mark.django_db
+    def test_reply_posts_message_in_private_channel(
+        self, bot_private_channel_factory, in_memory_procrastinate
+    ):
+        game, channel = bot_private_channel_factory()
+        bot_user = get_bot_user()
+        bot_member = game.members.get(user=bot_user)
+        human_member = game.members.get(user=game.created_by)
+        ChannelMessage.objects.create(channel=channel, sender=human_member, body="Just between us")
+
+        with patch("bot.tasks.LLMClient") as mock_llm:
+            mock_llm.return_value.complete.return_value = _reply_response(True, "Understood.")
+            tasks.reply(user_id=bot_user.id, game_id=game.id, channel_id=channel.id)
+
+        assert channel.messages.filter(sender=bot_member, body="Understood.").exists()
 
     @pytest.mark.django_db
     def test_reply_posts_message_when_model_replies(
@@ -1029,7 +1057,7 @@ class TestReplyTrigger:
         assert len(_bot_reply_jobs(in_memory_procrastinate)) == 0
 
     @pytest.mark.django_db
-    def test_private_channel_message_does_not_defer_reply(
+    def test_private_channel_message_defers_reply(
         self, bot_public_channel_factory, in_memory_procrastinate
     ):
         game, _ = bot_public_channel_factory()
@@ -1044,6 +1072,35 @@ class TestReplyTrigger:
         response = human_client.post(
             reverse("channel-message-create", args=[game.id, private.id]),
             {"body": "Just between us"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        jobs = _bot_reply_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        assert jobs[0]["lock"] == f"reply-{response.data['id']}-{bot_member.id}"
+        assert jobs[0]["args"] == {
+            "user_id": get_bot_user().id,
+            "game_id": game.id,
+            "channel_id": private.id,
+        }
+
+    @pytest.mark.django_db
+    def test_private_channel_without_bot_member_does_not_defer_reply(
+        self, bot_public_channel_factory, in_memory_procrastinate, secondary_user
+    ):
+        game, _ = bot_public_channel_factory()
+        human_member = game.members.get(user=game.created_by)
+        other_member = game.members.create(user=secondary_user)
+        private = game.channels.create(name="Private", private=True)
+        private.member_channels.create(member=human_member)
+        private.member_channels.create(member=other_member)
+
+        human_client = APIClient()
+        human_client.force_authenticate(user=game.created_by)
+        response = human_client.post(
+            reverse("channel-message-create", args=[game.id, private.id]),
+            {"body": "No bots here"},
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
## What this PR does

Bots previously only responded to messages in public press — a message sent to a bot in a private channel got no reply. The reply signal's `on_public_chat_message` decorator returned early whenever `instance.channel.private` was true. The reply task, reply prompts (which already mark channels `(public)`/`(private)`), and the context builder already handle private channels correctly, and `with_bot_channel_members` already restricts triggering to channels the bot belongs to, so dropping the guard is sufficient to make bots respond in private channels they're a member of.

The decorator is renamed `on_public_chat_message` → `on_human_chat_message` to reflect that it now fires for any human-sent chat message regardless of channel privacy (it still skips messages sent by bots).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

Test changes:
- `test_private_channel_message_defers_reply` — human message in a private channel the bot belongs to now defers a reply job (inverted from the old `does_not_defer` test).
- `test_private_channel_without_bot_member_does_not_defer_reply` — a private channel the bot is *not* in still defers nothing.
- `test_reply_posts_message_in_private_channel` — end-to-end: the reply task posts the bot's message into a private channel.

No visual changes — backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMH2xsnkYBipfSC83epPBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMH2xsnkYBipfSC83epPBN)_