### PR TITLE
Bump version to 1.5.4 for new iOS build

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## Summary

Bumps `packages/web/package.json` from `1.5.3` to `1.5.4` to release a new iOS build.

Merging this PR to `main` triggers the `ios-release.yml` workflow (it fires on push to `main` touching `packages/web/**`), which builds the web bundle, syncs Capacitor, and runs `fastlane ios release` to upload the build to TestFlight. `MARKETING_VERSION` is derived from the `package.json` `version` field, so this bump sets the released version to `1.5.4`.

This picks up the unreleased `packages/web` changes since `1.5.3` (the map re-architecture work).

## Changes

- Bump `version` to `1.5.4` in `packages/web/package.json`


---
_Generated by [Claude Code](https://claude.ai/code/session_013Sit4rvfRxKAdndcmh3ZRn)_