### PR TITLE
[ONE LINE CODE CHANGE] Show full participant list in draw proposals

### DIFF
--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.test.tsx
@@ -187,4 +187,14 @@ describe("DrawProposalsScreen (secret voting)", () => {
       data: { accepted: true },
     });
   });
+
+  it("does not clamp the participant list", () => {
+    mockProposalsData.mockReturnValue([baseProposal()]);
+
+    renderScreen();
+
+    const description = screen.getByText("England, France");
+    expect(description).toHaveClass("line-clamp-none");
+    expect(description).not.toHaveClass("line-clamp-2");
+  });
 });

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -122,7 +122,7 @@ const ProposalItem: React.FC<ProposalItemProps> = ({
             </DropdownMenu>
           )}
         </div>
-        <ItemDescription>
+        <ItemDescription className="line-clamp-none">
           {includedMembers.map(m => m.nation).join(", ")}
         </ItemDescription>
         <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
## What this PR does

Each draw proposal's participant list renders inside `ItemDescription`, which applies a shared `line-clamp-2`. In variants with many nations, the list was clipped to two lines with an ellipsis, hiding the remaining participants with no way to reveal them.

This overrides the clamp for just this one list (`className="line-clamp-none"`), leaving `ItemDescription`'s default two-line clamp intact for every other screen that uses it. The tab content already scrolls (`overflow-y-auto`), so a long list simply makes the proposal item taller — nothing is hidden.

Closes #1027

### Screenshots

16-participant proposal on mobile, before and after:

**Before (clipped)**
![before](https://raw.githubusercontent.com/johnpooch/diplicity-react/d3eee18ec1e2f691eae087b3378cf7aa2b797a33/shots/draw-proposal-before.png)

**After (full list)**
![after](https://raw.githubusercontent.com/johnpooch/diplicity-react/d3eee18ec1e2f691eae087b3378cf7aa2b797a33/shots/draw-proposal-after.png)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, one-line style change
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KtpiPPjbUUMzZ8AHaZqZYX)_