### PR TITLE
Guard Firefox users from crashing on non-array list data

### DIFF
--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -63,7 +63,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           game?.totalUnreadMessageCount &&
           game.totalUnreadMessageCount > 0) ||
         (item.label === "Orders" &&
-          game?.members.some(m => m.isCurrentUser && m.civilDisorder))
+          game?.members?.some(m => m.isCurrentUser && m.civilDisorder))
           ? "•"
           : undefined;
       let path: string;

--- a/packages/web/src/hooks/useMessaging.ts
+++ b/packages/web/src/hooks/useMessaging.ts
@@ -16,6 +16,7 @@ import {
   getDevicesListQueryKey,
   useDevicesList,
   useDevicesCreate,
+  FCMDevice,
 } from "../api/generated/endpoints";
 import { isNativePlatform, isIosPlatform } from "../utils/platform";
 
@@ -43,6 +44,9 @@ const useMessaging = (): MessagingState => {
 
   const native = isNativePlatform();
   const deviceType = native ? getNativeDeviceType() : "web";
+  const devices: readonly FCMDevice[] = Array.isArray(devicesListQuery.data)
+    ? devicesListQuery.data
+    : [];
 
   const devicesRef = useRef(devicesListQuery.data);
   devicesRef.current = devicesListQuery.data;
@@ -69,7 +73,12 @@ const useMessaging = (): MessagingState => {
   useEffect(() => {
     if (!native) return;
     const listener = addTokenRefreshListener(async (newToken) => {
-      const activeDevice = devicesRef.current?.find(
+      const currentDevices: readonly FCMDevice[] = Array.isArray(
+        devicesRef.current
+      )
+        ? devicesRef.current
+        : [];
+      const activeDevice = currentDevices.find(
         d => d.active && d.type === getNativeDeviceType()
       );
       if (activeDevice) {
@@ -143,8 +152,8 @@ const useMessaging = (): MessagingState => {
     try {
       setError(null);
       const activeDevice = native
-        ? devicesListQuery.data?.find(d => d.active && d.type === deviceType)
-        : devicesListQuery.data?.find(d => d.active && d.registrationId === webToken);
+        ? devices.find(d => d.active && d.type === deviceType)
+        : devices.find(d => d.active && d.registrationId === webToken);
       if (activeDevice) {
         await createDeviceMutation.mutateAsync({
           data: { registrationId: activeDevice.registrationId, type: deviceType, active: false },
@@ -158,8 +167,8 @@ const useMessaging = (): MessagingState => {
   };
 
   const enabled = native
-    ? Boolean(devicesListQuery.data?.some(d => d.active && d.type === deviceType))
-    : Boolean(webToken && devicesListQuery.data?.some(d => d.active && d.registrationId === webToken));
+    ? devices.some(d => d.active && d.type === deviceType)
+    : Boolean(webToken && devices.some(d => d.active && d.registrationId === webToken));
 
   const permissionDenied = native
     ? nativePermissionDenied

--- a/packages/web/src/hooks/useNotificationPermissionPrompt.ts
+++ b/packages/web/src/hooks/useNotificationPermissionPrompt.ts
@@ -5,6 +5,7 @@ import {
   useDevicesList,
   useDevicesCreate,
   getDevicesListQueryKey,
+  FCMDevice,
 } from "@/api/generated/endpoints";
 import { checkPermission } from "@/messaging-native";
 import { isNativePlatform, isIosPlatform } from "@/utils/platform";
@@ -30,7 +31,7 @@ const useNotificationPermissionPrompt = () => {
 
   const hasActiveNonSandboxGame =
     activeGamesData?.pages.some(page =>
-      page.results.some(game => !game.sandbox)
+      Array.isArray(page.results) && page.results.some(game => !game.sandbox)
     ) ?? false;
 
   const { data: devicesData, isLoading: devicesLoading } = useDevicesList({
@@ -54,7 +55,10 @@ const useNotificationPermissionPrompt = () => {
       ? isIosPlatform() ? "ios" : "android"
       : "web";
 
-    if (devicesData.some(d => d.active && d.type === deviceType)) return;
+    const devices: readonly FCMDevice[] = Array.isArray(devicesData)
+      ? devicesData
+      : [];
+    if (devices.some(d => d.active && d.type === deviceType)) return;
 
     const reRegister = async () => {
       if (isNativePlatform()) {

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -222,6 +222,69 @@ describe("OrdersScreen confirm orders button", () => {
   });
 });
 
+describe("OrdersScreen malformed list data", () => {
+  beforeEach(() => {
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "active", supplyCenters: [], units: [],
+    });
+  });
+
+  it("renders without crashing when game.members is not an array", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: undefined,
+    });
+    mockOrdersData.mockReturnValue([]);
+    mockPhaseStatesData.mockReturnValue([]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when orders is not an array", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "completed",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember()],
+    });
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "completed", supplyCenters: [], units: [],
+    });
+    mockOrdersData.mockReturnValue(undefined);
+    mockPhaseStatesData.mockReturnValue([]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText(/no orders created/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when phaseStates is not an array", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember()],
+    });
+    mockOrdersData.mockReturnValue([]);
+    mockPhaseStatesData.mockReturnValue(undefined);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+  });
+});
+
 describe("OrdersScreen named coast display", () => {
   beforeEach(() => {
     mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -61,6 +61,7 @@ import {
   getGameOptionsRetrieveQueryKey,
   Order,
   GameRetrieve,
+  Member,
   Unit,
 } from "@/api/generated/endpoints";
 import { useGameVariant } from "@/hooks/useGameVariant";
@@ -95,21 +96,29 @@ const buildNationGroups = (
   phase: PhaseRetrieve,
   game: GameRetrieve
 ): NationGroup[] => {
+  const safePhaseStates: readonly PhaseState[] = Array.isArray(phaseStates)
+    ? phaseStates
+    : [];
+  const safeOrders: readonly Order[] = Array.isArray(orders) ? orders : [];
+  const members: readonly Member[] = Array.isArray(game.members)
+    ? game.members
+    : [];
+
   if (isActivePhase) {
-    return phaseStates
+    return safePhaseStates
       .filter(ps => ps.orderableProvinces.length > 0)
       .map(ps => ({
         nation: ps.member.nation ?? "",
         member: ps.member,
         items: (ps.orderableProvinces as Province[]).map(province => ({
           province,
-          order: orders.find(o => o.source.id === province.id),
+          order: safeOrders.find(o => o.source.id === province.id),
           unit: findUnitForProvince(phase.units, province.id),
         })),
       }));
   }
 
-  const ordersByNation = orders.reduce(
+  const ordersByNation = safeOrders.reduce(
     (acc, order) => {
       const nation = order.nation.name;
       acc[nation] = [...(acc[nation] || []), order];
@@ -119,7 +128,7 @@ const buildNationGroups = (
   );
 
   return Object.entries(ordersByNation).map(([nation, nationOrders]) => {
-    const member = game.members.find(m => m.nation === nation);
+    const member = members.find(m => m.nation === nation);
     if (!member && import.meta.env.DEV) {
       console.warn(`buildNationGroups: no member found for nation "${nation}"`);
     }
@@ -186,7 +195,10 @@ const OrdersScreen: React.FC = () => {
   const isActivePhase = phase.status === "active";
   const isGameFinished =
     game.status === "completed" || game.status === "abandoned";
-  const currentMember = game.members.find(m => m.isCurrentUser);
+  const members: readonly Member[] = Array.isArray(game.members)
+    ? game.members
+    : [];
+  const currentMember = members.find(m => m.isCurrentUser);
   const isCurrentMemberInCivilDisorder = currentMember?.civilDisorder ?? false;
   const canModifyOrders =
     isActivePhase && !isGameFinished && !isCurrentMemberInCivilDisorder;

--- a/packages/web/src/screens/Home/FindGames.test.tsx
+++ b/packages/web/src/screens/Home/FindGames.test.tsx
@@ -7,6 +7,7 @@ import { useGamesListInfinite } from "@/hooks/useGamesListInfinite";
 
 const mockFetchNextPage = vi.fn();
 const mockSentinelRef = { current: null };
+const mockVariantsData = vi.fn();
 
 const defaultGamesListResult = {
   data: { pages: [{ results: [] }] },
@@ -21,12 +22,7 @@ vi.mock("@/api/generated/endpoints", async importOriginal => {
   >();
   return {
     ...actual,
-    useVariantsListSuspense: () => ({
-      data: [
-        { id: "classical", name: "Classical" },
-        { id: "pure", name: "Pure" },
-      ],
-    }),
+    useVariantsListSuspense: () => ({ data: mockVariantsData() }),
   };
 });
 
@@ -61,6 +57,10 @@ describe("FindGames", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseGamesListInfinite.mockReturnValue(defaultGamesListResult);
+    mockVariantsData.mockReturnValue([
+      { id: "classical", name: "Classical" },
+      { id: "pure", name: "Pure" },
+    ]);
   });
 
   it("shows the filter toggle button in the header", () => {
@@ -216,5 +216,54 @@ describe("FindGames", () => {
     expect(screen.queryByText(/fastest start/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/more games/i)).not.toBeInTheDocument();
     expect(screen.getAllByTestId("game-card")).toHaveLength(3);
+  });
+
+  it("renders without crashing when a page's results is not an array", () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: { pages: [{ results: undefined }] },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/no games found/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when variants is not an array", () => {
+    mockVariantsData.mockReturnValue(undefined);
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: {
+        pages: [
+          {
+            results: [
+              { id: "g1", variantId: "classical", phases: [1], members: [] },
+            ],
+          },
+        ],
+      },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/no games found/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when results contains a null entry", () => {
+    const buildGame = (id: string) => ({
+      id,
+      variantId: "classical",
+      phases: [1],
+      members: [],
+    });
+
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: { pages: [{ results: [null, buildGame("g1")] }] },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getAllByTestId("game-card")).toHaveLength(1);
   });
 });

--- a/packages/web/src/screens/Home/FindGames.tsx
+++ b/packages/web/src/screens/Home/FindGames.tsx
@@ -17,7 +17,11 @@ import {
 } from "@/components/ui/select";
 import { Inbox, Loader2, SlidersHorizontal, Zap } from "lucide-react";
 import { useVariantsListSuspense } from "@/api/generated/endpoints";
-import type { GamesListMovementPhaseDuration } from "@/api/generated/endpoints";
+import type {
+  GameList,
+  GamesListMovementPhaseDuration,
+  Variant,
+} from "@/api/generated/endpoints";
 import { useGamesListInfinite } from "@/hooks/useGamesListInfinite";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { DURATION_OPTIONS } from "@/constants";
@@ -50,7 +54,9 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
     });
   const { data: variants } = useVariantsListSuspense();
 
-  const games = data.pages.flatMap(page => page.results);
+  const games = data.pages
+    .flatMap(page => (Array.isArray(page.results) ? page.results : []))
+    .filter((game): game is GameList => Boolean(game));
 
   const sentinelRef = useInfiniteScroll(
     fetchNextPage,
@@ -58,7 +64,10 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
     isFetchingNextPage
   );
 
-  const variantMap = new Map(variants.map(v => [v.id, v]));
+  const safeVariants: readonly Variant[] = Array.isArray(variants)
+    ? variants
+    : [];
+  const variantMap = new Map(safeVariants.map(v => [v.id, v]));
   const knownGames = games.filter(game => variantMap.has(game.variantId));
 
   const handleVariantChange = (value: string) => {
@@ -98,7 +107,7 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={ALL_VARIANTS_VALUE}>All variants</SelectItem>
-              {variants.map(v => (
+              {safeVariants.map(v => (
                 <SelectItem key={v.id} value={v.id}>
                   {v.name}
                 </SelectItem>

--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -182,6 +182,37 @@ describe("MyGames draft variant fallback", () => {
   });
 });
 
+describe("MyGames malformed API data", () => {
+  it("renders without crashing when a page's results is not an array", async () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: undefined, next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    expect(await screen.findByText(/create a new game/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when results contains a null entry", async () => {
+    const game = mockActiveGames[0];
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: [null, game], next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    expect(await screen.findByText(game.name)).toBeInTheDocument();
+  });
+});
+
 describe("MyGames phase fetching", () => {
   it("renders without fanning out per-game phase fetches", async () => {
     const game = mockActiveGames[0];

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -119,7 +119,9 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGamesListInfinite({ mine: true, status: statusFilter, ordering });
 
-  const games = data.pages.flatMap(page => page.results);
+  const games = data.pages
+    .flatMap(page => (Array.isArray(page.results) ? page.results : []))
+    .filter((game): game is GameList => Boolean(game));
 
   const sentinelRef = useInfiniteScroll(
     fetchNextPage,
@@ -136,7 +138,7 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
 
   const firstEliminatedIndex =
     status === "active"
-      ? games.findIndex(game => !game.sandbox && game.members.find(m => m.isCurrentUser)?.eliminated)
+      ? games.findIndex(game => !game.sandbox && game.members?.find(m => m.isCurrentUser)?.eliminated)
       : -1;
 
   return (


### PR DESCRIPTION
## What this PR does

Seven Sentry issues (DIPLICITY-REACT-V, Y, D, X, W, J, S), all Firefox 152 users, share one crash signature: code that assumes list-shaped API data (`members`, `orders`, `variants`, `games`, `devices`) is an array and calls `.find`/`.some`/`.map` on it without checking. This adds `Array.isArray` guards (or completes optional chains) at each crash site:

- `GameDetailLayout.tsx:66` — `game?.members.some(...)` only guarded `game`, not `members`.
- `OrdersScreen.tsx` — `buildNationGroups` and the `currentMember` lookup now guard `phaseStates`, `orders`, and `game.members`.
- `MyGames.tsx` — `games` is now filtered for non-array pages and null entries, and the eliminated-index check completes its optional chain on `game.members`.
- `useMessaging.ts` / `useNotificationPermissionPrompt.ts` — the `devices` list is guarded everywhere it's read (including the ref used by the async token-refresh listener).

One deviation from the issue's stated file list: the `new Map(variants.map(...))` crash frame it describes as "MyGames.tsx" actually lives in `FindGames.tsx` — the minified bundle's chunk name didn't line up with the source file. Fixed at the real location (`variants` and the `games` list there get the same guards), noted here so the diff makes sense against the issue text.

Root cause investigation (part 2 of the issue's approach) wasn't reachable from this session: the attached Sentry replays and spans for these issues aren't retrievable through the Sentry MCP tools available here (replay/breadcrumb lookups 404, no spans recorded on the affected traces), and every event is `handled:true` with no network-response context. This PR is the defensive-guard half only; the "why is Firefox returning non-arrays" question is still open.

Also worth flagging: the same `game.members.find(...)`/`.map(...)` pattern (unguarded) exists in several files outside this issue's stated scope — `GameCard.tsx`, `DrawProposalsScreen.tsx`, `ProposeDrawScreen.tsx`, `ChannelListScreen.tsx`, `ChannelScreen.tsx`, `PhaseGuidance.tsx`, `PlayerInfoContent.tsx`. None have a matching Sentry issue yet, so left out of scope here, but likely worth a follow-up.

Closes #1046

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes — N/A, no visible UI change, only defensive guards against malformed data


---
_Generated by [Claude Code](https://claude.ai/code/session_016XxPPLdXkYoRwDszAzMgGb)_