### PR TITLE
Add reasoning field to bot LLM output

### DIFF
--- a/service/bot/context/parsers.py
+++ b/service/bot/context/parsers.py
@@ -32,6 +32,10 @@ def parse_order_selections(
 ) -> list[list[str]]:
     data = _extract_json(response_text)
 
+    reasoning = data.get("reasoning")
+    if reasoning:
+        logger.info(f"[bot.llm] order reasoning: {reasoning}")
+
     choices = {}
     for choice in data.get("choices", []):
         if isinstance(choice, dict) and "source_id" in choice and "option_index" in choice:
@@ -56,6 +60,9 @@ def parse_order_selections(
 
 def parse_reply(response_text: str) -> str | None:
     data = _extract_json(response_text)
+    reasoning = data.get("reasoning")
+    if reasoning:
+        logger.info(f"[bot.llm] reply reasoning: {reasoning}")
     if not data.get("should_reply"):
         logger.info("[bot.llm] model declined to reply")
         return None

--- a/service/bot/llm_client.py
+++ b/service/bot/llm_client.py
@@ -25,7 +25,7 @@ class LLMClient:
         try:
             message = self._client.messages.create(
                 model=settings.BOT_LLM_MODEL,
-                max_tokens=1024,
+                max_tokens=2048,
                 system=system,
                 messages=messages,
             )

--- a/service/bot/prompts/reply_instruction.txt
+++ b/service/bot/prompts/reply_instruction.txt
@@ -1,6 +1,6 @@
 Respond with a single JSON object in exactly this shape:
 
-To stay silent: {"should_reply": false}
-To reply: {"should_reply": true, "message": "<your reply>"}
+To stay silent: {"reasoning": "<why you are responding this way>", "should_reply": false}
+To reply: {"reasoning": "<why you are responding this way>", "should_reply": true, "message": "<your reply>"}
 
-Respond with the JSON object only.
+First, in the reasoning field, think through whether and how to respond. Then set should_reply and, if replying, message. Respond with the JSON object only.

--- a/service/bot/prompts/select_orders_instruction.txt
+++ b/service/bot/prompts/select_orders_instruction.txt
@@ -1,5 +1,5 @@
 Respond with a single JSON object in exactly this shape:
 
-{"choices": [{"source_id": "<unit>", "option_index": <integer>}, ...]}
+{"reasoning": "<your strategic reasoning>", "choices": [{"source_id": "<unit>", "option_index": <integer>}, ...]}
 
-Include one entry per unit, where source_id is the unit identifier and option_index is the index of the chosen legal option for that unit. Respond with the JSON object only.
+First, in the reasoning field, think through your position and what each unit should do. Then, in choices, include one entry per unit, where source_id is the unit identifier and option_index is the index of the chosen legal option for that unit. Respond with the JSON object only.

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -133,6 +133,21 @@ class TestSelectOrders:
             ["edi", OrderType.HOLD],
         ]
 
+    def test_ignores_reasoning_field(self):
+        response_text = json.dumps(
+            {
+                "reasoning": "Hold London and move Edinburgh north.",
+                "choices": [
+                    {"source_id": "lon", "option_index": 0},
+                    {"source_id": "edi", "option_index": 1},
+                ],
+            }
+        )
+        assert parse_order_selections(response_text, self._options()) == [
+            ["lon", OrderType.HOLD],
+            ["edi", OrderType.MOVE, "nwg"],
+        ]
+
     def test_raises_on_unparseable_json(self):
         with pytest.raises(LLMError):
             parse_order_selections("not json at all", self._options())
@@ -579,6 +594,16 @@ class TestComposeReply:
 
     def test_returns_none_for_empty_message(self):
         assert parse_reply(json.dumps({"should_reply": True, "message": "   "})) is None
+
+    def test_ignores_reasoning_field(self):
+        response_text = json.dumps(
+            {
+                "reasoning": "They asked me directly, so I should answer.",
+                "should_reply": True,
+                "message": "Sounds good.",
+            }
+        )
+        assert parse_reply(response_text) == "Sounds good."
 
     def test_raises_on_unparseable_json(self):
         with pytest.raises(LLMError):


### PR DESCRIPTION
## What this PR does

The order-selection and reply bots ask the model for JSON but gave it no room to reason first. This adds a leading `reasoning` field to both output shapes so the model thinks through its position before committing to orders or a reply — a chain-of-thought aid. The field is placed first (models generate left-to-right, so reasoning must precede the decision to influence it), parsed defensively via `.get()`, and logged for observability. It does not affect decision logic, so every existing fallback (first-legal selection, stay-silent, index clamping) is preserved.

`max_tokens` is raised from 1024 to 2048 (`bot/llm_client.py`) so the reasoning field — which now shares the output budget with the orders/reply payload — doesn't truncate the JSON on a large phase and force a full-phase fallback.

> **Follow-up:** enforced structured outputs (Anthropic `output_config.format` / strict tool use) will be implemented in a future PR. This PR keeps the existing prompted-JSON + tolerant-parser approach.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)