### PR TITLE
Redirect logged-in users from unknown routes to home

### DIFF
--- a/packages/web/src/Router.test.tsx
+++ b/packages/web/src/Router.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import Router, { GameIndexRoute } from "./Router";
-import { getVariantsListQueryKey } from "./api/generated/endpoints";
+import type { LoaderFunctionArgs } from "react-router";
+import { GameIndexRoute, createAuthenticatedRoutes } from "./Router";
 
 const mockUseIsMobile = vi.fn();
 
@@ -12,31 +12,20 @@ vi.mock("./hooks/use-mobile", () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
 
-vi.mock("./components/HomeLayout", () => ({
-  HomeLayout: ({ children }: { children: React.ReactNode }) => children,
+vi.mock("./screens", () => ({
+  GameDetail: {
+    MapScreen: React.lazy(() =>
+      Promise.resolve({ default: () => <div data-testid="map-screen" /> })
+    ),
+    OrdersScreen: React.lazy(() =>
+      Promise.resolve({ default: () => <div data-testid="orders-screen" /> })
+    ),
+  },
+  Home: {},
+  Variants: {},
+  LLMCalls: {},
+  Tutorial: {},
 }));
-
-vi.mock("./screens", () => {
-  const passthrough: React.FC = () => null;
-  const proxy = (overrides: Record<string, React.FC> = {}) =>
-    new Proxy(overrides, {
-      get: (target, prop) => target[prop as string] ?? passthrough,
-    });
-  return {
-    Home: proxy({ MyGames: () => <div data-testid="home-screen" /> }),
-    GameDetail: proxy({
-      MapScreen: React.lazy(() =>
-        Promise.resolve({ default: () => <div data-testid="map-screen" /> })
-      ),
-      OrdersScreen: React.lazy(() =>
-        Promise.resolve({ default: () => <div data-testid="orders-screen" /> })
-      ),
-    }),
-    Variants: proxy(),
-    LLMCalls: proxy(),
-    Tutorial: proxy(),
-  };
-});
 
 const renderRoute = () =>
   render(
@@ -67,20 +56,23 @@ describe("GameIndexRoute", () => {
   });
 });
 
-describe("Router", () => {
-  const createQueryClient = () => {
-    const queryClient = new QueryClient();
-    queryClient.setQueryDefaults(getVariantsListQueryKey(), {
-      staleTime: Infinity,
-    });
-    queryClient.setQueryData(getVariantsListQueryKey(), []);
-    return queryClient;
-  };
+describe("createAuthenticatedRoutes", () => {
+  it("redirects unknown paths to home so logged-in users never hit a 404", async () => {
+    const routes = createAuthenticatedRoutes(new QueryClient());
+    const catchAll = routes.find((route) => route.path === "*");
 
-  it("redirects a logged-in user from an unknown path to home", async () => {
-    window.history.pushState({}, "", "/register");
-    render(<Router loggedIn queryClient={createQueryClient()} />);
-    expect(await screen.findByTestId("home-screen")).toBeTruthy();
-    expect(window.location.pathname).toBe("/");
+    expect(catchAll).toBeDefined();
+    if (typeof catchAll?.loader !== "function") {
+      throw new Error("Expected the catch-all route to have a loader");
+    }
+
+    const response = await catchAll.loader({
+      request: new Request("http://localhost/register"),
+      params: {},
+    } as unknown as LoaderFunctionArgs);
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+    expect((response as Response).headers.get("Location")).toBe("/");
   });
 });

--- a/packages/web/src/Router.test.tsx
+++ b/packages/web/src/Router.test.tsx
@@ -1,8 +1,10 @@
 import React, { Suspense } from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { GameIndexRoute } from "./Router";
+import Router, { GameIndexRoute } from "./Router";
+import { getVariantsListQueryKey } from "./api/generated/endpoints";
 
 const mockUseIsMobile = vi.fn();
 
@@ -10,18 +12,31 @@ vi.mock("./hooks/use-mobile", () => ({
   useIsMobile: () => mockUseIsMobile(),
 }));
 
-vi.mock("./screens", () => ({
-  GameDetail: {
-    MapScreen: React.lazy(() =>
-      Promise.resolve({ default: () => <div data-testid="map-screen" /> })
-    ),
-    OrdersScreen: React.lazy(() =>
-      Promise.resolve({ default: () => <div data-testid="orders-screen" /> })
-    ),
-  },
-  Home: {},
-  Variants: {},
+vi.mock("./components/HomeLayout", () => ({
+  HomeLayout: ({ children }: { children: React.ReactNode }) => children,
 }));
+
+vi.mock("./screens", () => {
+  const passthrough: React.FC = () => null;
+  const proxy = (overrides: Record<string, React.FC> = {}) =>
+    new Proxy(overrides, {
+      get: (target, prop) => target[prop as string] ?? passthrough,
+    });
+  return {
+    Home: proxy({ MyGames: () => <div data-testid="home-screen" /> }),
+    GameDetail: proxy({
+      MapScreen: React.lazy(() =>
+        Promise.resolve({ default: () => <div data-testid="map-screen" /> })
+      ),
+      OrdersScreen: React.lazy(() =>
+        Promise.resolve({ default: () => <div data-testid="orders-screen" /> })
+      ),
+    }),
+    Variants: proxy(),
+    LLMCalls: proxy(),
+    Tutorial: proxy(),
+  };
+});
 
 const renderRoute = () =>
   render(
@@ -49,5 +64,23 @@ describe("GameIndexRoute", () => {
     renderRoute();
     expect(await screen.findByTestId("orders-screen")).toBeTruthy();
     expect(screen.queryByTestId("map-screen")).toBeNull();
+  });
+});
+
+describe("Router", () => {
+  const createQueryClient = () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryDefaults(getVariantsListQueryKey(), {
+      staleTime: Infinity,
+    });
+    queryClient.setQueryData(getVariantsListQueryKey(), []);
+    return queryClient;
+  };
+
+  it("redirects a logged-in user from an unknown path to home", async () => {
+    window.history.pushState({}, "", "/register");
+    render(<Router loggedIn queryClient={createQueryClient()} />);
+    expect(await screen.findByTestId("home-screen")).toBeTruthy();
+    expect(window.location.pathname).toBe("/");
   });
 });

--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -326,6 +326,10 @@ const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
                 },
               ],
             },
+            {
+              path: "*",
+              loader: () => redirect("/"),
+            },
           ])
         : createBrowserRouter([
             {

--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -5,6 +5,7 @@ import {
   RouterProvider,
   redirect,
   useRouteError,
+  type RouteObject,
 } from "react-router";
 import { QueryClient } from "@tanstack/react-query";
 import { Login } from "./screens/Login";
@@ -81,293 +82,299 @@ interface RouterProps {
   queryClient: QueryClient;
 }
 
+export const createAuthenticatedRoutes = (
+  queryClient: QueryClient
+): RouteObject[] => [
+  {
+    id: "root",
+    path: "/",
+    element: <AuthenticatedRoot />,
+    errorElement: <RootErrorBoundary />,
+    loader: createVariantsLoader(queryClient),
+    children: [
+      {
+        element: <HomeLayoutWrapper />,
+        children: [
+          {
+            index: true,
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.MyGames />
+              </Suspense>
+            ),
+          },
+          {
+            path: "find-games",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.FindGames />
+              </Suspense>
+            ),
+          },
+          {
+            path: "create-game",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.CreateGame />
+              </Suspense>
+            ),
+          },
+          {
+            path: "account",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.Account />
+              </Suspense>
+            ),
+          },
+          {
+            path: "delete-account",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.DeleteAccount />
+              </Suspense>
+            ),
+          },
+          {
+            path: "community",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.Community />
+              </Suspense>
+            ),
+          },
+          {
+            path: "learn-to-play",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.LearnToPlay />
+              </Suspense>
+            ),
+          },
+          {
+            path: "game-info/:gameId",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.GameInfoScreen />
+              </Suspense>
+            ),
+          },
+          {
+            path: "player-info/:gameId",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.PlayerInfoScreen />
+              </Suspense>
+            ),
+          },
+          {
+            path: "player/:userId",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Home.PlayerProfileScreen />
+              </Suspense>
+            ),
+          },
+          {
+            path: "variants",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Variants.VariantsList />
+              </Suspense>
+            ),
+          },
+          {
+            path: "variants/create",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Variants.VariantCreate />
+              </Suspense>
+            ),
+          },
+          {
+            path: "variants/:variantId/edit",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <Variants.VariantEditRoute />
+              </Suspense>
+            ),
+          },
+          {
+            path: "llm-calls",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <LLMCalls.ListScreen />
+              </Suspense>
+            ),
+          },
+          {
+            path: "llm-calls/:llmCallId",
+            element: (
+              <Suspense fallback={<RouteFallback />}>
+                <LLMCalls.DetailScreen />
+              </Suspense>
+            ),
+          },
+          ...(import.meta.env.DEV
+            ? [
+                {
+                  path: "card-gallery",
+                  element: (
+                    <Suspense fallback={<RouteFallback />}>
+                      <CardGallery />
+                    </Suspense>
+                  ),
+                },
+              ]
+            : []),
+        ],
+      },
+      {
+        path: "learn-to-play/tutorial",
+        element: (
+          <Suspense fallback={<RouteFallback />}>
+            <Tutorial.TutorialScreen />
+          </Suspense>
+        ),
+      },
+      {
+        path: "game/:gameId",
+        children: [
+          // Redirect /game/:gameId to /game/:gameId/phase/:currentPhaseId/orders
+          { index: true, element: <GamePhaseRedirect /> },
+          {
+            path: "phase/:phaseId",
+            element: <GameDetailLayoutWrapper />,
+            children: [
+              { index: true, element: <GameIndexRoute /> },
+              {
+                path: "orders",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.OrdersScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "chat",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.ChannelListScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "chat/channel/create",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.ChannelCreateScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "chat/channel/:channelId",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.ChannelScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "game-info",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.GameInfoScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "player-info",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.PlayerInfoScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "propose-draw",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.ProposeDrawScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "draw-proposals",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.DrawProposalsScreen />
+                  </Suspense>
+                ),
+              },
+              {
+                path: "player/:userId",
+                element: (
+                  <Suspense fallback={<RouteFallback />}>
+                    <GameDetail.PlayerProfileScreen />
+                  </Suspense>
+                ),
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: "*",
+    loader: () => redirect("/"),
+  },
+];
+
+export const createUnauthenticatedRoutes = (): RouteObject[] => [
+  {
+    path: "/",
+    element: <Login />,
+  },
+  {
+    path: "/register",
+    element: <Register />,
+  },
+  {
+    path: "/forgot-password",
+    element: <ForgotPassword />,
+  },
+  {
+    path: "/check-email",
+    element: <CheckEmail />,
+  },
+  {
+    path: "/verify-email",
+    element: <VerifyEmail />,
+  },
+  {
+    path: "/reset-password",
+    element: <ResetPassword />,
+  },
+  {
+    path: "*",
+    loader: ({ request }) => {
+      const url = new URL(request.url);
+      const path = `${url.pathname}${url.search}${url.hash}`;
+      if (url.pathname !== "/") {
+        deepLinkStorage.setPendingPath(path);
+      }
+      return redirect("/");
+    },
+  },
+];
+
 const Router: React.FC<RouterProps> = ({ loggedIn, queryClient }) => {
   const router = React.useMemo(
     () =>
       loggedIn
-        ? createBrowserRouter([
-            {
-              id: "root",
-              path: "/",
-              element: <AuthenticatedRoot />,
-              errorElement: <RootErrorBoundary />,
-              loader: createVariantsLoader(queryClient),
-              children: [
-                {
-                  element: <HomeLayoutWrapper />,
-                  children: [
-                    {
-                      index: true,
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.MyGames />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "find-games",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.FindGames />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "create-game",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.CreateGame />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "account",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.Account />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "delete-account",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.DeleteAccount />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "community",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.Community />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "learn-to-play",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.LearnToPlay />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "game-info/:gameId",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.GameInfoScreen />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "player-info/:gameId",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.PlayerInfoScreen />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "player/:userId",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Home.PlayerProfileScreen />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "variants",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantsList />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "variants/create",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantCreate />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "variants/:variantId/edit",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <Variants.VariantEditRoute />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "llm-calls",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <LLMCalls.ListScreen />
-                        </Suspense>
-                      ),
-                    },
-                    {
-                      path: "llm-calls/:llmCallId",
-                      element: (
-                        <Suspense fallback={<RouteFallback />}>
-                          <LLMCalls.DetailScreen />
-                        </Suspense>
-                      ),
-                    },
-                    ...(import.meta.env.DEV
-                      ? [
-                          {
-                            path: "card-gallery",
-                            element: (
-                              <Suspense fallback={<RouteFallback />}>
-                                <CardGallery />
-                              </Suspense>
-                            ),
-                          },
-                        ]
-                      : []),
-                  ],
-                },
-                {
-                  path: "learn-to-play/tutorial",
-                  element: (
-                    <Suspense fallback={<RouteFallback />}>
-                      <Tutorial.TutorialScreen />
-                    </Suspense>
-                  ),
-                },
-                {
-                  path: "game/:gameId",
-                  children: [
-                    // Redirect /game/:gameId to /game/:gameId/phase/:currentPhaseId/orders
-                    { index: true, element: <GamePhaseRedirect /> },
-                    {
-                      path: "phase/:phaseId",
-                      element: <GameDetailLayoutWrapper />,
-                      children: [
-                        { index: true, element: <GameIndexRoute /> },
-                        {
-                          path: "orders",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.OrdersScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelListScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat/channel/create",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelCreateScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "chat/channel/:channelId",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ChannelScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "game-info",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.GameInfoScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "player-info",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.PlayerInfoScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "propose-draw",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.ProposeDrawScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "draw-proposals",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.DrawProposalsScreen />
-                            </Suspense>
-                          ),
-                        },
-                        {
-                          path: "player/:userId",
-                          element: (
-                            <Suspense fallback={<RouteFallback />}>
-                              <GameDetail.PlayerProfileScreen />
-                            </Suspense>
-                          ),
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              path: "*",
-              loader: () => redirect("/"),
-            },
-          ])
-        : createBrowserRouter([
-            {
-              path: "/",
-              element: <Login />,
-            },
-            {
-              path: "/register",
-              element: <Register />,
-            },
-            {
-              path: "/forgot-password",
-              element: <ForgotPassword />,
-            },
-            {
-              path: "/check-email",
-              element: <CheckEmail />,
-            },
-            {
-              path: "/verify-email",
-              element: <VerifyEmail />,
-            },
-            {
-              path: "/reset-password",
-              element: <ResetPassword />,
-            },
-            {
-              path: "*",
-              loader: ({ request }) => {
-                const url = new URL(request.url);
-                const path = `${url.pathname}${url.search}${url.hash}`;
-                if (url.pathname !== "/") {
-                  deepLinkStorage.setPendingPath(path);
-                }
-                return redirect("/");
-              },
-            },
-          ]),
+        ? createBrowserRouter(createAuthenticatedRoutes(queryClient))
+        : createBrowserRouter(createUnauthenticatedRoutes()),
     [loggedIn, queryClient]
   );
 


### PR DESCRIPTION
## What this PR does

Fixes Sentry issue [DIPLICITY-REACT-Q](https://johnpooch.sentry.io/issues/132069226/) — `Error: No route matches URL "/register"`.

The app mounts one of two separate routers depending on auth state (`Router.tsx`). The logged-out router has a catch-all `*` route that redirects unknown paths to `/`, but the **logged-in router had none**. So when a logged-in user's URL was an unmatched path — e.g. `/register` reached via a bookmark, the back button, or browser URL autocomplete while their session was still valid — React Router produced a 404. That error bubbled to `RootErrorBoundary`, which reported it to Sentry (`Sentry.captureException`) and rendered an error screen instead of gracefully redirecting.

This adds a top-level `*` catch-all to the logged-in router that redirects to home, mirroring the fallback the logged-out router already has. Valid deep links (e.g. `/game/:gameId`) still match their real routes; only genuinely unknown paths hit the catch-all.

The inline route tables are also extracted into `createAuthenticatedRoutes` / `createUnauthenticatedRoutes` factories (pure move, no behaviour change) so the routing table can be unit-tested without rendering `createBrowserRouter` — the data router builds a `Request` with a jsdom `AbortSignal` that CI's undici rejects, which is why the existing suite never renders it.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in — the factory extraction exists solely to make the fix testable
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, small routing fix
- [x] Tests cover the change — added a `createAuthenticatedRoutes` test asserting the catch-all loader returns a 302 redirect to `/`
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual change (redirect only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3fnsg9ehba8yYxKN25MDm