### PR TITLE
Fix deadline warning denominator for retreat and adjustment phases

### DIFF
--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -323,6 +323,7 @@ class PhaseManager(models.Manager):
                 for sc in phase.prefetched_supply_centers:
                     sc_by_nation[sc.nation_id] = sc_by_nation.get(sc.nation_id, 0) + 1
 
+                is_adjustment = phase.type == PhaseType.ADJUSTMENT
                 warned_states = []
 
                 for ps in phase.phase_states.all():
@@ -334,7 +335,7 @@ class PhaseManager(models.Manager):
                     nation_id = ps.member.nation_id
                     unit_count = units_by_nation.get(nation_id, 0)
 
-                    if phase.type == PhaseType.ADJUSTMENT:
+                    if is_adjustment:
                         sc_count = sc_by_nation.get(nation_id, 0)
                         total_units = abs(sc_count - unit_count)
                     elif phase.type == PhaseType.RETREAT:
@@ -348,7 +349,7 @@ class PhaseManager(models.Manager):
                     body = build_notification_body(
                         ps.orders_confirmed, is_fixed_time, len(ps.orders.all()), total_units, time_left,
                         ps.member.nmr_extensions_remaining,
-                        is_adjustment=phase.type == PhaseType.ADJUSTMENT,
+                        is_adjustment=is_adjustment,
                     )
                     if body is None:
                         continue

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -313,8 +313,11 @@ class PhaseManager(models.Manager):
                 time_left = format_time_remaining(time_until_deadline)
 
                 units_by_nation = {}
+                dislodged_units_by_nation = {}
                 for unit in phase.prefetched_units:
                     units_by_nation[unit.nation_id] = units_by_nation.get(unit.nation_id, 0) + 1
+                    if unit.dislodged:
+                        dislodged_units_by_nation[unit.nation_id] = dislodged_units_by_nation.get(unit.nation_id, 0) + 1
 
                 sc_by_nation = {}
                 for sc in phase.prefetched_supply_centers:
@@ -334,6 +337,8 @@ class PhaseManager(models.Manager):
                     if phase.type == PhaseType.ADJUSTMENT:
                         sc_count = sc_by_nation.get(nation_id, 0)
                         total_units = abs(sc_count - unit_count)
+                    elif phase.type == PhaseType.RETREAT:
+                        total_units = dislodged_units_by_nation.get(nation_id, 0)
                     else:
                         total_units = unit_count
 
@@ -343,6 +348,7 @@ class PhaseManager(models.Manager):
                     body = build_notification_body(
                         ps.orders_confirmed, is_fixed_time, len(ps.orders.all()), total_units, time_left,
                         ps.member.nmr_extensions_remaining,
+                        is_adjustment=phase.type == PhaseType.ADJUSTMENT,
                     )
                     if body is None:
                         continue

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4684,6 +4684,51 @@ class TestSendDeadlineWarnings:
         assert "stop waiting for you" not in call_kwargs["body"]
         assert "adjustments will be made automatically" in call_kwargs["body"]
 
