### PR TITLE
Fix ~10s blank map on Android by forcing a WebView repaint when the base raster lands

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
+++ b/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
@@ -135,6 +135,7 @@ const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
       enableHover: mode === "interactive" && !isNativePlatform(),
       maxZoomFactor: showFillToggle ? undefined : 4,
       initialFill: showFillToggle,
+      forceCompositeOnBase: isNativePlatform(),
       onClickProvince: (province, position) =>
         onClickRef.current?.(province, position),
       onGesture: handleGesture,

--- a/packages/web/src/components/GameMapCanvas/GameMapController.ts
+++ b/packages/web/src/components/GameMapCanvas/GameMapController.ts
@@ -51,6 +51,7 @@ type ControllerOptions = {
   enableHover: boolean;
   maxZoomFactor?: number;
   initialFill?: boolean;
+  forceCompositeOnBase?: boolean;
   onClickProvince?: (province: string, position: Point) => void;
   onGesture: (record: GestureRecord) => void;
 };
@@ -102,6 +103,7 @@ export class GameMapController {
   private wheelDelta = 0;
   private wheelPoint: L.Point | null = null;
   private wheelRaf: number | null = null;
+  private compositeRaf: number | null = null;
 
   constructor(container: HTMLElement, options: ControllerOptions) {
     this.options = options;
@@ -302,7 +304,28 @@ export class GameMapController {
     if (!this.baseReady) {
       this.baseReady = true;
       this.map.getPane("overlayMap")!.style.visibility = "";
+      if (this.options.forceCompositeOnBase) {
+        this.nudgeComposite();
+      }
     }
+  }
+
+  // The base raster lands seconds after the map mounts (async SVG->PNG), and
+  // Android's WebView does not always paint a layer mutated that late: the board
+  // stays blank until the user pans or zooms and forces a repaint (reported as a
+  // ~10s white screen that clears on the first touch of the map or zoom button).
+  // Toggling the map pane's visibility for one frame re-rasterises it in place —
+  // the pane is already unpainted, so hiding it is invisible and the show forces
+  // the paint the WebView skipped, without moving the camera. Desktop browsers
+  // repaint on layer insertion, so this is gated to native via the option.
+  private nudgeComposite(): void {
+    const pane = this.map.getPane("mapPane");
+    if (!pane) return;
+    pane.style.visibility = "hidden";
+    this.compositeRaf = requestAnimationFrame(() => {
+      this.compositeRaf = null;
+      pane.style.visibility = "";
+    });
   }
 
   setOverlay(svg: string): void {
@@ -424,6 +447,9 @@ export class GameMapController {
     }
     if (this.wheelRaf !== null) {
       cancelAnimationFrame(this.wheelRaf);
+    }
+    if (this.compositeRaf !== null) {
+      cancelAnimationFrame(this.compositeRaf);
     }
     this.container.removeEventListener("wheel", this.onWheel);
     this.map.remove();


### PR DESCRIPTION
## Summary

Fixes the Android bug reported on Discord: after opening a game (or switching from Orders/Chat to Map), the map screen shows a **white/grey page for ~10 seconds**, and only renders once the user **touches the map or taps the zoom button**. Web is unaffected.

## Root cause

The map re-architecture made the Leaflet/canvas renderer the *only* map (`2ad9e9d`, 30 Jun), which shipped to the Android beta on 3 Jul — exactly when reports started. Before that Android used the old SVG map (plain DOM, no Leaflet, no async rasterisation).

The new renderer draws the board by rasterising the board SVG to a PNG **asynchronously** (`rasterizeSvg`), then applies it as a Leaflet `ImageOverlay` via `GameMapController.setBase()`, seconds after the map mounts. The units/orders overlay pane is kept `visibility: hidden` until that first raster lands (`d0726dc`), so before it lands the user sees pure white.

On Android's WebView, a layer mutated that late is **not always painted** — the board stays blank until something forces a repaint. Every workaround users found does exactly that:
- tapping the zoom/fill button → `setFill()` → `setView()` → transform change → repaint
- pinch/double-tap → zoom → repaint
- any pan → repaint

Desktop and mobile-web browsers repaint on layer insertion, which is why the bug is native-only.

This is corroborated by a new native-only Sentry crash in the same component, `TypeError: Cannot read properties of undefined (reading '_leaflet_pos')` (`GameMapCanvas` chunk, `_onZoomTransitionEnd → _getMapPanePos`, Android 10) — see notes below.

## Fix

When the first base raster is applied on a native platform, toggle the Leaflet `mapPane` visibility for one frame (`nudgeComposite`) so the WebView repaints in place — the same effect as the user's first touch, but without moving the camera. The pane is already unpainted at that moment, so hiding it for one frame is imperceptible.

- New `forceCompositeOnBase` controller option, set to `isNativePlatform()` in `GameMapCanvas`; desktop/web keeps the existing behaviour (no toggle).
- The scheduled `requestAnimationFrame` is cancelled in `destroy()`.

## Testing

- `npx tsc -b --noEmit` — clean
- `npx eslint` on changed files — clean
- `vitest run MapView.test.tsx GameMap.test.tsx` — 7 passed

⚠️ **Needs on-device verification on the Android beta.** The compositing behaviour is WebView-specific and cannot be reproduced in the browser test environment, so this fix is reasoned from the crash/regression evidence and the users' own repaint-based workarounds rather than a local Android repro.

No web-visible UI change (the toggle is native-only and lasts one frame), so no screenshots.

## Related Sentry issues (not fixed here)

Investigated alongside this bug; flagged for follow-up to keep this PR focused:
- **`DIPLICITY-REACT-9` — `..._leaflet_pos`** (native): a queued Leaflet zoom-transition-end callback fires after `map.remove()` (navigating away mid-zoom-animation). Same component/native trigger as this bug, but a separate crash-on-unmount.
- **`DIPLICITY-REACT-M` / `-E` — `Cannot read properties of undefined (reading 'GameMapCanvas' / 'MapScreen')`**: the `React.lazy` dynamic `import()` resolving to `undefined` (chunk-load race / deploy skew), a distinct code-splitting issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ4gKbXUoE4bRC5PzJKVbi)_