### PR TITLE
Isolate prompt-build and response-validate seams for bot LLM calls

### DIFF
--- a/service/bot/context/parsers.py
+++ b/service/bot/context/parsers.py
@@ -1,106 +1,33 @@
-import json
-import logging
-
-from bot.context.orders import (
-    group_options_by_source,
-    option_to_selected,
-    order_option_label,
-)
 from bot.llm_client import LLMError
+from bot.steps import (
+    ORDER_SELECTION_SCHEMA,
+    REPLY_SCHEMA,
+    reply_from_verdict,
+    selections_from_order_verdict,
+    validate_order_selections,
+    validate_reply,
+)
 from bot.types import OrderOptionDict
 
-logger = logging.getLogger(__name__)
-
-ORDER_SELECTION_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "reasoning": {"type": "string"},
-        "choices": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source_id": {"type": "string"},
-                    "option_index": {"type": "integer"},
-                },
-                "required": ["source_id", "option_index"],
-                "additionalProperties": False,
-            },
-        },
-    },
-    "required": ["reasoning", "choices"],
-    "additionalProperties": False,
-}
-
-REPLY_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "reasoning": {"type": "string"},
-        "should_reply": {"type": "boolean"},
-        "message": {"type": "string"},
-    },
-    "required": ["reasoning", "should_reply"],
-    "additionalProperties": False,
-}
-
-
-def _extract_json(response_text: str) -> dict:
-    text = response_text.strip()
-    if text.startswith("```"):
-        lines = text.splitlines()
-        if lines and lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        text = "\n".join(lines).strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as e:
-        raise LLMError(f"could not parse JSON from response: {e}") from e
+__all__ = [
+    "ORDER_SELECTION_SCHEMA",
+    "REPLY_SCHEMA",
+    "parse_order_selections",
+    "parse_reply",
+]
 
 
 def parse_order_selections(
     response_text: str, options: list[OrderOptionDict]
 ) -> list[list[str]]:
-    data = _extract_json(response_text)
-
-    reasoning = data.get("reasoning")
-    if reasoning:
-        logger.info(f"[bot.llm] order reasoning: {reasoning}")
-
-    choices = {}
-    for choice in data.get("choices", []):
-        if isinstance(choice, dict) and "source_id" in choice and "option_index" in choice:
-            choices[choice["source_id"]] = choice["option_index"]
-
-    selections = []
-    for source_id, source_options in group_options_by_source(options).items():
-        index = choices.get(source_id)
-        if index is None or not (0 <= index < len(source_options)):
-            chosen = source_options[0]
-            logger.info(
-                f"[bot.llm] {source_id}: invalid/missing choice {index}; "
-                f"using first legal option {order_option_label(chosen)}"
-            )
-        else:
-            chosen = source_options[index]
-            logger.info(f"[bot.llm] {source_id}: chose {order_option_label(chosen)}")
-        selections.append(option_to_selected(chosen))
-    logger.info(f"[bot.llm] selected {len(selections)} order(s)")
-    return selections
+    verdict = validate_order_selections(response_text, options)
+    if verdict["parse_error"] is not None:
+        raise LLMError(verdict["parse_error"])
+    return selections_from_order_verdict(verdict, options)
 
 
 def parse_reply(response_text: str) -> str | None:
-    data = _extract_json(response_text)
-    reasoning = data.get("reasoning")
-    if reasoning:
-        logger.info(f"[bot.llm] reply reasoning: {reasoning}")
-    if not data.get("should_reply"):
-        logger.info("[bot.llm] model declined to reply")
-        return None
-    reply = (data.get("message") or "").strip()
-    if not reply:
-        logger.info("[bot.llm] model returned empty reply; staying silent")
-        return None
-    logger.info(f"[bot.llm] composed chat reply ({len(reply)} char(s))")
-    return reply
+    verdict = validate_reply(response_text)
+    if verdict["parse_error"] is not None:
+        raise LLMError(verdict["parse_error"])
+    return reply_from_verdict(verdict)

