### PR TITLE
Bump version to 1.5.6 for new iOS build

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## What this PR does

Bumps the app version from `1.5.5` to `1.5.6` in `packages/web/package.json` (and the synced `package-lock.json`) to cut a new iOS release. The iOS `MARKETING_VERSION` is derived from this `version` field, so a push to `main` triggers `ios-release.yml` to build and upload the new build to TestFlight.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

<!-- Version-bump only: no code paths, tests, or visuals change, so /review-pr, test coverage, and screenshots are not applicable. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA8e3ANTXASFwyKe366SXd)_