### PR TITLE
Fix eliminated players receiving false civil-disorder notifications

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -616,9 +616,10 @@ class Game(BaseModel):
                 data={"game_id": str(self.id), "link": f"{settings.FRONTEND_URL}/game/{self.id}"},
             )
 
-    def notification_user_ids(self, exclude_user_id=None):
+    def notification_user_ids(self, exclude_user_id=None, active_only=False):
+        members = self.members.filter(eliminated=False, kicked=False) if active_only else self.members.all()
         user_ids = {
-            member.user_id for member in self.members.all()
+            member.user_id for member in members
             if member.user_id is not None
         }
         if self.game_master_id is not None:

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -457,10 +457,42 @@ class PhaseManager(models.Manager):
         if any(m.user_id == phase.game.admin_id for m in newly_cd_members):
             phase.game.reassign_admin()
 
+        return newly_cd_members
+
+    def _reconcile_civil_disorder_eliminations(self, newly_cd_members, adjudication_data):
+        if not newly_cd_members:
+            return []
+
+        surviving_nations = {u["nation"] for u in adjudication_data["units"]} | {
+            sc["nation"] for sc in adjudication_data["supply_centers"]
+        }
+
+        eliminated = [
+            m for m in newly_cd_members
+            if m.nation is not None and m.nation.name not in surviving_nations
+        ]
+        surviving = [m for m in newly_cd_members if m not in eliminated]
+
+        if eliminated:
+            for m in eliminated:
+                m.civil_disorder = False
+            Member.objects.bulk_update(eliminated, ["civil_disorder"])
+
+        return surviving
+
+    def _notify_civil_disorder(self, phase, newly_cd_members):
+        if not newly_cd_members:
+            return
+
         cd_user_ids = [m.user_id for m in newly_cd_members if m.user_id is not None]
         self._remove_from_staging_games(cd_user_ids)
 
-        user_ids = phase.game.notification_user_ids()
+        active_members = phase.game.members.filter(eliminated=False, kicked=False)
+        user_ids = {m.user_id for m in active_members if m.user_id is not None}
+        if phase.game.game_master_id is not None:
+            user_ids.add(phase.game.game_master_id)
+        user_ids = list(user_ids)
+
         nation_names = ", ".join(
             m.nation.name for m in newly_cd_members if m.nation is not None
         )
@@ -488,8 +520,6 @@ class PhaseManager(models.Manager):
                 )
 
         transaction.on_commit(send_notifications)
-
-        return newly_cd_members
 
     def _remove_from_staging_games(self, user_ids):
         if not user_ids:
@@ -588,13 +618,16 @@ class PhaseManager(models.Manager):
             if extension_members:
                 return phase
 
-            self._check_civil_disorder(phase)
+            self._set_orders_outcome(phase)
+            newly_cd_members = self._check_civil_disorder(phase)
             adjudication_data = resolve(phase)
 
             with tracer.start_as_current_span("phase.transaction_atomic"):
                 with transaction.atomic():
-                    self._set_orders_outcome(phase)
-                    self._check_civil_disorder(phase)
+                    surviving_cd_members = self._reconcile_civil_disorder_eliminations(
+                        newly_cd_members, adjudication_data
+                    )
+                    self._notify_civil_disorder(phase, surviving_cd_members)
                     new_phase = self.create_from_adjudication_data(phase, adjudication_data)
                     self._check_eliminations(phase, new_phase)
 

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -487,11 +487,7 @@ class PhaseManager(models.Manager):
         cd_user_ids = [m.user_id for m in newly_cd_members if m.user_id is not None]
         self._remove_from_staging_games(cd_user_ids)
 