+    @pytest.mark.django_db
+    def test_adjustment_phase_no_orders_with_extensions_shows_extension_message(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        primary_user,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game = Game.objects.create(
+            name="Adjustment Extension Test",
+            variant=italy_vs_germany_variant,
+            deadline_mode=DeadlineMode.DURATION,
+            movement_phase_duration="24h",
+        )
+        italy = game.members.create(nation=italy_vs_germany_italy_nation, user=primary_user)
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.ADJUSTMENT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=now + timedelta(minutes=10),
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation
+        )
+        phase.supply_centers.create(province=italy_vs_germany_venice_province, nation=italy_vs_germany_italy_nation)
+        phase.supply_centers.create(province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "deadline will extend" in call_kwargs["body"]
+        assert "lose an extension" in call_kwargs["body"]
+        assert "adjustments will be made automatically" not in call_kwargs["body"]
+
 
 class TestNMRExtensionsFixedTime:
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4591,6 +4591,99 @@ class TestSendDeadlineWarnings:
 
         mock_send_notification_to_users.assert_not_called()
 
+    @pytest.mark.django_db
+    def test_retreat_phase_denominator_is_dislodged_units_not_all_units(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        primary_user,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game = Game.objects.create(
+            name="Retreat Denominator Test",
+            variant=italy_vs_germany_variant,
+            deadline_mode=DeadlineMode.DURATION,
+            movement_phase_duration="24h",
+        )
+        italy = game.members.create(nation=italy_vs_germany_italy_nation, user=primary_user)
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.RETREAT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=now + timedelta(minutes=10),
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation
+        )
+        dislodged_unit = phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+            dislodged=True,
+        )
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+        italy_ps.orders.create(
+            source=dislodged_unit.province, order_type=OrderType.MOVE, target=italy_vs_germany_rome_province
+        )
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "orders ready" in call_kwargs["body"]
+        assert "waiting confirmation" in call_kwargs["body"]
+        assert "1/2" not in call_kwargs["body"]
+
+    @pytest.mark.django_db
+    def test_adjustment_phase_no_orders_omits_stop_waiting_framing(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        primary_user,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game = Game.objects.create(
+            name="Adjustment Optional Build Test",
+            variant=italy_vs_germany_variant,
+            deadline_mode=DeadlineMode.DURATION,
+            movement_phase_duration="24h",
+        )
+        italy = game.members.create(nation=italy_vs_germany_italy_nation, user=primary_user)
+        phase = Phase.objects.create(
+            game=game,
+            variant=italy_vs_germany_variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.ADJUSTMENT,
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=now + timedelta(minutes=10),
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation
+        )
+        phase.supply_centers.create(province=italy_vs_germany_venice_province, nation=italy_vs_germany_italy_nation)
+        phase.supply_centers.create(province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert "no orders given" in call_kwargs["body"]
+        assert "stop waiting for you" not in call_kwargs["body"]
+        assert "adjustments will be made automatically" in call_kwargs["body"]
+
 
 class TestNMRExtensionsFixedTime:
 

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -30,10 +30,10 @@ def build_notification_body(
     orders_confirmed, is_fixed_time, orders_given, total_units, time_left, extensions_remaining,
     is_adjustment=False,
 ):
-    if is_adjustment:
-        nmr_suffix = "If no orders given, adjustments will be made automatically."
-    elif extensions_remaining > 0:
+    if extensions_remaining > 0:
         nmr_suffix = "If no orders given, the deadline will extend, but you'll lose an extension."
+    elif is_adjustment:
+        nmr_suffix = "If no orders given, adjustments will be made automatically."
     else:
         nmr_suffix = "If no orders given, the game will stop waiting for you for next turns."
 

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -26,8 +26,13 @@ def format_deadline(dt, tz_name=None):
     return dt.strftime("%b %d, %Y at %I:%M %p UTC")
 
 
-def build_notification_body(orders_confirmed, is_fixed_time, orders_given, total_units, time_left, extensions_remaining):
-    if extensions_remaining > 0:
+def build_notification_body(
+    orders_confirmed, is_fixed_time, orders_given, total_units, time_left, extensions_remaining,
+    is_adjustment=False,
+):
+    if is_adjustment:
+        nmr_suffix = "If no orders given, adjustments will be made automatically."
+    elif extensions_remaining > 0:
         nmr_suffix = "If no orders given, the deadline will extend, but you'll lose an extension."
     else:
         nmr_suffix = "If no orders given, the game will stop waiting for you for next turns."


### PR DESCRIPTION
## What this PR does

`send_deadline_warnings` used the nation's total unit count as the "units needing orders" denominator for every non-adjustment phase, including retreat phases where only dislodged units can actually be ordered. A player with 1 dislodged unit out of 10 who hadn't submitted a retreat got a "no orders given ... the game will stop waiting for you" warning implying all 10 units were at risk. This PR changes the denominator to the dislodged-unit count for retreat phases (`service/phase/models.py`).

It also removes the NMR-drop framing ("the game will stop waiting for you") from adjustment-phase warnings, since builds are optional and unresolved adjustments are handled automatically rather than triggering civil disorder (`service/phase/utils.py`).

Closes #1017

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only change with no visible UI impact


---
_Generated by [Claude Code](https://claude.ai/code/session_017Q9h61iiwRfnRiTLBNps2r)_