### PR TITLE
Dedupe active games list request on My Games screen

### DIFF
--- a/packages/web/src/hooks/useGamesListInfinite.ts
+++ b/packages/web/src/hooks/useGamesListInfinite.ts
@@ -1,4 +1,7 @@
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import {
+  infiniteQueryOptions,
+  useSuspenseInfiniteQuery,
+} from "@tanstack/react-query";
 import {
   gamesList,
   getGamesListQueryKey,
@@ -12,11 +15,14 @@ const getNextPageParam = (lastPage: Awaited<ReturnType<typeof gamesList>>) => {
   return page ? Number(page) : undefined;
 };
 
-export const useGamesListInfinite = (params?: GamesListParams) => {
-  return useSuspenseInfiniteQuery({
+export const gamesListInfiniteQueryOptions = (params?: GamesListParams) =>
+  infiniteQueryOptions({
     queryKey: [...getGamesListQueryKey(params), "infinite"],
     queryFn: ({ pageParam }) => gamesList({ ...params, page: pageParam }),
     initialPageParam: 1,
     getNextPageParam,
   });
+
+export const useGamesListInfinite = (params?: GamesListParams) => {
+  return useSuspenseInfiniteQuery(gamesListInfiniteQueryOptions(params));
 };

--- a/packages/web/src/hooks/useNotificationPermissionPrompt.ts
+++ b/packages/web/src/hooks/useNotificationPermissionPrompt.ts
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/auth";
 import {
-  useGamesList,
   useDevicesList,
   useDevicesCreate,
   getDevicesListQueryKey,
@@ -11,6 +10,7 @@ import { checkPermission } from "@/messaging-native";
 import { isNativePlatform, isIosPlatform } from "@/utils/platform";
 import { requestNotificationPermission } from "@/utils/notificationToken";
 import { useCheckNotificationPermission } from "./useCheckNotificationPermission";
+import { gamesListInfiniteQueryOptions } from "./useGamesListInfinite";
 
 const useNotificationPermissionPrompt = () => {
   const { loggedIn } = useAuth();
@@ -19,10 +19,19 @@ const useNotificationPermissionPrompt = () => {
   const createDeviceMutation = useDevicesCreate();
   const queryClient = useQueryClient();
 
-  const { data: activeGamesData } = useGamesList(
-    { mine: true, status: "active", sandbox: false },
-    { query: { enabled: loggedIn } }
-  );
+  const { data: activeGamesData } = useInfiniteQuery({
+    ...gamesListInfiniteQueryOptions({
+      mine: true,
+      status: "active",
+      ordering: "deadline",
+    }),
+    enabled: loggedIn,
+  });
+
+  const hasActiveNonSandboxGame =
+    activeGamesData?.pages.some(page =>
+      page.results.some(game => !game.sandbox)
+    ) ?? false;
 
   const { data: devicesData, isLoading: devicesLoading } = useDevicesList({
     query: { enabled: loggedIn },
@@ -31,12 +40,11 @@ const useNotificationPermissionPrompt = () => {
   // Prompt for permission when user has active games and hasn't been asked yet
   useEffect(() => {
     if (!loggedIn || hasPromptedRef.current) return;
-    if (activeGamesData === undefined) return;
-    if (activeGamesData.count === 0) return;
+    if (!hasActiveNonSandboxGame) return;
 
     hasPromptedRef.current = true;
     checkNotificationPermission();
-  }, [loggedIn, activeGamesData, checkNotificationPermission]);
+  }, [loggedIn, hasActiveNonSandboxGame, checkNotificationPermission]);
 
   // Silently re-register if permission is already granted but device record is missing
   useEffect(() => {


### PR DESCRIPTION
## What this PR does

The My Games screen fired **two** requests to the games list endpoint on load:

- `games/?mine=true&status=active&ordering=deadline&page=1` — the "Started" tab's own list (`useGamesListInfinite` in `MyGames.tsx`)
- `games/?mine=true&status=active&sandbox=false` — the app-level notification permission prompt (`useNotificationPermissionPrompt`, mounted in `App.tsx`)

Because the params differed (`ordering=deadline` vs `sandbox=false`) — and one used `useSuspenseInfiniteQuery` while the other used `useGamesList` — React Query built distinct cache keys and issued two independent round-trips, slowing initial load. This was introduced in #527 ("Notification improvement: request permissions progressively"), which added the prompt hook.

This PR extracts the infinite games query into a shared `gamesListInfiniteQueryOptions` factory and has the prompt hook consume the **same query key** via `useInfiniteQuery`. On the My Games screen the two hooks now share a single request; on other screens the prompt still fetches on its own (unchanged). The prompt trigger switches from the server `count` to detecting a non-sandbox active game in the loaded results, preserving the original "returning user with an active game" behaviour (sandbox-only users are still not prompted).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] Self-reviewed the diff (the `/review-pr` skill shells out to `gh`, which isn't available in this environment, so the review was manual) — no findings
- [x] Tests cover the change (existing `MyGames`/`FindGames` suites pass; full suite green — 507 tests, plus lint and `tsc -b --noEmit`)
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual change (request deduplication only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)