### PR TITLE
Filter third-party and stale-chunk noise from Sentry

### DIFF
--- a/packages/web/src/sentry.ts
+++ b/packages/web/src/sentry.ts
@@ -21,6 +21,17 @@ export function initializeSentry() {
     replaysOnErrorSampleRate: 1.0,
     sendDefaultPii: false,
 
+    ignoreErrors: [
+      "not a child of this node",
+      "CancelledError",
+      "Java object is gone",
+      "Importing a module script failed",
+      "Failed to fetch dynamically imported module",
+      "error loading dynamically imported module",
+    ],
+
+    denyUrls: [/chrome-extension:\/\//, /moz-extension:\/\//, /iabjs:\/\//],
+
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration({


### PR DESCRIPTION
## What this PR does

Adds `ignoreErrors` and `denyUrls` to the browser Sentry SDK config (`packages/web/src/sentry.ts`) to stop reporting error classes that are not actionable application bugs, cutting noise so real regressions stand out. Identified while triaging the current unresolved Sentry issues.

Filtered:
- **Browser-translation DOM errors** — `removeChild`/`insertBefore` "not a child of this node" (Google Translate and similar mutating the DOM under React).
- **react-query `CancelledError`** — requests aborted on unmount.
- **Instagram in-app browser** — "Java object is gone" injection.
- **Extension / in-app-browser frames** — via `denyUrls` (`chrome-extension://`, `moz-extension://`, `iabjs://`).
- **Stale-chunk dynamic-import failures** — `Importing a module script failed` / `Failed to fetch dynamically imported module`, which already self-heal via `reloadForStaleChunk`.

Network errors are intentionally left unfiltered so they stay visible for spike alerting.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — config-only change, no logic
- [ ] Tests cover the change — no existing test harness for `Sentry.init` config; testing SDK filter options in isolation adds little value and there is no pattern to follow
- [x] Screenshots embedded in the PR description for any visual changes — none; no user-visible change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrH1sDt6Rz5vPRYjNDKug

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXrH1sDt6Rz5vPRYjNDKug)_