### PR TITLE
Bump version to 1.5.5 for new iOS build

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## What this PR does

Bumps `MARKETING_VERSION` from 1.5.4 to 1.5.5 (via `packages/web/package.json` and the synced `package-lock.json`) to cut a new iOS release. Merging to `main` triggers the `ios-release.yml` workflow, which builds, syncs Capacitor, and uploads the new build to TestFlight.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — N/A, version-bump only
- [x] Tests cover the change — N/A, no code logic changed
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_018bRqqi4siGCqrRRqDds8XV)_