--- a/service/bot/steps.py
+++ b/service/bot/steps.py
@@ -1,0 +1,282 @@
+import json
+import logging
+from typing import Callable, TypedDict
+
+from bot.context.builder import ContextBuilder
+from bot.context.orders import (
+    group_options_by_source,
+    option_to_selected,
+    order_option_label,
+)
+from bot.llm_client import LLMError
+from bot.prompts import load_prompt
+from bot.types import ContextData, OrderOptionDict
+
+logger = logging.getLogger(__name__)
+
+Complete = Callable[..., str]
+
+ORDER_SELECTION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "reasoning": {"type": "string"},
+        "choices": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source_id": {"type": "string"},
+                    "option_index": {"type": "integer"},
+                },
+                "required": ["source_id", "option_index"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["reasoning", "choices"],
+    "additionalProperties": False,
+}
+
+REPLY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "reasoning": {"type": "string"},
+        "should_reply": {"type": "boolean"},
+        "message": {"type": "string"},
+    },
+    "required": ["reasoning", "should_reply"],
+    "additionalProperties": False,
+}
+
+
+class OrderSourceVerdict(TypedDict):
+    source_id: str
+    index: int | None
+    status: str
+
+
+class OrderVerdict(TypedDict):
+    parsed: bool
+    parse_error: str | None
+    reasoning: str
+    choices: dict[str, int]
+    sources: list[OrderSourceVerdict]
+    duplicate_source_ids: list[str]
+    unknown_source_ids: list[str]
+    malformed_choices: list[object]
+
+
+class ReplyVerdict(TypedDict):
+    parsed: bool
+    parse_error: str | None
+    reasoning: str
+    should_reply: bool
+    message: str
+    empty: bool
+
+
+class SelectOrdersResult(TypedDict):
+    response_text: str
+    verdict: OrderVerdict
+
+
+class ReplyResult(TypedDict):
+    response_text: str
+    verdict: ReplyVerdict
+
+
+def _extract_json(response_text: str) -> dict:
+    text = response_text.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise LLMError(f"could not parse JSON from response: {e}") from e
+
+
+def build_select_orders_prompt(
+    data: ContextData, persona: str = ""
+) -> tuple[str, list[dict]]:
+    builder = (
+        ContextBuilder(data)
+        .with_game_state()
+        .with_tactical_annotations()
+        .with_identity()
+        .with_orders()
+        .with_phase_state()
+        .with_conversations()
+    )
+    system = load_prompt("select_orders_system.txt")
+    if persona:
+        system = f"{system}\n\n{persona}"
+    instruction = load_prompt("select_orders_instruction.txt")
+    user_content = "\n\n".join(
+        part for part in [builder.build_shared(), builder.build_private(), instruction] if part
+    )
+    return system, [{"role": "user", "content": user_content}]
+
+
+def build_reply_prompt(
+    data: ContextData, persona: str = "", channel_id=None
+) -> tuple[str, list[dict]]:
+    builder = (
+        ContextBuilder(data)
+        .with_game_state()
+        .with_tactical_annotations()
+        .with_identity()
+        .with_messages(channel_id=channel_id)
+    )
+    system = load_prompt("reply_system.txt")
+    if persona:
+        system = f"{system}\n\n{persona}"
+    instruction = load_prompt("reply_instruction.txt")
+    user_content = "\n\n".join(
+        part for part in [builder.build_shared(), builder.build_private(), instruction] if part
+    )
+    return system, [{"role": "user", "content": user_content}]
+
+
+def validate_order_selections(
+    response_text: str, options: list[OrderOptionDict]
+) -> OrderVerdict:
+    try:
+        data = _extract_json(response_text)
+    except LLMError as e:
+        return OrderVerdict(
+            parsed=False,
+            parse_error=str(e),
+            reasoning="",
+            choices={},
+            sources=[],
+            duplicate_source_ids=[],
+            unknown_source_ids=[],
+            malformed_choices=[],
+        )
+
+    choices: dict[str, int] = {}
+    duplicate_source_ids: list[str] = []
+    malformed_choices: list[object] = []
+    for choice in data.get("choices", []):
+        if isinstance(choice, dict) and "source_id" in choice and "option_index" in choice:
+            source_id = choice["source_id"]
+            if source_id in choices:
+                duplicate_source_ids.append(source_id)
+            choices[source_id] = choice["option_index"]
+        else:
+            malformed_choices.append(choice)
+
+    grouped = group_options_by_source(options)
+    sources: list[OrderSourceVerdict] = []
+    for source_id, source_options in grouped.items():
+        index = choices.get(source_id)
+        if index is None:
+            status = "missing"
+        elif not (0 <= index < len(source_options)):
+            status = "out_of_range"
+        else:
+            status = "valid"
+        sources.append(OrderSourceVerdict(source_id=source_id, index=index, status=status))
+
+    unknown_source_ids = [source_id for source_id in choices if source_id not in grouped]
+
+    return OrderVerdict(
+        parsed=True,
+        parse_error=None,
+        reasoning=str(data.get("reasoning") or ""),
+        choices=choices,
+        sources=sources,
+        duplicate_source_ids=duplicate_source_ids,
+        unknown_source_ids=unknown_source_ids,
+        malformed_choices=malformed_choices,
+    )
+
+
+def selections_from_order_verdict(
+    verdict: OrderVerdict, options: list[OrderOptionDict]
+) -> list[list[str]]:
+    if verdict["reasoning"]:
+        logger.info(f"[bot.llm] order reasoning: {verdict['reasoning']}")
+    grouped = group_options_by_source(options)
+    selections = []
+    for source in verdict["sources"]:
+        source_id = source["source_id"]
+        source_options = grouped[source_id]
+        index = source["index"]
+        if source["status"] == "valid":
+            chosen = source_options[index]
+            logger.info(f"[bot.llm] {source_id}: chose {order_option_label(chosen)}")
+        else:
+            chosen = source_options[0]
+            logger.info(
+                f"[bot.llm] {source_id}: invalid/missing choice {index}; "
+                f"using first legal option {order_option_label(chosen)}"
+            )
+        selections.append(option_to_selected(chosen))
+    logger.info(f"[bot.llm] selected {len(selections)} order(s)")
+    return selections
+
+
+def validate_reply(response_text: str) -> ReplyVerdict:
+    try:
+        data = _extract_json(response_text)
+    except LLMError as e:
+        return ReplyVerdict(
+            parsed=False,
+            parse_error=str(e),
+            reasoning="",
+            should_reply=False,
+            message="",
+            empty=True,
+        )
+
+    should_reply = bool(data.get("should_reply"))
+    message = (data.get("message") or "").strip()
+    return ReplyVerdict(
+        parsed=True,
+        parse_error=None,
+        reasoning=str(data.get("reasoning") or ""),
+        should_reply=should_reply,
+        message=message,
+        empty=not message,
+    )
+
+
+def reply_from_verdict(verdict: ReplyVerdict) -> str | None:
+    if verdict["reasoning"]:
+        logger.info(f"[bot.llm] reply reasoning: {verdict['reasoning']}")
+    if not verdict["should_reply"]:
+        logger.info("[bot.llm] model declined to reply")
+        return None
+    if verdict["empty"]:
+        logger.info("[bot.llm] model returned empty reply; staying silent")
+        return None
+    logger.info(f"[bot.llm] composed chat reply ({len(verdict['message'])} char(s))")
+    return verdict["message"]
+
+
+def run_select_orders(
+    data: ContextData, persona: str, complete: Complete
+) -> SelectOrdersResult:
+    system, messages = build_select_orders_prompt(data, persona)
+    response_text = complete(
+        system=system, messages=messages, output_schema=ORDER_SELECTION_SCHEMA
+    )
+    verdict = validate_order_selections(response_text, data["orders"])
+    return SelectOrdersResult(response_text=response_text, verdict=verdict)
+
+
+def run_reply(
+    data: ContextData, persona: str, channel_id, complete: Complete
+) -> ReplyResult:
+    system, messages = build_reply_prompt(data, persona, channel_id=channel_id)
+    response_text = complete(
+        system=system, messages=messages, output_schema=REPLY_SCHEMA
+    )
+    verdict = validate_reply(response_text)
+    return ReplyResult(response_text=response_text, verdict=verdict)

