### PR TITLE
[ONE LINE CODE CHNAGE] Update Discord invite link on community page

### DIFF
--- a/packages/web/src/screens/Home/Community.tsx
+++ b/packages/web/src/screens/Home/Community.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 
 const VARIANT_CREATOR_URL = "https://variantcreator.diplicity.com";
 
-const DISCORD_URL = "https://discord.gg/2TkZbBRPW";
+const DISCORD_URL = "https://discord.gg/cwjzxEqTuN";
 
 const GITHUB_DISCUSSIONS_URL =
   "https://github.com/johnpooch/diplicity-react/discussions";


### PR DESCRIPTION
## What this PR does

Updates the outdated Discord invite link on the community page (`packages/web/src/screens/Home/Community.tsx`) to the current invite `https://discord.gg/cwjzxEqTuN`.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gud5skpmnF1PNaAC5vzjPe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gud5skpmnF1PNaAC5vzjPe)_