### PR TITLE
Enable Public Press chat during staging (backend)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,8 @@ python -m pytest -n auto --reuse-db # full suite
 8. **Write tests alongside features** — not as an afterthought. All tests for a single app live in that app's `tests.py`; do not split them across multiple test modules (e.g. `tests_emit.py`).
 9. **Self-review non-trivial PRs with `/review-pr`** before requesting human review. Address or explicitly respond to all findings. Trivial PRs (typo fixes, dep bumps, doc-only) are exempt.
 10. **PR description must match the diff** — run `git diff main` and confirm every described change is visible. Do not describe work from a prior PR or session.
-11. **Python imports go at module top-level** — do not add an inline `import` inside a function/method body, even if you find an existing one nearby to copy. The only exception is breaking a genuine circular import, and that exception should be rare enough to call out in a PR description when used.
+11. **Never add a vacuous permission class** — if a Django REST `BasePermission` check's condition covers every possible value of the field it inspects (e.g. every `GameStatus`), it always evaluates `True` and gates nothing. Before adding a new permission class, check whether it excludes at least one real case; if it doesn't, don't add it — use `permissions.AllowAny` (or omit the check) instead.
+12. **Python imports go at module top-level** — do not add an inline `import` inside a function/method body, even if you find an existing one nearby to copy. The only exception is breaking a genuine circular import, and that exception should be rare enough to call out in a PR description when used.
 
 ---
 