--- a/service/bot/tasks.py
+++ b/service/bot/tasks.py
@@ -5,19 +5,17 @@ from procrastinate.contrib.django import app
 
 from bot.api_client import ApiClient, ApiClientError
 from bot.constants import LLMCallStage
-from bot.context import (
-    ORDER_SELECTION_SCHEMA,
-    REPLY_SCHEMA,
-    ContextBuilder,
-    fetch_context,
-    first_legal_selections,
-    parse_order_selections,
-    parse_reply,
-)
+from bot.context import fetch_context, first_legal_selections
 from bot.llm_client import LLMClient, LLMError
 from bot.models import BotProfile
 from bot.prompts import load_prompt
 from bot.recorder import LLMCallRecorder
+from bot.steps import (
+    reply_from_verdict,
+    run_reply,
+    run_select_orders,
+    selections_from_order_verdict,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,23 +34,6 @@ def _persona_block(user_id) -> str:
 
 
 def _submit_orders_from_context(api, data, game_id, user_id, label, stage, persona=""):
-    builder = (
-        ContextBuilder(data)
-        .with_game_state()
-        .with_tactical_annotations()
-        .with_identity()
-        .with_orders()
-        .with_phase_state()
-        .with_conversations()
-    )
-    system = load_prompt("select_orders_system.txt")
-    if persona:
-        system = f"{system}\n\n{persona}"
-    instruction = load_prompt("select_orders_instruction.txt")
-    user_content = "\n\n".join(
-        part for part in [builder.build_shared(), builder.build_private(), instruction] if part
-    )
-
     recorder = LLMCallRecorder(
         game_id=game_id,
         user_id=user_id,
@@ -60,15 +41,18 @@ def _submit_orders_from_context(api, data, game_id, user_id, label, stage, perso
         stage=stage,
     )
     try:
-        response_text = LLMClient(settings.ANTHROPIC_API_KEY, recorder).complete(
-            system=system,
-            messages=[{"role": "user", "content": user_content}],
-            output_schema=ORDER_SELECTION_SCHEMA,
-        )
-        selections = parse_order_selections(response_text, data["orders"])
+        complete = LLMClient(settings.ANTHROPIC_API_KEY, recorder).complete
+        result = run_select_orders(data, persona, complete)
     except LLMError as e:
         logger.info(f"[{label}] {e}; using first-legal selection")
         selections = first_legal_selections(data["orders"])
+    else:
+        verdict = result["verdict"]
+        if verdict["parse_error"] is not None:
+            logger.info(f"[{label}] {verdict['parse_error']}; using first-legal selection")
+            selections = first_legal_selections(data["orders"])
+        else:
+            selections = selections_from_order_verdict(verdict, data["orders"])
 
     phase_states = data["phase_states"]
     max_orders = phase_states[0].get("max_orders") if phase_states else None
@@ -141,22 +125,6 @@ def reply(user_id, game_id, channel_id):
             logger.info(f"[{label}] message cap reached ({count}/{limit}); staying silent")
             return
 
-    builder = (
-        ContextBuilder(data)
-        .with_game_state()
-        .with_tactical_annotations()
-        .with_identity()
-        .with_messages(channel_id=channel_id)
-    )
-    system = load_prompt("reply_system.txt")
-    persona = _persona_block(user_id)
-    if persona:
-        system = f"{system}\n\n{persona}"
-    instruction = load_prompt("reply_instruction.txt")
-    user_content = "\n\n".join(
-        part for part in [builder.build_shared(), builder.build_private(), instruction] if part
-    )
-
     recorder = LLMCallRecorder(
         game_id=game_id,
         user_id=user_id,
@@ -165,16 +133,18 @@ def reply(user_id, game_id, channel_id):
         channel_id=channel_id,
     )
     try:
-        response_text = LLMClient(settings.ANTHROPIC_API_KEY, recorder).complete(
-            system=system,
-            messages=[{"role": "user", "content": user_content}],
-            output_schema=REPLY_SCHEMA,
-        )
-        reply_text = parse_reply(response_text)
+        complete = LLMClient(settings.ANTHROPIC_API_KEY, recorder).complete
+        result = run_reply(data, _persona_block(user_id), channel_id, complete)
     except LLMError as e:
         logger.info(f"[{label}] {e}; staying silent")
         return
 
+    verdict = result["verdict"]
+    if verdict["parse_error"] is not None:
+        logger.info(f"[{label}] {verdict['parse_error']}; staying silent")
+        return
+
+    reply_text = reply_from_verdict(verdict)
     if not reply_text:
         logger.info(f"[{label}] no reply composed; staying silent")
         return

--- a/service/bot/tests.py
+++ b/service/bot/tests.py
@@ -35,6 +35,12 @@ from bot.context.parsers import (
     parse_order_selections,
     parse_reply,
 )
+from bot.steps import (
+    build_reply_prompt,
+    build_select_orders_prompt,
+    validate_order_selections,
+    validate_reply,
+)
 from bot.llm_client import LLMClient, LLMError
 from bot.recorder import LLMCallRecorder
 from bot.utils import get_bot_user
@@ -662,6 +668,148 @@ class TestComposeReply:
     def test_raises_on_unparseable_json(self):
         with pytest.raises(LLMError):
             parse_reply("not json at all")
+
+
+class TestValidateOrderSelections:
+
+    def _options(self):
+        return [
+            _option("lon", OrderType.HOLD),
+            _option("lon", OrderType.MOVE, target="nth"),
+            _option("edi", OrderType.HOLD),
+            _option("edi", OrderType.MOVE, target="nwg"),
+        ]
+
+    def _statuses(self, verdict):
+        return {source["source_id"]: source["status"] for source in verdict["sources"]}
+
+    def test_well_formed_reports_valid_per_source(self):
+        response = json.dumps(
+            {"choices": [
+                {"source_id": "lon", "option_index": 1},
+                {"source_id": "edi", "option_index": 0},
+            ]}
+        )
+        verdict = validate_order_selections(response, self._options())
+        assert verdict["parsed"] is True
+        assert verdict["parse_error"] is None
+        assert verdict["choices"] == {"lon": 1, "edi": 0}
+        assert self._statuses(verdict) == {"lon": "valid", "edi": "valid"}
+
+    def test_parse_failure_reports_error_and_no_sources(self):
+        verdict = validate_order_selections("not json at all", self._options())
+        assert verdict["parsed"] is False
+        assert verdict["parse_error"] is not None
+        assert verdict["sources"] == []
+        assert verdict["choices"] == {}
+
+    def test_out_of_range_index_is_reported(self):
+        response = json.dumps({"choices": [{"source_id": "lon", "option_index": 9}]})
+        verdict = validate_order_selections(response, self._options())
+        assert self._statuses(verdict) == {"lon": "out_of_range", "edi": "missing"}
+
+    def test_missing_unit_is_reported(self):
+        response = json.dumps({"choices": [{"source_id": "lon", "option_index": 0}]})
+        verdict = validate_order_selections(response, self._options())
+        assert self._statuses(verdict)["edi"] == "missing"
+
+    def test_duplicate_source_keeps_last_and_records_it(self):
+        response = json.dumps(
+            {"choices": [
+                {"source_id": "lon", "option_index": 0},
+                {"source_id": "lon", "option_index": 1},
+            ]}
+        )
+        verdict = validate_order_selections(response, self._options())
+        assert verdict["duplicate_source_ids"] == ["lon"]
+        assert verdict["choices"]["lon"] == 1
+
+    def test_unknown_source_is_reported(self):
+        response = json.dumps({"choices": [{"source_id": "ber", "option_index": 0}]})
+        verdict = validate_order_selections(response, self._options())
+        assert verdict["unknown_source_ids"] == ["ber"]
+
+    def test_malformed_choice_entries_are_collected(self):
+        response = json.dumps({"choices": ["nonsense", {"source_id": "lon"}]})
+        verdict = validate_order_selections(response, self._options())
+        assert verdict["malformed_choices"] == ["nonsense", {"source_id": "lon"}]
+
+
+class TestValidateReply:
+
+    def test_well_formed_reply(self):
+        verdict = validate_reply(_reply_response(True, "Hello."))
+        assert verdict["parsed"] is True
+        assert verdict["parse_error"] is None
+        assert verdict["should_reply"] is True
+        assert verdict["message"] == "Hello."
+        assert verdict["empty"] is False
+
+    def test_declined_reply(self):
+        verdict = validate_reply(_reply_response(False))
+        assert verdict["should_reply"] is False
+        assert verdict["empty"] is True
+
+    def test_empty_message_is_reported(self):
+        verdict = validate_reply(json.dumps({"should_reply": True, "message": "   "}))
+        assert verdict["should_reply"] is True
+        assert verdict["message"] == ""
+        assert verdict["empty"] is True
+
+    def test_parse_failure_reports_error(self):
+        verdict = validate_reply("not json at all")
+        assert verdict["parsed"] is False
+        assert verdict["parse_error"] is not None
+
+
+class TestBuildPrompts:
+
+    def _data(self, channels=None):
+        return {
+            "orders": [
+                _option("lon", OrderType.HOLD),
+                _option("lon", OrderType.MOVE, target="nth"),
+            ],
+            "phase_states": [{"max_orders": 3, "member": {"nation": "England"}}],
+            "game": {"phase_confirmed": False},
+            "phase": {},
+            "channels": channels or [],
+            "variant": {},
+        }
+
+    def _channels(self):
+        return [
+            {
+                "id": 1,
+                "name": "Public Press",
+                "private": False,
+                "messages": [
+                    {"body": "hi", "sender": {"is_current_user": False, "nation": {"name": "England"}}}
+                ],
+            }
+        ]
+
+    def test_build_select_orders_prompt_is_deterministic(self):
+        data = self._data()
+        assert build_select_orders_prompt(data) == build_select_orders_prompt(data)
+
+    def test_build_select_orders_prompt_returns_system_and_user_message(self):
+        system, messages = build_select_orders_prompt(self._data())
+        assert system
+        assert messages[0]["role"] == "user"
+        assert "Legal orders:" in messages[0]["content"]
+
+    def test_build_select_orders_prompt_appends_persona_to_system(self):
+        system, _ = build_select_orders_prompt(self._data(), persona="PERSONA-BLOCK")
+        assert system.endswith("PERSONA-BLOCK")
+
+    def test_build_reply_prompt_is_deterministic(self):
+        data = self._data(self._channels())
+        assert build_reply_prompt(data, channel_id=1) == build_reply_prompt(data, channel_id=1)
+
+    def test_build_reply_prompt_includes_only_selected_channel(self):
+        _, messages = build_reply_prompt(self._data(self._channels()), channel_id=1)
+        assert "England: hi" in messages[0]["content"]
 
 
 class TestAdjustmentOrderLimit:


### PR DESCRIPTION
## What this PR does

Enabling refactor for deterministic bot evals (closes #1020). The three bot LLM tasks (`bot.plan`, `bot.finalize`, `bot.reply`) shared a hidden `ContextData → prompt → call → parse` shape inlined inside `tasks.py`, and the parse step fused two jobs: detecting whether the model output was valid AND silently substituting a fallback, so a total model failure and a good response looked identical downstream.

This extracts three cleanly separated, independently callable seams per call into one new module `service/bot/steps.py`, and reroutes the tasks through them so each seam has exactly one implementation. No runtime behaviour, prompt text, or model interaction changes.

- **build**: `build_select_orders_prompt(data, persona="")` and `build_reply_prompt(data, persona="", channel_id=...)` — pure `ContextData → (system, messages)`, moved verbatim in effect out of `tasks.py`. No I/O, no DB, no model call.
- **call**: the existing `LLMClient(...).complete` — now injected into the composed runner rather than constructed inside the pure code. Each `run_*` passes its step's output schema (`ORDER_SELECTION_SCHEMA` / `REPLY_SCHEMA`) through to `complete`, preserving the structured-outputs behaviour.
- **validate**: `validate_order_selections(response_text, options) → OrderVerdict` and `validate_reply(response_text) → ReplyVerdict` — pure detection running the same checks the parser used (`_extract_json`, the `source_id`/`option_index` guards, the `0 <= index < len(...)` range check; `should_reply`/non-empty for reply). Reports a structured verdict (including the model's `reasoning`); substitutes no fallback and decides no pass/fail threshold.
- **run**: `run_select_orders` / `run_reply` compose build + injected `complete` + validate into a `StepResult` (`response_text` + `verdict`). Production calls these; evals will later call the same `build`/`validate` seams with their own `complete`.

`parse_order_selections` / `parse_reply` now delegate their detection to `validate_*` and apply the substitution/silence on top of the verdict (no duplicated checks). The fallback / `max_orders` cap / reply truncation / staying-silent reactions stay in `tasks.py`, driven off the verdict.

**Design notes:**
- The task-layer *policy* reactions the issue calls out — total first-legal fallback on parse/call failure, the `max_orders` cap, reply truncation, staying silent — live in `tasks.py`. The two pure per-verdict interpretation helpers (`selections_from_order_verdict`, `reply_from_verdict`) live in `steps.py` next to the verdicts they consume, because they are shared by both `tasks.py` and `parsers.py` and are deterministic verdict→result transforms, not production policy.
- The `reasoning`-field logging (from PR #1003) and the output schemas + `output_schema` threading (from PR #1004), both merged into `main` while this was open, are folded into the new seams: `reasoning` is captured in each verdict by `validate_*` and logged in the reaction helpers, and the schemas are co-located in `steps.py` and re-exported from `bot.context.parsers` so existing import paths keep working.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only, no visible surface

## Verification

- `cd service && python -m pytest bot -v` → 116 passed (includes the pre-existing suite plus the `reasoning`/structured-output tests merged from #1003/#1004, all now exercising the refactored path; 16 new unit tests for the pure seams: `validate_*` verdicts for parse failure / out-of-range / duplicate / missing / unknown / malformed / well-formed, and `build_*_prompt` determinism).
- Rebased onto latest `main` to resolve merge conflicts with #1003 and #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXHz1yMFs2HB8y8B68yWEa