-        active_members = phase.game.members.filter(eliminated=False, kicked=False)
-        user_ids = {m.user_id for m in active_members if m.user_id is not None}
-        if phase.game.game_master_id is not None:
-            user_ids.add(phase.game.game_master_id)
-        user_ids = list(user_ids)
+        user_ids = phase.game.notification_user_ids(active_only=True)
 
         nation_names = ", ".join(
             m.nation.name for m in newly_cd_members if m.nation is not None
@@ -618,18 +614,18 @@ class PhaseManager(models.Manager):
             if extension_members:
                 return phase
 
-            self._set_orders_outcome(phase)
-            newly_cd_members = self._check_civil_disorder(phase)
-            adjudication_data = resolve(phase)
-
             with tracer.start_as_current_span("phase.transaction_atomic"):
                 with transaction.atomic():
+                    self._set_orders_outcome(phase)
+                    newly_cd_members = self._check_civil_disorder(phase)
+                    adjudication_data = resolve(phase)
+
                     surviving_cd_members = self._reconcile_civil_disorder_eliminations(
                         newly_cd_members, adjudication_data
                     )
-                    self._notify_civil_disorder(phase, surviving_cd_members)
                     new_phase = self.create_from_adjudication_data(phase, adjudication_data)
                     self._check_eliminations(phase, new_phase)
+                    self._notify_civil_disorder(phase, surviving_cd_members)
 
                     victory = Victory.objects.try_create_victory(new_phase)
 

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3243,7 +3243,8 @@ class TestCivilDisorderDetection:
         phase2.phase_states.create(member=germany, has_possible_orders=True)
         Phase.objects._set_orders_outcome(phase2)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -3293,7 +3294,8 @@ class TestCivilDisorderDetection:
         phase2.phase_states.create(member=italy, has_possible_orders=True)
         phase2.phase_states.create(member=germany, has_possible_orders=True)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         mock_send_notification_to_users.assert_not_called()
 
@@ -3342,7 +3344,8 @@ class TestCivilDisorderDetection:
         Phase.objects._set_orders_outcome(phase2)
 
         with patch("game.models.send_notification") as mock_send:
-            Phase.objects._check_civil_disorder(phase2)
+            newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         game.refresh_from_db()
         assert game.admin == secondary_user
@@ -3393,7 +3396,8 @@ class TestCivilDisorderDetection:
         Phase.objects._set_orders_outcome(phase2)
 
         with patch("game.models.send_notification") as mock_send:
-            Phase.objects._check_civil_disorder(phase2)
+            newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         game.refresh_from_db()
         assert game.admin == secondary_user
@@ -3479,7 +3483,8 @@ class TestCivilDisorderStagingRemoval:
         staging_game.members.create(user=primary_user)
         staging_game.members.create(user=secondary_user)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         assert not staging_game.members.filter(user=primary_user).exists()
         assert staging_game.members.filter(user=secondary_user).exists()
@@ -3511,7 +3516,8 @@ class TestCivilDisorderStagingRemoval:
         )
         other_active_game.members.create(user=primary_user)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         assert other_active_game.members.filter(user=primary_user).exists()
 
@@ -3543,7 +3549,8 @@ class TestCivilDisorderStagingRemoval:
         staging_game.members.create(user=primary_user)
         staging_id = staging_game.id
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         assert not Game.objects.filter(id=staging_id).exists()
 