--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -103,7 +103,7 @@ export interface ChannelMember {
   readonly isBot: boolean;
   /** @nullable */
   readonly commitment: string | null;
-  nation: Nation;
+  nation: Nation | null;
 }
 
 export interface ChannelMessage {

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -34,7 +34,7 @@ const getLatestMessagePreview = (
   const latestMessage = messages[messages.length - 1];
   const senderLabel = latestMessage.sender.isCurrentUser
     ? "You"
-    : latestMessage.sender.nation.name;
+    : (latestMessage.sender.nation?.name ?? latestMessage.sender.name);
   return `${senderLabel}: ${latestMessage.body}`;
 };
 

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -62,17 +62,19 @@ const buildMessageItems = (
   messages: readonly ChannelMessageType[]
 ): MessageDisplayItem[] => {
   return messages.map((msg, index) => {
-    const showAvatar =
-      index === 0 ||
-      messages[index - 1].sender.nation.name !== msg.sender.nation.name;
+    const nationName = msg.sender.nation?.name ?? msg.sender.name;
+    const previousNationName = index > 0
+      ? messages[index - 1].sender.nation?.name ?? messages[index - 1].sender.name
+      : null;
+    const showAvatar = index === 0 || previousNationName !== nationName;
 
     return {
       id: msg.id,
       body: msg.body,
       createdAt: msg.createdAt,
       sender: {
-        nationName: msg.sender.nation.name,
-        nationColor: msg.sender.nation.color,
+        nationName,
+        nationColor: msg.sender.nation?.color ?? "#808080",
         picture: msg.sender.picture,
       },
       isCurrentUser: msg.sender.isCurrentUser,

--- a/service/channel/serializers.py
+++ b/service/channel/serializers.py
@@ -13,7 +13,7 @@ Member = apps.get_model("member", "Member")
 
 
 class ChannelMemberSerializer(BaseMemberSerializer):
-    nation = NationSerializer()
+    nation = NationSerializer(allow_null=True)
 
 
 class ChannelMessageSerializer(serializers.Serializer):

--- a/service/channel/tests/test_channel.py
+++ b/service/channel/tests/test_channel.py
@@ -587,6 +587,61 @@ class TestChannelMarkReadView:
         assert response2.status_code == status.HTTP_204_NO_CONTENT
 
 
+class TestChannelPendingGameAccess:
+
+    @pytest.mark.django_db
+    def test_list_channels_allowed_for_pending_game(
+        self, authenticated_client, pending_game_created_by_secondary_user
+    ):
+        game = pending_game_created_by_secondary_user
+        Channel.objects.create(game=game, name="Public Press", private=False)
+
+        url = reverse("channel-list", args=[game.id])
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data[0]["name"] == "Public Press"
+
+    @pytest.mark.django_db
+    def test_message_create_allowed_for_pending_game_member(
+        self, authenticated_client, pending_game_created_by_secondary_user, in_memory_procrastinate
+    ):
+        game = pending_game_created_by_secondary_user
+        public_channel = Channel.objects.create(game=game, name="Public Press", private=False)
+        authenticated_client.post(reverse("game-join", args=[game.id]))
+
+        url = reverse("channel-message-create", args=[game.id, public_channel.id])
+        response = authenticated_client.post(url, {"body": "Hello staging"}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["sender"]["nation"] is None
+
+    @pytest.mark.django_db
+    def test_message_create_blocked_for_non_member_in_pending_game(
+        self, authenticated_client_for_tertiary_user, pending_game_created_by_secondary_user
+    ):
+        game = pending_game_created_by_secondary_user
+        public_channel = Channel.objects.create(game=game, name="Public Press", private=False)
+
+        url = reverse("channel-message-create", args=[game.id, public_channel.id])
+        response = authenticated_client_for_tertiary_user.post(url, {"body": "Nope"}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_mark_read_allowed_for_pending_game_member(
+        self, authenticated_client, pending_game_created_by_secondary_user
+    ):
+        game = pending_game_created_by_secondary_user
+        public_channel = Channel.objects.create(game=game, name="Public Press", private=False)
+        authenticated_client.post(reverse("game-join", args=[game.id]))
+
+        url = reverse("channel-mark-read", args=[game.id, public_channel.id])
+        response = authenticated_client.post(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
 class TestChannelUnreadCount:
 
     @pytest.mark.django_db

--- a/service/channel/views.py
+++ b/service/channel/views.py
@@ -13,12 +13,12 @@ class ChannelCreateView(SelectedGameMixin, CurrentGameMemberMixin, generics.Crea
 
 
 class ChannelMessageCreateView(SelectedGameMixin, SelectedChannelMixin, CurrentGameMemberMixin, generics.CreateAPIView):
-    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsNotKickedGameMember, IsChannelMember, IsNotSandboxGame, IsNotNoPressActiveGame]
+    permission_classes = [permissions.IsAuthenticated, IsNotKickedGameMember, IsChannelMember, IsNotSandboxGame, IsNotNoPressActiveGame]
     serializer_class = ChannelMessageSerializer
 
 
 class ChannelMarkReadView(SelectedGameMixin, SelectedChannelMixin, CurrentGameMemberMixin, generics.CreateAPIView):
-    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsGameMember, IsChannelMember]
+    permission_classes = [permissions.IsAuthenticated, IsGameMember, IsChannelMember]
     serializer_class = ChannelMarkReadSerializer
 
     def create(self, request, *args, **kwargs):
@@ -29,7 +29,7 @@ class ChannelMarkReadView(SelectedGameMixin, SelectedChannelMixin, CurrentGameMe
 
 
 class ChannelListView(SelectedGameMixin, generics.ListAPIView):
-    permission_classes = [IsActiveOrCompletedGame]
+    permission_classes = [permissions.AllowAny]
     serializer_class = ChannelSerializer
 
     def get_queryset(self):

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -1097,6 +1097,7 @@ paths:
       - games
       security:
       - jwtAuth: []
+      - {}
       responses:
         '200':
           content:
@@ -1848,7 +1849,9 @@ components:
           nullable: true
           readOnly: true
         nation:
-          $ref: '#/components/schemas/Nation'
+          allOf:
+          - $ref: '#/components/schemas/Nation'
+          nullable: true
       required:
       - commitment
       - id


### PR DESCRIPTION
## What this PR does

Makes Public Press usable during staging (pending games), per #902: joined players can post, and anyone who can see the game can read — no new Lobby channel, Public Press doubles as the lobby.

- `ChannelMessageCreateView` and `ChannelMarkReadView` no longer carry a game-status permission (only `IsGameMember`/`IsChannelMember` etc.); `ChannelListView` uses `permissions.AllowAny`. None of the three needs to restrict by game status — `ChannelCreateView` is untouched, so private channels still only exist once a game is active.
- `ChannelMemberSerializer.nation` is now nullable, since staging members have no nation assigned yet. The two chat screens (`ChannelScreen`, `ChannelListScreen`) that read `sender.nation.name` now fall back to the member's display name when nation is null.
- Regenerated `openapi-schema.yaml` and the frontend TS client for the nullable `nation` field.
- Added a CLAUDE.md guideline against permission classes whose condition covers every possible value of the field they inspect (discovered during review: an earlier version of this PR added exactly that).

Out of scope, per review: an optional intro-message-on-join feature was cut from this PR in favor of a simpler two-chained-request frontend approach (join, then post to Public Press) in a follow-up.

Closes #902

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — the `gh`-CLI-based skill isn't available in this sandbox, so I performed an equivalent manual read-through of the diff instead, and separately addressed human review comments.
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes — this PR is backend-only; the two frontend edits are type-safety fixes for the new nullable field, not visible changes.
