### PR TITLE
Serialize manage.py migrate across concurrent web containers

### DIFF
--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -22,7 +22,21 @@ if [ "$PROCESS_ROLE" = "worker" ]; then
 fi
 
 echo "Running database migrations..."
-if python manage.py migrate; then
+if python manage.py shell << 'EOF'
+from django.core.management import call_command
+from django.db import connection
+
+MIGRATION_LOCK_ID = 727272001
+
+with connection.cursor() as cursor:
+    cursor.execute("SELECT pg_advisory_lock(%s)", [MIGRATION_LOCK_ID])
+try:
+    call_command("migrate")
+finally:
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_advisory_unlock(%s)", [MIGRATION_LOCK_ID])
+EOF
+then
     echo "Migrations completed successfully."
 else
     echo "Migration failed!" >&2


### PR DESCRIPTION
## What this PR does

Wraps the `web` role's `manage.py migrate` in `service/entrypoint.sh` with a Postgres session-level advisory lock (`pg_advisory_lock`/`pg_advisory_unlock`), so concurrent `web` containers queue for the lock instead of racing each other's migration DDL.

**Problem:** the `web` entrypoint runs `manage.py migrate` unconditionally on every container start with no coordination. When two `web` containers overlap (a rolling deploy where the old instance hasn't stopped before the new one starts, or a brief multi-replica window), both invoke `manage.py migrate` against the same production database concurrently. Postgres serializes the conflicting `CREATE TABLE`/`ADD COLUMN` DDL at the catalog level, so the losing process gets `relation already exists` ([DIPLICITY-API-6E](https://johnpooch.sentry.io/issues/DIPLICITY-API-6E), 432 occurrences since 2026-03-29) or `relation does not exist` ([DIPLICITY-API-96](https://johnpooch.sentry.io/issues/DIPLICITY-API-96)) and exits mid-run, leaving a later migration unapplied even though `django_migrations` bookkeeping may look otherwise consistent. That's what the procrastinate worker then hits when it queries a column that isn't actually there yet ([DIPLICITY-API-8D](https://johnpooch.sentry.io/issues/DIPLICITY-API-8D)) — a regression of #942/#943, which fixed the worker-vs-web race but not this web-vs-web race.

**Fix:** acquire a Postgres advisory lock before calling `migrate` and release it in a `finally`, via a `manage.py shell` heredoc (matching the existing superuser-creation pattern in this file). A second container's migrate call now blocks until the first finishes, instead of racing its DDL.

Closes #995

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — no Python/TS test suite applies (shell-script-only change); verified via `sh -n` syntax check and by manually exercising the lock against the local Postgres cluster: (1) the migrate-with-lock script runs cleanly end-to-end, (2) a second concurrent process attempting `pg_advisory_lock` on the same key blocks until the first process explicitly unlocks, confirmed by timing the second process's acquisition against the first's release.
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — not applicable, deploy/infrastructure-only change with no user-facing surface


---
_Generated by [Claude Code](https://claude.ai/code/session_015AaZbtmQy5KR3CCiKrecrJ)_