### PR TITLE
Make GET /variants/ a shared cacheable published catalogue

### DIFF
--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -898,6 +898,11 @@ export interface VictoryConditions {
   drawAfterYear: number | null;
 }
 
+export interface VariantProvinceAdjacency {
+  to: string;
+  pass: string;
+}
+
 export interface VariantProvince {
   id: string;
   name: string;
@@ -906,11 +911,6 @@ export interface VariantProvince {
   /** @nullable */
   parentId: string | null;
   readonly adjacencies: readonly VariantProvinceAdjacency[];
-}
-
-export interface VariantProvinceAdjacency {
-  to: string;
-  pass: string;
 }
 
 export interface VariantTemplateNationRef {
@@ -10305,6 +10305,254 @@ export const useVariantsNationsFlagDestroy = <
     queryClient
   );
 };
+
+export const variantsMineList = (signal?: AbortSignal) => {
+  return customInstance<Variant[]>({
+    url: `/variants/mine/`,
+    method: "GET",
+    signal,
+  });
+};
+
+export const getVariantsMineListQueryKey = () => {
+  return [`/variants/mine/`] as const;
+};
+
+export const getVariantsMineListQueryOptions = <
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof variantsMineList>>, TError, TData>
+  >;
+}) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getVariantsMineListQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof variantsMineList>>
+  > = ({ signal }) => variantsMineList(signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof variantsMineList>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type VariantsMineListQueryResult = NonNullable<
+  Awaited<ReturnType<typeof variantsMineList>>
+>;
+export type VariantsMineListQueryError = unknown;
+
+export function useVariantsMineList<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof variantsMineList>>,
+          TError,
+          Awaited<ReturnType<typeof variantsMineList>>
+        >,
+        "initialData"
+      >;
+  },
+  queryClient?: QueryClient
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useVariantsMineList<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof variantsMineList>>,
+          TError,
+          Awaited<ReturnType<typeof variantsMineList>>
+        >,
+        "initialData"
+      >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useVariantsMineList<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useVariantsMineList<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getVariantsMineListQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+export const getVariantsMineListSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof variantsMineList>>,
+      TError,
+      TData
+    >
+  >;
+}) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getVariantsMineListQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof variantsMineList>>
+  > = ({ signal }) => variantsMineList(signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof variantsMineList>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type VariantsMineListSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof variantsMineList>>
+>;
+export type VariantsMineListSuspenseQueryError = unknown;
+
+export function useVariantsMineListSuspense<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useVariantsMineListSuspense<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useVariantsMineListSuspense<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useVariantsMineListSuspense<
+  TData = Awaited<ReturnType<typeof variantsMineList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof variantsMineList>>,
+        TError,
+        TData
+      >
+    >;
+  },
+  queryClient?: QueryClient
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getVariantsMineListSuspenseQueryOptions(options);
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
 
 export const versionRetrieve = (signal?: AbortSignal) => {
   return customInstance<Version>({ url: `/version/`, method: "GET", signal });

--- a/packages/web/src/components/GameInfoContent.tsx
+++ b/packages/web/src/components/GameInfoContent.tsx
@@ -8,8 +8,8 @@ import { DeadlineSummary } from "@/components/DeadlineSummary";
 import {
   useGameRetrieveSuspense,
   useGamePhaseRetrieve,
-  useVariantsListSuspense,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { getCurrentPhaseId, formatDateTime, formatTimeAgo } from "@/util";
 import { MIN_RELIABILITY_OPTIONS } from "@/constants";
 import { ExpandableMapPreview } from "@/components/ExpandableMapPreview";
@@ -69,7 +69,7 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
   const { gameId } = useRequiredParams<{ gameId: string }>();
 
   const { data: game } = useGameRetrieveSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
 
   const currentPhaseId = getCurrentPhaseId(game);
   const { data: currentPhase } = useGamePhaseRetrieve(
@@ -77,8 +77,6 @@ export const GameInfoContent: React.FC<GameInfoContentProps> = ({
     currentPhaseId ?? 0,
     { query: { enabled: !!currentPhaseId } }
   );
-
-  const variant = variants.find(v => v.id === game.variantId);
 
   return (
     <>

--- a/packages/web/src/components/PlayerInfoContent.test.tsx
+++ b/packages/web/src/components/PlayerInfoContent.test.tsx
@@ -15,6 +15,7 @@ const mockKickMutateAsync = vi.fn();
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({ data: mockGameData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useGamePhaseRetrieve: () => ({ data: mockCurrentPhaseData() }),
   useUserRetrieveSuspense: () => ({ data: mockUserProfileData() }),
   useGameKickDestroy: () => ({

--- a/packages/web/src/components/PlayerInfoContent.tsx
+++ b/packages/web/src/components/PlayerInfoContent.tsx
@@ -18,11 +18,11 @@ import {
   useGamePhaseRetrieve,
   useGameKickDestroy,
   useUserRetrieveSuspense,
-  useVariantsListSuspense,
   getGameAvailableBotsListQueryKey,
   getGameRetrieveQueryKey,
   Member,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { getCurrentPhaseId } from "@/util";
 import { useRequiredParams } from "@/hooks";
 
@@ -31,7 +31,7 @@ export const PlayerInfoContent: React.FC = () => {
   const { phaseId } = useParams<{ phaseId: string }>();
 
   const { data: game } = useGameRetrieveSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const { data: userProfile } = useUserRetrieveSuspense();
   const queryClient = useQueryClient();
   const kickMutation = useGameKickDestroy();
@@ -44,8 +44,6 @@ export const PlayerInfoContent: React.FC = () => {
     currentPhaseId ?? 0,
     { query: { enabled: !!currentPhaseId } }
   );
-
-  const variant = variants.find(v => v.id === game.variantId);
 
   const getSupplyCenterCount = (member: Member) => {
     if (!currentPhase) return undefined;

--- a/packages/web/src/hooks/useGameVariant.ts
+++ b/packages/web/src/hooks/useGameVariant.ts
@@ -1,0 +1,16 @@
+import {
+  useVariantsListSuspense,
+  useVariantsRetrieve,
+  type Variant,
+} from "@/api/generated/endpoints";
+
+export const useGameVariant = (game: {
+  variantId: string;
+}): Variant | undefined => {
+  const { data: variants } = useVariantsListSuspense();
+  const published = variants.find(v => v.id === game.variantId);
+  const { data: fetched } = useVariantsRetrieve(game.variantId, {
+    query: { enabled: !published },
+  });
+  return published ?? fetched;
+};

--- a/packages/web/src/mocks/fixtures/index.ts
+++ b/packages/web/src/mocks/fixtures/index.ts
@@ -18,7 +18,7 @@ import {
 
 export type { GameFixture } from "./types";
 export { classicalVariant, classicalProvinces, nation, province } from "./classical";
-export { allVariants, extraVariants } from "./variants";
+export { allVariants, extraVariants, draftVariant } from "./variants";
 export { botRoster, currentUserProfile, makeBotMember, publicProfiles } from "./users";
 export { llmCallSummaries, llmCallDetails } from "./llmCalls";
 

--- a/packages/web/src/mocks/fixtures/variants.ts
+++ b/packages/web/src/mocks/fixtures/variants.ts
@@ -69,3 +69,14 @@ export const extraVariants: Variant[] = [
 ];
 
 export const allVariants: Variant[] = [classicalVariant, ...extraVariants];
+
+export const draftVariant: Variant = {
+  ...classicalVariant,
+  id: "my-draft",
+  name: "My Draft Variant",
+  status: "draft",
+  official: false,
+  ownerId: 1,
+  ownerUsername: "testuser",
+  canEdit: true,
+};

--- a/packages/web/src/mocks/fixtures/variants.ts
+++ b/packages/web/src/mocks/fixtures/variants.ts
@@ -24,7 +24,7 @@ const buildVariant = (raw: GodipVariant): Variant =>
     description: raw.description ?? "",
     author: raw.author ?? "",
     rules: "",
-    status: "active",
+    status: "published",
     official: true,
     ownerId: null,
     ownerUsername: null,

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -9,6 +9,7 @@ import {
   allVariants,
   botRoster,
   currentUserProfile,
+  draftVariant,
   fixtureByGameId,
   llmCallDetails,
   llmCallSummaries,
@@ -84,10 +85,16 @@ export const handlers = [
     HttpResponse.json({ environment: "mock", version: "mock" } satisfies Version)
   ),
 
-  http.get("*/variants/", () => HttpResponse.json(allVariants)),
+  http.get("*/variants/", () =>
+    HttpResponse.json(allVariants.filter(v => v.status === "published"))
+  ),
+
+  http.get("*/variants/mine/", () => HttpResponse.json([draftVariant])),
 
   http.get("*/variants/:variantId/", ({ params }) => {
-    const variant = allVariants.find(v => v.id === params.variantId);
+    const variant = [...allVariants, draftVariant].find(
+      v => v.id === params.variantId
+    );
     return variant ? HttpResponse.json(variant) : notFound();
   }),
 

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   useVariantsListSuspense: () => ({
     data: [],
   }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useUserRetrieveSuspense: () => ({
     data: { canCreateBotGames: false },
   }),

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -23,8 +23,8 @@ import {
   useGameRetrieveSuspense,
   useGamesChannelsListSuspense,
   useUserRetrieveSuspense,
-  useVariantsListSuspense,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { getChannelDisplayName, getChannelFlagUrls } from "./channelUtils";
 import { ChannelAvatar } from "./ChannelAvatar";
 
@@ -46,12 +46,12 @@ const ChannelListScreen: React.FC = () => {
   }>();
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: channels } = useGamesChannelsListSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const { data: profile } = useUserRetrieveSuspense();
 
   const currentNationName =
     game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
-  const variantNations = variants.find(v => v.id === game.variantId)?.nations ?? [];
+  const variantNations = variant?.nations ?? [];
   const isSandboxGame = game.sandbox;
   const isNoPressActiveGame =
     game.pressType === "no_press" &&

--- a/packages/web/src/screens/GameDetail/ChannelScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   }),
   useGamesChannelsListSuspense: () => ({ data: mockChannelsData() }),
   useVariantsListSuspense: () => ({ data: [] }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useGamesChannelsMessagesCreateCreate: () => ({
     mutateAsync: vi.fn().mockResolvedValue({}),
     isPending: false,

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -24,13 +24,13 @@ import { Panel } from "@/components/Panel";
 import {
   useGameRetrieveSuspense,
   useGamesChannelsListSuspense,
-  useVariantsListSuspense,
   useGamesChannelsMessagesCreateCreate,
   useGamesChannelsMarkReadCreate,
   getGamesChannelsListQueryKey,
   getGameRetrieveQueryKey,
   ChannelMessage as ChannelMessageType,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 
 type MessageDisplayItem = {
   id: number;
@@ -111,7 +111,7 @@ const ChannelScreen: React.FC = () => {
       refetchInterval: 5000,
     },
   });
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const createMessageMutation = useGamesChannelsMessagesCreateCreate();
   const markReadMutation = useGamesChannelsMarkReadCreate();
 
@@ -137,7 +137,6 @@ const ChannelScreen: React.FC = () => {
 
   const currentMember = game.members.find(m => m.isCurrentUser);
   const currentNationName = currentMember?.nation ?? undefined;
-  const variant = variants.find(v => v.id === game.variantId);
   const channelDisplayName = getChannelDisplayName(channel, currentNationName);
   const channelFlagUrls = getChannelFlagUrls(
     channel,

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({ data: mockGameData() }),
   useGamesDrawProposalsListSuspense: () => ({ data: mockProposalsData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useGamesDrawProposalsVotePartialUpdate: () => ({
     mutateAsync: mockVoteMutation,
     isPending: false,

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -33,7 +33,6 @@ import {
   useGamesDrawProposalsCancelDestroy,
   getGamesDrawProposalsListQueryKey,
   getGameRetrieveQueryKey,
-  useVariantsListSuspense,
 } from "@/api/generated/endpoints";
 import type {
   DrawProposal,
@@ -41,6 +40,7 @@ import type {
   Member,
   Variant,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 
 type TabValue = "active" | "rejected";
 
@@ -181,11 +181,10 @@ const DrawProposalsScreen: React.FC = () => {
 
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: proposals } = useGamesDrawProposalsListSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const voteMutation = useGamesDrawProposalsVotePartialUpdate();
   const cancelMutation = useGamesDrawProposalsCancelDestroy();
 
-  const variant = variants.find(v => v.id === game.variantId);
   const currentMember = game.members.find(m => m.isCurrentUser);
 
   const handleVote = async (proposalId: number, accepted: boolean) => {

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/api/generated/endpoints", () => ({
   useGamePhaseRetrieveSuspense: () => ({ data: mockPhaseData() }),
   useGameOrdersListSuspense: () => ({ data: mockOrdersData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useGamePhaseStatesListSuspense: () => ({ data: mockPhaseStatesData() }),
   useGameOrdersDeleteDestroy: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useGameConfirmPhasePartialUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -53,7 +53,6 @@ import {
   useGameConfirmPhasePartialUpdate,
   useGameResolvePhaseCreate,
   useGameRetrieveSuspense,
-  useVariantsListSuspense,
   useGamesDrawProposalsListSuspense,
   useGameRecoverFromCivilDisorderCreate,
   getGameRetrieveQueryKey,
@@ -64,6 +63,7 @@ import {
   GameRetrieve,
   Unit,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { cn } from "../../lib/utils";
 
 type NationGroup = {
@@ -167,7 +167,7 @@ const OrdersScreen: React.FC = () => {
   const { data: game } = useGameRetrieveSuspense(gameId);
   const { data: phase } = useGamePhaseRetrieveSuspense(gameId, selectedPhase);
   const { data: orders } = useGameOrdersListSuspense(gameId, selectedPhase);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const { data: phaseStates } = useGamePhaseStatesListSuspense(gameId);
 
   const deleteOrderMutation = useGameOrdersDeleteDestroy();
@@ -175,7 +175,7 @@ const OrdersScreen: React.FC = () => {
   const resolvePhaseMutation = useGameResolvePhaseCreate();
   const recoverMutation = useGameRecoverFromCivilDisorderCreate();
 
-  const variant = variants.find(v => v.id === game.variantId)!;
+  if (!variant) return null;
 
   const isActivePhase = phase.status === "active";
   const isGameFinished =

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -175,7 +175,13 @@ const OrdersScreen: React.FC = () => {
   const resolvePhaseMutation = useGameResolvePhaseCreate();
   const recoverMutation = useGameRecoverFromCivilDisorderCreate();
 
-  if (!variant) return null;
+  if (!variant) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground"></div>
+      </div>
+    );
+  }
 
   const isActivePhase = phase.status === "active";
   const isGameFinished =

--- a/packages/web/src/screens/GameDetail/ProposeDrawScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ProposeDrawScreen.test.tsx
@@ -28,6 +28,7 @@ const mockCreateMutation = vi.fn();
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({ data: mockGameData() }),
   useVariantsListSuspense: () => ({ data: mockVariantsData() }),
+  useVariantsRetrieve: () => ({ data: undefined }),
   useGamesDrawProposalsCreateCreate: () => ({
     mutateAsync: mockCreateMutation,
     isPending: false,

--- a/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ProposeDrawScreen.tsx
@@ -25,8 +25,8 @@ import {
   useGameRetrieveSuspense,
   useGamesDrawProposalsCreateCreate,
   getGamesDrawProposalsListQueryKey,
-  useVariantsListSuspense,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 
 const ProposeDrawScreen: React.FC = () => {
   const { gameId, phaseId } = useRequiredParams<{
@@ -37,10 +37,9 @@ const ProposeDrawScreen: React.FC = () => {
   const queryClient = useQueryClient();
 
   const { data: game } = useGameRetrieveSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const createProposalMutation = useGamesDrawProposalsCreateCreate();
 
-  const variant = variants.find(v => v.id === game.variantId);
   const activeMembers = game.members.filter(m => !m.eliminated && !m.kicked);
   const includedMembers = activeMembers.filter(m => !m.civilDisorder);
   const cdMembers = activeMembers.filter(m => m.civilDisorder);

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/constants";
 import {
   useVariantsListSuspense,
+  useVariantsRetrieve,
   useUserRetrieveSuspense,
   useGameCreate,
   useSandboxGameCreate,
@@ -1011,10 +1012,6 @@ const CreateGame: React.FC = () => {
   const { data: allVariants } = useVariantsListSuspense();
   const { data: userProfile } = useUserRetrieveSuspense();
   const maxReliability = getMaxReliability(userProfile.reliabilityTier);
-  const publishedVariants = React.useMemo(
-    () => allVariants.filter(v => v.status === "published"),
-    [allVariants]
-  );
 
   const initialVariantId =
     searchParams.get(CREATE_GAME_PARAM.variantId) ?? undefined;
@@ -1022,22 +1019,20 @@ const CreateGame: React.FC = () => {
   const initialMode: GameMode =
     searchParams.get("sandbox") === "true" ? "sandbox" : "standard";
 
-  const initialVariant = React.useMemo(
-    () =>
-      initialVariantId
-        ? allVariants.find(v => v.id === initialVariantId)
-        : undefined,
-    [allVariants, initialVariantId]
+  const initialVariantFromCatalogue = initialVariantId
+    ? allVariants.find(v => v.id === initialVariantId)
+    : undefined;
+  const { data: fetchedInitialVariant } = useVariantsRetrieve(
+    initialVariantId ?? "",
+    { query: { enabled: !!initialVariantId && !initialVariantFromCatalogue } }
   );
+  const initialVariant = initialVariantFromCatalogue ?? fetchedInitialVariant;
   const variants = React.useMemo(() => {
-    if (
-      initialVariant &&
-      !publishedVariants.some(v => v.id === initialVariant.id)
-    ) {
-      return [initialVariant, ...publishedVariants];
+    if (initialVariant && !allVariants.some(v => v.id === initialVariant.id)) {
+      return [initialVariant, ...allVariants];
     }
-    return publishedVariants;
-  }, [publishedVariants, initialVariant]);
+    return allVariants;
+  }, [allVariants, initialVariant]);
   const createGameMutation = useGameCreate();
   const createSandboxGameMutation = useSandboxGameCreate();
   const checkNotificationPermission = useCheckNotificationPermission();

--- a/packages/web/src/screens/Home/GameInfo.tsx
+++ b/packages/web/src/screens/Home/GameInfo.tsx
@@ -13,9 +13,9 @@ import {
   useGameJoinCreate,
   useGameLeaveDestroy,
   useUserRetrieveSuspense,
-  useVariantsListSuspense,
   getGameRetrieveQueryKey,
 } from "@/api/generated/endpoints";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
 import { AddBotSheet } from "@/components/AddBotSheet";
@@ -28,7 +28,7 @@ const GameInfo: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: game } = useGameRetrieveSuspense(gameId);
-  const { data: variants } = useVariantsListSuspense();
+  const variant = useGameVariant(game);
   const { data: userProfile } = useUserRetrieveSuspense();
   const joinGameMutation = useGameJoinCreate();
   const leaveGameMutation = useGameLeaveDestroy();
@@ -76,7 +76,6 @@ const GameInfo: React.FC = () => {
     navigate(`/game-info/${gameId}`);
   };
 
-  const variant = variants.find(v => v.id === game.variantId);
   const playableSeats = variant
     ? variant.nations.filter(n => !n.nonPlayable).length
     : 0;

--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -9,6 +9,7 @@ import { mockActiveGames, mockPhaseMovement, mockVariants } from "@/mocks/legacy
 const mockUseGamesListInfinite = vi.fn();
 const mockUseGamePhaseRetrieve = vi.fn();
 const mockUseVariantsListSuspense = vi.fn();
+const mockUseVariantsRetrieve = vi.fn();
 
 vi.mock("@/hooks/useGamesListInfinite", () => ({
   useGamesListInfinite: (...args: unknown[]) => mockUseGamesListInfinite(...args),
@@ -19,6 +20,7 @@ vi.mock("@/api/generated/endpoints", async (importOriginal) => {
   return {
     ...(actual as Record<string, unknown>),
     useVariantsListSuspense: () => mockUseVariantsListSuspense(),
+    useVariantsRetrieve: (...args: unknown[]) => mockUseVariantsRetrieve(...args),
     useUserRetrieveSuspense: () => ({
       data: { id: 1, email: "test@example.com", name: "Test", picture: null },
     }),
@@ -66,6 +68,8 @@ beforeEach(() => {
   mockUseGamePhaseRetrieve.mockReturnValue({ data: mockPhaseMovement });
   mockUseVariantsListSuspense.mockReset();
   mockUseVariantsListSuspense.mockReturnValue({ data: [] });
+  mockUseVariantsRetrieve.mockReset();
+  mockUseVariantsRetrieve.mockReturnValue({ data: undefined });
 });
 
 describe("MyGames empty states", () => {
@@ -156,6 +160,25 @@ describe("MyGames eliminated games", () => {
 
     await screen.findByText(game.name);
     expect(screen.queryByRole("heading", { name: "Eliminated", level: 3 })).not.toBeInTheDocument();
+  });
+});
+
+describe("MyGames draft variant fallback", () => {
+  it("renders a game whose variant is a draft not in the published catalogue", async () => {
+    const draftVariant = { ...mockVariants[0], id: "own-draft", status: "draft" };
+    const game = { ...mockActiveGames[0], variantId: draftVariant.id };
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: [game], next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+    mockUseVariantsRetrieve.mockReturnValue({ data: draftVariant });
+
+    renderMyGames();
+
+    expect(await screen.findByText(game.name)).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -89,7 +89,9 @@ interface GameTabContentProps {
 
 const MyGameCard: React.FC<{ game: GameList }> = ({ game }) => {
   const variant = useGameVariant(game);
-  if (!variant) return null;
+  if (!variant) {
+    return <div className="h-24 rounded-lg bg-muted animate-pulse" />;
+  }
 
   return (
     <GameCard

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -10,8 +10,9 @@ import { Notice } from "@/components/Notice";
 import { Button } from "@/components/ui/button";
 import { Inbox, Loader2 } from "lucide-react";
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
-import { useVariantsListSuspense } from "@/api/generated/endpoints";
+import type { GameList } from "@/api/generated/endpoints";
 import { useGamesListInfinite } from "@/hooks/useGamesListInfinite";
+import { useGameVariant } from "@/hooks/useGameVariant";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 
 const statuses = [
@@ -86,6 +87,27 @@ interface GameTabContentProps {
   ordering?: string;
 }
 
+const MyGameCard: React.FC<{ game: GameList }> = ({ game }) => {
+  const variant = useGameVariant(game);
+  if (!variant) return null;
+
+  return (
+    <GameCard
+      game={game}
+      variant={variant}
+      map={
+        <MapView
+          mode="static"
+          variant={variant}
+          phase={game.currentPhase ?? variant.templatePhase}
+          cover
+          className="w-full h-full"
+        />
+      }
+    />
+  );
+};
+
 const GameTabContent: React.FC<GameTabContentProps> = ({
   statusFilter,
   emptyTitle,
@@ -94,7 +116,6 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
 }) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGamesListInfinite({ mine: true, status: statusFilter, ordering });
-  const { data: variants } = useVariantsListSuspense();
 
   const games = data.pages.flatMap(page => page.results);
 
@@ -104,10 +125,7 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
     isFetchingNextPage
   );
 
-  const variantMap = new Map(variants.map(v => [v.id, v]));
-  const knownGames = games.filter(game => variantMap.has(game.variantId));
-
-  if (knownGames.length === 0) {
+  if (games.length === 0) {
     const { message, actions } = getEmptyStateConfig(status);
     return (
       <Notice title={emptyTitle} message={message} icon={Inbox} actions={actions} />
@@ -116,29 +134,17 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
 
   const firstEliminatedIndex =
     status === "active"
-      ? knownGames.findIndex(game => !game.sandbox && game.members.find(m => m.isCurrentUser)?.eliminated)
+      ? games.findIndex(game => !game.sandbox && game.members.find(m => m.isCurrentUser)?.eliminated)
       : -1;
 
   return (
     <div className="space-y-4">
-      {knownGames.map((game, index) => (
+      {games.map((game, index) => (
         <Fragment key={game.id}>
           {index === firstEliminatedIndex && (
             <h3 className="text-sm font-semibold pt-2">Eliminated</h3>
           )}
-          <GameCard
-            game={game}
-            variant={variantMap.get(game.variantId)!}
-            map={
-              <MapView
-                mode="static"
-                variant={variantMap.get(game.variantId)!}
-                phase={game.currentPhase ?? variantMap.get(game.variantId)!.templatePhase}
-                cover
-                className="w-full h-full"
-              />
-            }
-          />
+          <MyGameCard game={game} />
         </Fragment>
       ))}
       {isFetchingNextPage && (

--- a/packages/web/src/screens/Variants/VariantCreate.tsx
+++ b/packages/web/src/screens/Variants/VariantCreate.tsx
@@ -19,7 +19,7 @@ import {
   useVariantsRetrieveSuspense,
   useVariantsNationsFlagUpdate,
   useVariantsNationsFlagDestroy,
-  getVariantsListQueryKey,
+  getVariantsMineListQueryKey,
   getVariantsRetrieveQueryKey,
   Nation,
   NationFlagUpload,
@@ -174,7 +174,7 @@ const VariantCreate: React.FC = () => {
     });
     toast.success("Draft variant uploaded");
     await queryClient.invalidateQueries({
-      queryKey: getVariantsListQueryKey(),
+      queryKey: getVariantsMineListQueryKey(),
     });
     navigate("/variants");
   };
@@ -302,7 +302,7 @@ const VariantEdit: React.FC<{ variantId: string }> = ({ variantId }) => {
     });
     toast.success(`Updated draft variant '${variantId}'`);
     await queryClient.invalidateQueries({
-      queryKey: getVariantsListQueryKey(),
+      queryKey: getVariantsMineListQueryKey(),
     });
     navigate("/variants");
   };

--- a/packages/web/src/screens/Variants/VariantsList.test.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { VariantsList } from "./index";
+import { mockVariants } from "@/mocks/legacy";
+
+const mockUseVariantsListSuspense = vi.fn();
+const mockUseVariantsMineListSuspense = vi.fn();
+
+vi.mock("@/api/generated/endpoints", async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    useVariantsListSuspense: () => mockUseVariantsListSuspense(),
+    useVariantsMineListSuspense: () => mockUseVariantsMineListSuspense(),
+    useVariantsDestroy: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    useSandboxGameCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  };
+});
+
+vi.mock("@/components/MapView", () => ({
+  MapView: () => <div data-testid="map-preview" />,
+}));
+
+const publishedVariant = {
+  ...mockVariants[0],
+  id: "classical",
+  name: "Classical",
+  status: "published",
+  canEdit: false,
+};
+
+const ownDraft = {
+  ...mockVariants[0],
+  id: "own-draft",
+  name: "Own Draft",
+  status: "draft",
+  canEdit: true,
+};
+
+const renderVariantsList = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <VariantsList />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  mockUseVariantsListSuspense.mockReset();
+  mockUseVariantsListSuspense.mockReturnValue({ data: [publishedVariant] });
+  mockUseVariantsMineListSuspense.mockReset();
+  mockUseVariantsMineListSuspense.mockReturnValue({ data: [ownDraft] });
+});
+
+describe("VariantsList", () => {
+  it("shows both the published catalogue and the user's own drafts", async () => {
+    renderVariantsList();
+
+    expect(await screen.findByText("Classical")).toBeInTheDocument();
+    expect(screen.getByText("Own Draft")).toBeInTheDocument();
+  });
+
+  it("lists drafts before published variants", async () => {
+    renderVariantsList();
+
+    const headings = await screen.findAllByRole("heading", { level: 3 });
+    expect(headings.map(h => h.textContent)).toEqual(["Own Draft", "Classical"]);
+  });
+
+  it("shows the empty state when there are no variants", async () => {
+    mockUseVariantsListSuspense.mockReturnValue({ data: [] });
+    mockUseVariantsMineListSuspense.mockReturnValue({ data: [] });
+
+    renderVariantsList();
+
+    expect(await screen.findByText("No variants yet")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/screens/Variants/VariantsList.tsx
+++ b/packages/web/src/screens/Variants/VariantsList.tsx
@@ -22,9 +22,10 @@ import {
 
 import {
   useVariantsListSuspense,
+  useVariantsMineListSuspense,
   useVariantsDestroy,
   useSandboxGameCreate,
-  getVariantsListQueryKey,
+  getVariantsMineListQueryKey,
   Variant,
 } from "@/api/generated/endpoints";
 import { MapView } from "@/components/MapView";
@@ -194,6 +195,7 @@ const VariantsList: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: variants } = useVariantsListSuspense();
+  const { data: myDrafts } = useVariantsMineListSuspense();
   const destroyMutation = useVariantsDestroy();
   const sandboxMutation = useSandboxGameCreate();
 
@@ -206,15 +208,13 @@ const VariantsList: React.FC = () => {
       draft: 0,
       published: 1,
     };
-    return [...variants]
-      .filter((v) => v.status === "published" || v.canEdit)
-      .sort((a, b) => {
-        const statusDiff =
-          (order[a.status] ?? 99) - (order[b.status] ?? 99);
-        if (statusDiff !== 0) return statusDiff;
-        return a.name.localeCompare(b.name);
-      });
-  }, [variants]);
+    return [...myDrafts, ...variants].sort((a, b) => {
+      const statusDiff =
+        (order[a.status] ?? 99) - (order[b.status] ?? 99);
+      if (statusDiff !== 0) return statusDiff;
+      return a.name.localeCompare(b.name);
+    });
+  }, [variants, myDrafts]);
 
   const handleDelete = async () => {
     if (!pendingDeleteId) return;
@@ -222,7 +222,7 @@ const VariantsList: React.FC = () => {
       await destroyMutation.mutateAsync({ id: pendingDeleteId });
       toast.success("Variant deleted");
       await queryClient.invalidateQueries({
-        queryKey: getVariantsListQueryKey(),
+        queryKey: getVariantsMineListQueryKey(),
       });
     } catch {
       toast.error("Failed to delete variant");

--- a/service/nation/tests/test_nation_flag_upload.py
+++ b/service/nation/tests/test_nation_flag_upload.py
@@ -144,3 +144,22 @@ def test_unknown_nation_returns_404(
         format="multipart",
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_flag_upload_changes_variant_detail_etag(
+    authenticated_client, draft_variant_for_primary, minimal_flag_svg
+):
+    detail_url = reverse("variant-detail", kwargs={"pk": "primary-draft"})
+    before = authenticated_client.get(detail_url)
+    etag = before["ETag"]
+
+    authenticated_client.put(
+        reverse("nation-flag", kwargs={"variant_id": "primary-draft", "nation_id": "reds"}),
+        _flag_upload(minimal_flag_svg),
+        format="multipart",
+    )
+
+    after = authenticated_client.get(detail_url, HTTP_IF_NONE_MATCH=etag)
+    assert after.status_code == status.HTTP_200_OK
+    assert after["ETag"] != etag

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -1661,6 +1661,22 @@ paths:
       responses:
         '204':
           description: No response body
+  /variants/mine/:
+    get:
+      operationId: variantsMineList
+      tags:
+      - variants
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Variant'
+          description: ''
   /version/:
     get:
       operationId: versionRetrieve

--- a/service/variant/serializers.py
+++ b/service/variant/serializers.py
@@ -194,11 +194,3 @@ class VariantWriteSerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         return VariantSerializer(instance, context=self.context).data
-
-
-class GameListVariantSerializer(serializers.Serializer):
-    id = serializers.CharField()
-    name = serializers.CharField()
-    description = serializers.CharField()
-    author = serializers.CharField(required=False)
-    nations = NationSerializer(many=True)

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -69,10 +69,10 @@ def test_list_variants_unauthenticated(unauthenticated_client, classical_variant
 
 
 @pytest.mark.django_db
-def test_list_variants_cache_control_allows_private_caching(authenticated_client):
+def test_list_variants_cache_control_allows_public_caching(authenticated_client):
     response = authenticated_client.get(reverse(viewname))
 
-    assert response["Cache-Control"] == "private, must-revalidate, max-age=60"
+    assert response["Cache-Control"] == "public"
 
 
 @pytest.mark.django_db
@@ -124,9 +124,8 @@ class TestVariantListViewQueryPerformance:
         query_count = len(connection.queries)
 
         # 18 prefetch queries + 2 ETag aggregates (Variant + NationFlag max
-        # updated_at) + 1 published-only gate query (routes the request to the
-        # shared render cache). This is the cache-miss path; hits skip the 18.
-        assert query_count == 21
+        # updated_at). This is the cache-miss path; hits skip the 18.
+        assert query_count == 20
 
     @pytest.mark.django_db
     def test_list_variants_query_count_with_single_variant(self, authenticated_client, classical_variant):
@@ -161,9 +160,8 @@ class TestVariantListViewQueryPerformance:
         # due to prefetch_related optimization
         query_count = len(connection.queries)
         # 18 prefetch queries + 2 ETag aggregates (Variant + NationFlag max
-        # updated_at) + 1 published-only gate query (routes the request to the
-        # shared render cache). This is the cache-miss path; hits skip the 18.
-        assert query_count == 21
+        # updated_at). This is the cache-miss path; hits skip the 18.
+        assert query_count == 20
 
 
 class TestPhaseProgressionBackfill:
@@ -318,7 +316,7 @@ def test_published_variant_visible_to_any_user(authenticated_client):
 
 
 @pytest.mark.django_db
-def test_own_draft_visible_to_owner(user_factory, authenticated_client_factory):
+def test_own_draft_hidden_from_list(user_factory, authenticated_client_factory):
     owner = user_factory()
     owner_client = authenticated_client_factory(owner)
     draft_variant = Variant.objects.create(
@@ -327,7 +325,7 @@ def test_own_draft_visible_to_owner(user_factory, authenticated_client_factory):
     )
     response = owner_client.get(reverse(viewname))
     ids = {v["id"] for v in response.data}
-    assert draft_variant.id in ids
+    assert draft_variant.id not in ids
 
 
 @pytest.mark.django_db
@@ -365,7 +363,7 @@ def test_archived_variant_hidden_from_list(authenticated_client):
 
 
 @pytest.mark.django_db
-def test_member_of_draft_variant_game_can_see_variant(
+def test_member_of_draft_variant_game_does_not_see_variant_in_list(
     user_factory, authenticated_client_factory, game_factory, member_factory
 ):
     owner = user_factory()
@@ -379,7 +377,7 @@ def test_member_of_draft_variant_game_can_see_variant(
     member_factory(game=game, user=other_user)
     response = other_client.get(reverse(viewname))
     ids = {v["id"] for v in response.data}
-    assert draft_variant.id in ids
+    assert draft_variant.id not in ids
 
 
 @pytest.mark.django_db

--- a/service/variant/tests/test_variants_list_performance.py
+++ b/service/variant/tests/test_variants_list_performance.py
@@ -72,7 +72,7 @@ def test_list_variants_no_n_plus_one_when_variant_count_grows(
         format="multipart",
     )
     assert upload_response.status_code == status.HTTP_201_CREATED, upload_response.data
-    assert Variant.objects.filter(id=upload_response.data["id"]).exists()
+    Variant.objects.filter(id=upload_response.data["id"]).update(status=VariantStatus.PUBLISHED)
 
     grown_count, grown_response = _list_query_count(authenticated_client)
     assert len(grown_response.data) == baseline_variant_count + 1
@@ -88,7 +88,7 @@ def test_list_variants_returns_etag_and_cache_control(authenticated_client):
     response = authenticated_client.get(reverse("variant-list"))
     assert response.status_code == status.HTTP_200_OK
     assert response["ETag"].startswith('"') and response["ETag"].endswith('"')
-    assert response["Cache-Control"] == "private, must-revalidate, max-age=60"
+    assert response["Cache-Control"] == "public"
 
 
 @pytest.mark.django_db
@@ -135,8 +135,8 @@ def test_published_variants_list_served_from_render_cache(authenticated_client):
         hit_count, hit_response = _list_query_count(authenticated_client)
 
     assert hit_response.data == miss_response.data
-    # The hit path runs only the content-version aggregates and the
-    # published-only gate query; the ~18 prefetch queries are skipped.
+    # The hit path runs only the content-version aggregates; the ~18
+    # prefetch queries are skipped.
     assert hit_count < miss_count
     assert hit_count <= 5
 
@@ -163,11 +163,9 @@ def test_render_cache_shared_across_users(user_factory, authenticated_client_fac
 
 
 @pytest.mark.django_db
-def test_draft_owner_is_not_served_published_cache(
+def test_draft_variant_never_appears_in_published_list(
     unauthenticated_client, user_factory, authenticated_client_factory
 ):
-    """Warming the shared cache from a published-only request must not cause a
-    draft owner to be served the cached payload in place of their own draft."""
     owner = user_factory()
     draft = Variant.objects.create(
         id="cache-draft", name="Cache Draft", description="",
@@ -178,8 +176,71 @@ def test_draft_owner_is_not_served_published_cache(
     with override_settings(CACHES=_LOCMEM_CACHE):
         cache.clear()
         anonymous = unauthenticated_client.get(reverse("variant-list"))
-        assert draft.id not in {v["id"] for v in anonymous.data}
-
         owned = owner_client.get(reverse("variant-list"))
 
-    assert draft.id in {v["id"] for v in owned.data}
+    assert draft.id not in {v["id"] for v in anonymous.data}
+    assert draft.id not in {v["id"] for v in owned.data}
+
+
+@pytest.mark.django_db
+def test_mine_list_returns_only_own_drafts(user_factory, authenticated_client_factory):
+    owner = user_factory()
+    other = user_factory()
+    own_draft = Variant.objects.create(
+        id="own-draft", name="Own Draft", description="",
+        status=VariantStatus.DRAFT, owner=owner,
+    )
+    Variant.objects.create(
+        id="other-draft", name="Other Draft", description="",
+        status=VariantStatus.DRAFT, owner=other,
+    )
+
+    response = authenticated_client_factory(owner).get(reverse("variant-mine-list"))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert {v["id"] for v in response.data} == {own_draft.id}
+
+
+@pytest.mark.django_db
+def test_mine_list_requires_authentication(unauthenticated_client):
+    response = unauthenticated_client.get(reverse("variant-mine-list"))
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_variant_detail_returns_etag_and_cache_control(authenticated_client, classical_variant):
+    response = authenticated_client.get(
+        reverse("variant-detail", kwargs={"pk": classical_variant.id})
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response["ETag"].startswith('"') and response["ETag"].endswith('"')
+    assert response["Cache-Control"] == "private, must-revalidate, max-age=60"
+
+
+@pytest.mark.django_db
+def test_variant_detail_returns_304_on_matching_if_none_match(
+    authenticated_client, classical_variant
+):
+    url = reverse("variant-detail", kwargs={"pk": classical_variant.id})
+    first = authenticated_client.get(url)
+    etag = first["ETag"]
+
+    second = authenticated_client.get(url, HTTP_IF_NONE_MATCH=etag)
+    assert second.status_code == status.HTTP_304_NOT_MODIFIED
+    assert second["ETag"] == etag
+
+
+@pytest.mark.django_db
+def test_variant_detail_resolves_a_draft_by_id(user_factory, authenticated_client_factory):
+    owner = user_factory()
+    draft = Variant.objects.create(
+        id="detail-draft", name="Detail Draft", description="",
+        status=VariantStatus.DRAFT, owner=owner,
+    )
+
+    response = authenticated_client_factory(owner).get(
+        reverse("variant-detail", kwargs={"pk": draft.id})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == draft.id

--- a/service/variant/urls.py
+++ b/service/variant/urls.py
@@ -6,11 +6,13 @@ from .views import (
     VariantDetailView,
     VariantDvarDownloadView,
     VariantListCreateView,
+    VariantMineListView,
     VariantSvgView,
 )
 
 urlpatterns = [
     path("variants/", VariantListCreateView.as_view(), name="variant-list"),
+    path("variants/mine/", VariantMineListView.as_view(), name="variant-mine-list"),
     path("variants/<str:pk>/", VariantDetailView.as_view(), name="variant-detail"),
     path(
         "variants/<str:variant_id>/dvar/",

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -50,8 +50,13 @@ def _variants_list_etag(variant_max, flag_max):
 
 
 def _variant_detail_etag(variant, user):
+    flag_max = NationFlag.objects.filter(nation__variant=variant).aggregate(
+        Max("updated_at")
+    )["updated_at__max"]
     user_id = user.id if user.is_authenticated else "anon"
-    digest = hashlib.sha256(f"{variant.updated_at}|{user_id}".encode()).hexdigest()
+    digest = hashlib.sha256(
+        f"{variant.updated_at}|{flag_max}|{user_id}".encode()
+    ).hexdigest()
     return f'"{digest[:32]}"'
 
 

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -4,7 +4,7 @@ import json
 
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models import Max, Q
+from django.db.models import Max
 from django.http import HttpResponse, HttpResponseNotFound
 from django.views import View
 from rest_framework import generics, permissions, status
@@ -44,31 +44,15 @@ def _variants_list_cache_inputs():
     return variant_max, flag_max
 
 
-def _variants_list_etag(variant_max, flag_max, user):
-    digest = hashlib.sha256(
-        f"{variant_max}|{flag_max}|{user.id}".encode()
-    ).hexdigest()
+def _variants_list_etag(variant_max, flag_max):
+    digest = hashlib.sha256(f"{variant_max}|{flag_max}".encode()).hexdigest()
     return f'"{digest[:32]}"'
 
 
-def _user_sees_only_published_variants(user):
-    """Whether ``visible_to(user)`` returns exactly the published variants.
-
-    True for anonymous users and for authenticated users who neither own a
-    draft nor belong to a game running a non-published variant — the common
-    case, and the only one whose payload can be served from the shared cache.
-    Mirrors the non-published clauses of ``VariantQuerySet.visible_to``.
-    """
-    if not user.is_authenticated:
-        return True
-    return not (
-        Variant.objects.filter(
-            Q(status=VariantStatus.DRAFT, owner=user)
-            | Q(games__members__user=user)
-        )
-        .exclude(status=VariantStatus.PUBLISHED)
-        .exists()
-    )
+def _variant_detail_etag(variant, user):
+    user_id = user.id if user.is_authenticated else "anon"
+    digest = hashlib.sha256(f"{variant.updated_at}|{user_id}".encode()).hexdigest()
+    return f'"{digest[:32]}"'
 
 
 class VariantListCreateView(generics.ListCreateAPIView):
@@ -80,7 +64,7 @@ class VariantListCreateView(generics.ListCreateAPIView):
         return [AllowAny()]
 
     def get_queryset(self):
-        return Variant.objects.visible_to(self.request.user).with_related_data()
+        return Variant.objects.filter(status=VariantStatus.PUBLISHED).with_related_data()
 
     def get_serializer_class(self):
         if self.request.method == "POST":
@@ -89,15 +73,13 @@ class VariantListCreateView(generics.ListCreateAPIView):
 
     def list(self, request, *args, **kwargs):
         variant_max, flag_max = _variants_list_cache_inputs()
-        etag = _variants_list_etag(variant_max, flag_max, request.user)
+        etag = _variants_list_etag(variant_max, flag_max)
         if request.headers.get("If-None-Match") == etag:
             response = Response(status=status.HTTP_304_NOT_MODIFIED)
-        elif _user_sees_only_published_variants(request.user):
-            response = Response(self._published_variants_data(variant_max, flag_max))
         else:
-            response = super().list(request, *args, **kwargs)
+            response = Response(self._published_variants_data(variant_max, flag_max))
         response["ETag"] = etag
-        response["Cache-Control"] = "private, must-revalidate, max-age=60"
+        response["Cache-Control"] = "public"
         return response
 
     def _published_variants_data(self, variant_max, flag_max):
@@ -105,14 +87,21 @@ class VariantListCreateView(generics.ListCreateAPIView):
         cache_key = f"variants-list:published:{digest}"
         data = cache.get(cache_key)
         if data is None:
-            queryset = Variant.objects.filter(
-                status=VariantStatus.PUBLISHED
-            ).with_related_data()
-            serialized = self.get_serializer(queryset, many=True).data
+            serialized = self.get_serializer(self.get_queryset(), many=True).data
             # Strip DRF's request-bound wrappers so the payload pickles cleanly.
             data = json.loads(json.dumps(serialized))
             cache.set(cache_key, data, _VARIANTS_LIST_CACHE_TIMEOUT)
         return data
+
+
+class VariantMineListView(generics.ListAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = VariantSerializer
+
+    def get_queryset(self):
+        return Variant.objects.filter(
+            status=VariantStatus.DRAFT, owner=self.request.user
+        ).with_related_data()
 
 
 class VariantDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -126,6 +115,17 @@ class VariantDetailView(generics.RetrieveUpdateDestroyAPIView):
         if self.request.method in ("PUT", "PATCH"):
             return VariantWriteSerializer
         return VariantSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        etag = _variant_detail_etag(instance, request.user)
+        if request.headers.get("If-None-Match") == etag:
+            response = Response(status=status.HTTP_304_NOT_MODIFIED)
+        else:
+            response = Response(self.get_serializer(instance).data)
+        response["ETag"] = etag
+        response["Cache-Control"] = "private, must-revalidate, max-age=60"
+        return response
 
     def perform_destroy(self, instance):
         with transaction.atomic():


### PR DESCRIPTION
## What this PR does

`GET /variants/` is now published-only and user-independent: the ETag drops `user.id`, `Cache-Control` becomes `public`, and the shared render cache added in #963 is the sole path (the per-user "does this user see only published variants" gate query is gone). Games keep referencing variants only by `variantId` — no variant data is embedded in the volatile per-user games list.

A new small `useGameVariant(game)` hook resolves a game's variant from the cached published catalogue and falls back to fetching it by id (now also ETag/`Cache-Control`-cacheable) for the one case that can't come from the published list: a private game running on its owner's still-draft variant. `CreateGame`, `MyGames`, and the game-detail screens (`GameInfoContent`, `PlayerInfoContent`, `OrdersScreen`, `DrawProposalsScreen`, `ProposeDrawScreen`, `ChannelListScreen`, `ChannelScreen`, `GameInfo`) are repointed accordingly. `FindGames` needed no change: it lists `can_join=true` games, which `game/filters.py`'s `filter_can_join` restricts to `private=False` and excludes games the requesting user is already a member of — draft variants can only back private games, so a joinable game's variant is always in the published catalogue for a browsing, not-yet-a-member user, both before and after this PR.

The Variants management screen gets a new `GET /variants/mine/` endpoint enumerating just the caller's own drafts, since those no longer appear in the published list, and merges it with the published catalogue for display.

**Trade-off worth flagging:** `MyGames` isn't named in the issue's approach, but it lists private games too (via `mine=true`), which can be draft-backed (a user's own sandbox or private game created from their own draft). Without the same per-game fallback there, those games would have silently disappeared from "My Games" once their variant stopped being in the published list. I applied the same `useGameVariant` treatment there to avoid that regression.

Regenerated `service/openapi-schema.yaml` and `src/api/generated/endpoints.ts` via the underlying `manage.py spectacular` + `orval` commands (no local Docker daemon in this environment); the diff is limited to the new `variants/mine/` endpoint plus a harmless interface-declaration reorder. Also deleted the now-unused `GameListVariantSerializer` and updated MSW handlers/fixtures with a draft-variant fixture.

Closes #992


---
_Generated by [Claude Code](https://claude.ai/code/session_01PrQeTNvcfKmjeBXG7gSMZf)_