### PR TITLE
Trigger NMR extensions on unsubmitted orders, not unconfirmed ones

### DIFF
--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -202,6 +202,8 @@ class PhaseManager(models.Manager):
     def _check_and_apply_nmr_extensions(self, phase):
         not_submitted = phase.phase_states.filter(
             has_possible_orders=True
+        ).exclude(
+            member__civil_disorder=True
         ).annotate(order_count=Count("orders")).filter(order_count=0).select_related('member')
 
         members_with_extensions = [

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -200,12 +200,12 @@ class PhaseManager(models.Manager):
         return self.resolve_due_phases(canary=True)
 
     def _check_and_apply_nmr_extensions(self, phase):
-        unconfirmed = phase.phase_states.filter(
-            has_possible_orders=True, orders_confirmed=False
-        ).select_related('member')
+        not_submitted = phase.phase_states.filter(
+            has_possible_orders=True
+        ).annotate(order_count=Count("orders")).filter(order_count=0).select_related('member')
 
         members_with_extensions = [
-            ps.member for ps in unconfirmed
+            ps.member for ps in not_submitted
             if ps.member.nmr_extensions_remaining > 0
         ]
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4627,7 +4627,7 @@ class TestNMRExtensionsFixedTime:
         assert phase.scheduled_resolution > now + timedelta(hours=24)
 
     @pytest.mark.django_db
-    def test_fixed_time_confirmed_skips_extension(
+    def test_fixed_time_orders_submitted_unconfirmed_skips_extension(
         self,
         deadline_warning_game_factory,
         italy_vs_germany_italy_nation,
@@ -4644,13 +4644,44 @@ class TestNMRExtensionsFixedTime:
             type=UnitType.ARMY,
             nation=italy_vs_germany_italy_nation,
         )
-        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+        ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
 
         result = Phase.objects._check_and_apply_nmr_extensions(phase)
 
         assert result is None
         italy.refresh_from_db()
         assert italy.nmr_extensions_remaining == 1
+
+    @pytest.mark.django_db
+    def test_fixed_time_confirmed_with_no_orders_still_applies_extension(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(
+            DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
+        )
+        game.movement_frequency = PhaseFrequency.EVERY_2_DAYS
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
+        game.save()
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+
+        result = Phase.objects._check_and_apply_nmr_extensions(phase)
+
+        assert result is not None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 0
 
 
 def _elimination_jobs(connector):

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4683,6 +4683,37 @@ class TestNMRExtensionsFixedTime:
         italy.refresh_from_db()
         assert italy.nmr_extensions_remaining == 0
 
+    @pytest.mark.django_db
+    def test_fixed_time_civil_disorder_member_does_not_consume_extension(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(
+            DeadlineMode.FIXED_TIME, now - timedelta(minutes=1)
+        )
+        game.movement_frequency = PhaseFrequency.EVERY_2_DAYS
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
+        game.save()
+        italy.nmr_extensions_remaining = 1
+        italy.civil_disorder = True
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+
+        result = Phase.objects._check_and_apply_nmr_extensions(phase)
+
+        assert result is None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 1
+
 
 def _elimination_jobs(connector):
     return [


### PR DESCRIPTION
## What this PR does

`PhaseManager._check_and_apply_nmr_extensions` was granting NMR extensions and pushing the phase deadline forward for any player with `orders_confirmed=False`, regardless of whether they had actually submitted orders. Since confirming is an optional, independent toggle (`PhaseStateSerializer.update`), a player who submitted a full set of orders but never tapped "Confirm" was treated identically to a genuine no-show — causing fixed-deadline phases to slide day after day until extensions ran out.

The fix changes the check to look at whether a member has submitted zero orders (the same NMR definition already used by `_set_orders_outcome`), rather than the confirmation flag. `PhaseQuerySet.filter_due_phases`'s separate "all confirmed → resolve early" mechanism is untouched — that's a distinct, working feature (early resolution via the optional confirm button) and isn't part of this bug.

Self-review turned up a regression the first version of this fix would have introduced: civil-disorder members never submit orders, and the old `orders_confirmed=False` check happened to skip them because their phase states get `orders_confirmed` auto-set to `True` at phase creation. Switching to an order-count check would have made CD members match "not submitted" and silently burn through their extensions every deadline. Civil-disorder members are now explicitly excluded from the check, with a regression test.

Closes #1011

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I self-reviewed this diff (the `/review-pr` skill needs the `gh` CLI, unavailable in this environment) and fixed a civil-disorder regression it surfaced
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — not applicable, backend-only change