@@ -3576,7 +3583,8 @@ class TestCivilDisorderStagingRemoval:
         staging_game.members.create(user=primary_user)
         staging_game.members.create(user=secondary_user)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         staging_removal_jobs = [
             j for j in in_memory_procrastinate.jobs.values()
@@ -3616,10 +3624,229 @@ class TestCivilDisorderStagingRemoval:
         staging_game.members.create(user=primary_user)
         staging_game.members.create(user=secondary_user)
 
-        Phase.objects._check_civil_disorder(phase2)
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
         assert staging_game.members.filter(user=primary_user).exists()
         assert staging_game.members.filter(user=secondary_user).exists()
+
+
+class TestCivilDisorderExcludesEliminatedMembers:
+
+    @pytest.mark.django_db
+    def test_cd_notification_excludes_eliminated_members(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        primary_user,
+        secondary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="CD Excludes Eliminated Test",
+            status=GameStatus.ACTIVE,
+        )
+        italy = Member.objects.create(
+            nation=italy_vs_germany_italy_nation,
+            user=primary_user,
+            game=game,
+        )
+        germany = Member.objects.create(
+            nation=italy_vs_germany_germany_nation,
+            user=secondary_user,
+            game=game,
+            eliminated=True,
+        )
+
+        phase1 = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        phase1.phase_states.create(member=italy, has_possible_orders=True)
+        phase1.phase_states.create(member=germany, has_possible_orders=False)
+        Phase.objects._set_orders_outcome(phase1)
+
+        phase2 = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        phase2.phase_states.create(member=italy, has_possible_orders=True)
+        phase2.phase_states.create(member=germany, has_possible_orders=False)
+        Phase.objects._set_orders_outcome(phase2)
+
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        assert [m.id for m in newly_cd_members] == [italy.id]
+
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
+
+        mock_send_notification_to_users.assert_called_once()
+        call_kwargs = mock_send_notification_to_users.call_args.kwargs
+        assert call_kwargs["user_ids"] == [primary_user.id]
+
+
+class TestCivilDisorderEliminationReconciliation:
+
+    @staticmethod
+    def _setup_and_flag_cd(
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+    ):
+        game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="CD Elimination Reconciliation Test",
+            status=GameStatus.ACTIVE,
+        )
+        italy = Member.objects.create(
+            nation=italy_vs_germany_italy_nation,
+            user=primary_user,
+            game=game,
+        )
+        germany = Member.objects.create(
+            nation=italy_vs_germany_germany_nation,
+            user=secondary_user,
+            game=game,
+        )
+
+        phase1 = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Spring", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=1, status=PhaseStatus.COMPLETED,
+        )
+        phase1.phase_states.create(member=italy, has_possible_orders=True)
+        phase1_germany = phase1.phase_states.create(member=germany, has_possible_orders=True)
+        phase1_germany.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+        Phase.objects._set_orders_outcome(phase1)
+
+        phase2 = Phase.objects.create(
+            game=game, variant=italy_vs_germany_variant,
+            season="Fall", year=1901, type=PhaseType.MOVEMENT,
+            ordinal=2, status=PhaseStatus.ACTIVE,
+        )
+        phase2.phase_states.create(member=italy, has_possible_orders=True)
+        phase2_germany = phase2.phase_states.create(member=germany, has_possible_orders=True)
+        phase2_germany.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+        Phase.objects._set_orders_outcome(phase2)
+
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        assert [m.id for m in newly_cd_members] == [italy.id]
+
+        return game, italy, germany, phase2, newly_cd_members
+
+    @pytest.mark.django_db
+    def test_member_eliminated_same_turn_is_not_flagged_civil_disorder(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+    ):
+        game, italy, germany, phase2, newly_cd_members = self._setup_and_flag_cd(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+        italy.refresh_from_db()
+        assert italy.civil_disorder is True
+
+        adjudication_data = {
+            "units": [{"nation": "Germany", "province": "kie"}],
+            "supply_centers": [{"nation": "Germany", "province": "kie"}],
+        }
+
+        surviving = Phase.objects._reconcile_civil_disorder_eliminations(
+            newly_cd_members, adjudication_data
+        )
+
+        assert surviving == []
+        italy.refresh_from_db()
+        assert italy.civil_disorder is False
+
+    @pytest.mark.django_db
+    def test_surviving_cd_member_is_unaffected_by_reconciliation(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+    ):
+        game, italy, germany, phase2, newly_cd_members = self._setup_and_flag_cd(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+
+        adjudication_data = {
+            "units": [{"nation": "Italy", "province": "ven"}],
+            "supply_centers": [{"nation": "Italy", "province": "ven"}],
+        }
+
+        surviving = Phase.objects._reconcile_civil_disorder_eliminations(
+            newly_cd_members, adjudication_data
+        )
+
+        assert [m.id for m in surviving] == [italy.id]
+        italy.refresh_from_db()
+        assert italy.civil_disorder is True
+
+    @pytest.mark.django_db
+    def test_member_eliminated_same_turn_is_not_removed_from_staging(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2, newly_cd_members = self._setup_and_flag_cd(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+
+        staging_game = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Staging Game",
+            status=GameStatus.PENDING,
+            created_by=secondary_user,
+        )
+        staging_game.members.create(user=primary_user)
+        staging_game.members.create(user=secondary_user)
+
+        adjudication_data = {
+            "units": [{"nation": "Germany", "province": "kie"}],
+            "supply_centers": [{"nation": "Germany", "province": "kie"}],
+        }
+
+        surviving = Phase.objects._reconcile_civil_disorder_eliminations(
+            newly_cd_members, adjudication_data
+        )
+        Phase.objects._notify_civil_disorder(phase2, surviving)
+
+        assert staging_game.members.filter(user=primary_user).exists()
 
 
 class TestSetOrdersOutcome:


### PR DESCRIPTION
## What this PR does

Fixes two defects in the civil-disorder path described in #1032: the "Civil Disorder" broadcast was sent to every game member including eliminated/kicked ones, and a player eliminated on the exact turn they'd otherwise enter civil disorder was flagged `civil_disorder=True` and removed from their staging games anyway, producing contradictory notifications.

`_check_civil_disorder` is split into detection (flags members, reassigns admin) and a new `_reconcile_civil_disorder_eliminations` step that runs after adjudication but before phase creation: it un-flags any member whose nation has zero units and zero supply centers in the just-computed adjudication data, since they're being eliminated this same turn. The actual staging-game removal and broadcast (`_notify_civil_disorder`) now run after `_check_eliminations`, so the recipient list — built via a new `active_only=True` option on `Game.notification_user_ids()` — correctly excludes anyone eliminated or kicked, including bystanders eliminated on the same turn as the civil-disorder event.

This also fixes a dead duplicate `_check_civil_disorder` call in `resolve()`: the pre-adjudication call had been a guaranteed no-op since `orders_outcome` wasn't set until later, so civil disorder was only ever detected by a second, in-transaction call. `_set_orders_outcome` now runs before civil-disorder detection and before adjudication, restoring the ordering described in the issue (originally from 863055c8) and removing the redundant second call. One side effect worth flagging for review: `adjudication.service.resolve()` reads `civil_disorder` to decide which nations' empty retreat/adjustment phases to auto-skip, and it now sees this turn's newly-detected civil-disorder nations rather than only prior-turn ones — this is the intended restoration of the original behavior, but isn't covered by a dedicated test given the complexity of constructing that exact timing in an integration test.

Self-review also widened `resolve()`'s transaction to cover order-outcome/civil-disorder detection and adjudication alongside phase creation, so the sandbox-only manual-resolve path (`PhaseResolveView`, which has no transaction of its own) can't commit civil-disorder state that never rolls back if adjudication fails.

Closes #1032


---
_Generated by [Claude Code](https://claude.ai/code/session_01PDRspbyMTRbd8vTfeGHwNa)_