### PR TITLE
[ONE LINE CODE CHANGE] Make the map's out-of-bounds background follow the app theme

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
+++ b/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
@@ -254,7 +254,7 @@ const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
       <div
         ref={containerRef}
         data-map-impl="leaflet"
-        style={{ width: "100%", height: "100%", background: "#fff" }}
+        style={{ width: "100%", height: "100%", background: "var(--background)" }}
       />
       {showFillToggle && (
         <Button


### PR DESCRIPTION
## What this PR does

In dark mode, the area around the game board (visible when the map is letterboxed in fit mode, while panning past the edge, or during load) stayed white. The white came from a hardcoded `background: "#fff"` on the Leaflet container div in `GameMapCanvas.tsx` — the rasterized board PNG is transparent outside painted areas, so the container color shows through.

The container now uses `background: "var(--background)"`, the theme token the rest of the app is built on, so the surround is near-black in dark mode and white in light mode as before. It stays an inline style because `leaflet/dist/leaflet.css` sets its own `.leaflet-container { background: #ddd }`, and the inline style overrides it regardless of stylesheet order.

The colored area *inside* the board rectangle comes from the variant's dSVG artwork (`rootFill` / background layer) and is intentionally untouched.

### Screenshots

**Dark mode (fixed)** — letterboxed board on `/game/active-movement/phase/101`, surround now follows the theme:

![map dark mode](https://raw.githubusercontent.com/johnpooch/diplicity-react/2e7c341353771f96e2ad6aac1b1747d3e034b4d4/shots/map-dark-fit.png)

**Light mode (unchanged)** — surround remains white, which is also what dark mode looked like before this fix:

![map light mode](https://raw.githubusercontent.com/johnpooch/diplicity-react/2e7c341353771f96e2ad6aac1b1747d3e034b4d4/shots/map-light-fit.png)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, one-line style change
- [x] Tests cover the change — n/a, inline style only; verified via the screenshots above in both themes
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)