### PR TITLE
Cap rasterised base map to a pixel-area budget

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
+++ b/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
@@ -12,7 +12,11 @@ import type {
 import { parseDsvg } from "../InteractiveMap/dsvgParser";
 import { DiplicityMap } from "../InteractiveMap/mapRenderer";
 import { toRenderState } from "../InteractiveMap/toRenderState";
-import { recordGesture, recordInitialRender } from "../InteractiveMap/mapTelemetry";
+import {
+  recordGesture,
+  recordInitialRender,
+  recordRasterFailure,
+} from "../InteractiveMap/mapTelemetry";
 import { useDsvg } from "../../hooks/useDsvg";
 import { isNativePlatform } from "../../utils/platform";
 import {
@@ -216,8 +220,13 @@ const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
           containerRef.current?.setAttribute("data-map-ready", "true");
         }
       })
-      .catch(() => {
-        /* a failed raster leaves the previous base in place */
+      .catch((error) => {
+        // A failed raster leaves the previous base in place.
+        recordRasterFailure({
+          variantId: variantIdRef.current,
+          error,
+          implementation: "leaflet",
+        });
       });
 
     return () => {

--- a/packages/web/src/components/GameMapCanvas/rasterizeSvg.test.ts
+++ b/packages/web/src/components/GameMapCanvas/rasterizeSvg.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { injectSvgDimensions } from "./rasterizeSvg";
+import { computeRasterDimensions, injectSvgDimensions } from "./rasterizeSvg";
 
 describe("injectSvgDimensions", () => {
   it("stamps width and height onto the root svg tag", () => {
@@ -16,5 +16,25 @@ describe("injectSvgDimensions", () => {
     expect(sized).toContain('viewBox="0 0 1234.5 987.25"');
     expect(sized).toContain('width="1234.5"');
     expect(sized).toContain('height="987.25"');
+  });
+});
+
+describe("computeRasterDimensions", () => {
+  it("leaves dimensions unchanged when already within the pixel budget", () => {
+    const dimensions = computeRasterDimensions(1000, 1000, 4_000_000);
+    expect(dimensions).toEqual({ width: 1000, height: 1000 });
+  });
+
+  it("scales down large viewboxes to fit the pixel budget", () => {
+    const dimensions = computeRasterDimensions(4000, 4000, 4_000_000);
+    expect(dimensions.width * dimensions.height).toBeCloseTo(4_000_000, 0);
+    expect(dimensions.width).toBeCloseTo(2000, 5);
+    expect(dimensions.height).toBeCloseTo(2000, 5);
+  });
+
+  it("preserves aspect ratio for non-square viewboxes", () => {
+    const dimensions = computeRasterDimensions(8000, 2000, 4_000_000);
+    expect(dimensions.width / dimensions.height).toBeCloseTo(4, 5);
+    expect(dimensions.width * dimensions.height).toBeLessThanOrEqual(4_000_000);
   });
 });

--- a/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
+++ b/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
@@ -9,18 +9,40 @@ export const injectSvgDimensions = (
   height: number
 ): string => svg.replace("<svg ", `<svg width="${width}" height="${height}" `);
 
+// Ceiling on the rasterised base's pixel area. Variants with very large
+// viewBoxes (e.g. Cold War 1961 at 4000x4000 = 16 MP) can exceed the canvas
+// area limit on mobile Safari/iOS WebKit and memory-constrained devices,
+// causing drawImage/toBlob to fail silently. The raster is only a backdrop
+// image positioned by Leaflet from the true viewBox, so downscaling it is
+// safe — it only slightly softens the base landmass at maximum zoom.
+export const MAX_RASTER_PIXELS = 4_000_000;
+
+export const computeRasterDimensions = (
+  width: number,
+  height: number,
+  maxPixels: number = MAX_RASTER_PIXELS
+): { width: number; height: number } => {
+  const scale = Math.min(1, Math.sqrt(maxPixels / (width * height)));
+  return { width: width * scale, height: height * scale };
+};
+
 // Rasterises an SVG string to a PNG object URL once. Per the map re-architecture
 // proposal, the static base is rasterised a single time and thereafter only
 // moved by the camera, so the ~17k path commands are never repainted per frame.
-// The board is drawn at its native viewBox resolution (the accepted "soft base
-// map at 4× zoom" trade).
+// The board is drawn at its native viewBox resolution, capped to a pixel-area
+// budget (the accepted "soft base map at 4× zoom" trade).
 export const rasterizeSvg = (
   svg: string,
   width: number,
   height: number
 ): Promise<string> =>
   new Promise((resolve, reject) => {
-    const sizedSvg = injectSvgDimensions(svg, width, height);
+    const rasterDimensions = computeRasterDimensions(width, height);
+    const sizedSvg = injectSvgDimensions(
+      svg,
+      rasterDimensions.width,
+      rasterDimensions.height
+    );
     const blob = new Blob([sizedSvg], { type: "image/svg+xml;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const image = new Image();
@@ -34,8 +56,8 @@ export const rasterizeSvg = (
           await image.decode();
         }
         const canvas = document.createElement("canvas");
-        canvas.width = Math.max(1, Math.round(width));
-        canvas.height = Math.max(1, Math.round(height));
+        canvas.width = Math.max(1, Math.round(rasterDimensions.width));
+        canvas.height = Math.max(1, Math.round(rasterDimensions.height));
         const context = canvas.getContext("2d");
         if (!context) {
           throw new Error("Could not acquire a 2D canvas context");

--- a/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
+++ b/packages/web/src/components/InteractiveMap/mapTelemetry.test.ts
@@ -15,7 +15,7 @@ vi.mock("@opentelemetry/api", () => ({
   trace: { getTracer: () => ({ startSpan: startSpanSpy }) },
 }));
 
-import { recordInitialRender, recordGesture } from "./mapTelemetry";
+import { recordInitialRender, recordGesture, recordRasterFailure } from "./mapTelemetry";
 
 describe("mapTelemetry", () => {
   beforeEach(() => {
@@ -84,6 +84,26 @@ describe("mapTelemetry", () => {
         attributes: expect.objectContaining({ "map.implementation": "leaflet" }),
       })
     );
+  });
+
+  it("emits a map.raster_failure span with the error message", () => {
+    recordRasterFailure({
+      variantId: "cold-war-1961",
+      error: new Error("Failed to rasterise base map to PNG"),
+      implementation: "leaflet",
+    });
+
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      "map.raster_failure",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          "map.variant_id": "cold-war-1961",
+          "map.implementation": "leaflet",
+          "map.error_message": "Failed to rasterise base map to PNG",
+        }),
+      })
+    );
+    expect(endSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not emit a gesture span when no frames were recorded", () => {

--- a/packages/web/src/components/InteractiveMap/mapTelemetry.ts
+++ b/packages/web/src/components/InteractiveMap/mapTelemetry.ts
@@ -99,4 +99,21 @@ const recordGesture = (params: {
   span.end();
 };
 
-export { recordInitialRender, recordGesture };
+const recordRasterFailure = (params: {
+  variantId: string;
+  error: unknown;
+  implementation?: MapImplementation;
+}): void => {
+  const span = tracer.startSpan("map.raster_failure", {
+    attributes: {
+      "map.variant_id": params.variantId,
+      "map.implementation": params.implementation ?? "svg",
+      "map.error_message":
+        params.error instanceof Error ? params.error.message : String(params.error),
+      ...deviceContext(),
+    },
+  });
+  span.end();
+};
+
+export { recordInitialRender, recordGesture, recordRasterFailure };


### PR DESCRIPTION
## What this PR does

Large-viewBox variants such as Cold War 1961 (4000×4000 = 16 MP) can exceed the canvas area ceiling on mobile Safari/iOS WebKit and memory-constrained devices. When that happens, `drawImage`/`toBlob` fails, the error was previously swallowed silently, and the interactive board rendered blank on first load since there was no prior base to fall back to.

`rasterizeSvg` now caps the rasterised base to a ~4 MP pixel budget, scaling both the injected SVG dimensions and the destination canvas down while preserving aspect ratio (`scale = min(1, sqrt(maxPixels / (width * height)))`). This is safe because Leaflet positions the base image from the true viewBox via `imageOverlay(pngUrl, this.bounds, ...)`, independent of the PNG's own pixel dimensions — the vector unit/order overlay is unaffected, and the trade is a slightly softer landmass at maximum zoom on the largest maps, which the code already accepts for all variants.

Also swapped the silent `.catch(() => {})` for a `map.raster_failure` telemetry span, so a raster failure that does slip through is observable instead of invisible.

Closes #1013

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3LZ5NoYyvRY66eYTxcptJ)_