### PR TITLE
Guard list-shaped data against non-array API responses

### DIFF
--- a/packages/web/src/components/GameCard.tsx
+++ b/packages/web/src/components/GameCard.tsx
@@ -83,7 +83,8 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const phase = game.currentPhase;
-  const playerNation = game.members.find(m => m.isCurrentUser)?.nation ?? null;
+  const members = Array.isArray(game.members) ? game.members : [];
+  const playerNation = members.find(m => m.isCurrentUser)?.nation ?? null;
   const joinGameMutation = useGameJoinCreate();
   const checkNotificationPermission = useCheckNotificationPermission();
 
@@ -91,10 +92,10 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
   const isPending = game.status === "pending";
   const isAbandoned = game.status === "abandoned";
   const isFinished = game.status === "completed" || isAbandoned;
-  const currentMember = game.members.find(m => m.isCurrentUser);
+  const currentMember = members.find(m => m.isCurrentUser);
   const showAvatars = !game.sandbox;
   const totalSlots = variant.nations.length;
-  const joinedCount = game.members.length;
+  const joinedCount = members.length;
   const winnerIds = new Set(game.victory?.members.map(m => m.id) ?? []);
 
   const handleClickGame = () => {
@@ -366,7 +367,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                   </Tooltip>
                 )}
                 <div className="flex -space-x-2">
-                  {game.members.slice(0, 7).map(member => (
+                  {members.slice(0, 7).map(member => (
                     <Avatar
                       key={member.id}
                       className={`h-8 w-8 border-2 border-background ${
@@ -381,9 +382,9 @@ const GameCard: React.FC<GameCardProps> = ({ game, variant, map }) => {
                       </AvatarFallback>
                     </Avatar>
                   ))}
-                  {game.members.length > 7 && (
+                  {members.length > 7 && (
                     <div className="h-8 w-8 rounded-full bg-muted border-2 border-background flex items-center justify-center text-xs">
-                      +{game.members.length - 7}
+                      +{members.length - 7}
                     </div>
                   )}
                 </div>

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -63,7 +63,8 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           game?.totalUnreadMessageCount &&
           game.totalUnreadMessageCount > 0) ||
         (item.label === "Orders" &&
-          game?.members?.some(m => m.isCurrentUser && m.civilDisorder))
+          Array.isArray(game?.members) &&
+          game.members.some(m => m.isCurrentUser && m.civilDisorder))
           ? "•"
           : undefined;
       let path: string;

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -63,7 +63,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           game?.totalUnreadMessageCount &&
           game.totalUnreadMessageCount > 0) ||
         (item.label === "Orders" &&
-          game?.members.some(m => m.isCurrentUser && m.civilDisorder))
+          game?.members?.some(m => m.isCurrentUser && m.civilDisorder))
           ? "•"
           : undefined;
       let path: string;

--- a/packages/web/src/hooks/useMessaging.ts
+++ b/packages/web/src/hooks/useMessaging.ts
@@ -44,8 +44,9 @@ const useMessaging = (): MessagingState => {
   const native = isNativePlatform();
   const deviceType = native ? getNativeDeviceType() : "web";
 
-  const devicesRef = useRef(devicesListQuery.data);
-  devicesRef.current = devicesListQuery.data;
+  const devices = Array.isArray(devicesListQuery.data) ? devicesListQuery.data : [];
+  const devicesRef = useRef(devices);
+  devicesRef.current = devices;
 
   // Check native permission state on mount for the denied indicator
   useEffect(() => {
@@ -69,7 +70,7 @@ const useMessaging = (): MessagingState => {
   useEffect(() => {
     if (!native) return;
     const listener = addTokenRefreshListener(async (newToken) => {
-      const activeDevice = devicesRef.current?.find(
+      const activeDevice = devicesRef.current.find(
         d => d.active && d.type === getNativeDeviceType()
       );
       if (activeDevice) {
@@ -143,8 +144,8 @@ const useMessaging = (): MessagingState => {
     try {
       setError(null);
       const activeDevice = native
-        ? devicesListQuery.data?.find(d => d.active && d.type === deviceType)
-        : devicesListQuery.data?.find(d => d.active && d.registrationId === webToken);
+        ? devices.find(d => d.active && d.type === deviceType)
+        : devices.find(d => d.active && d.registrationId === webToken);
       if (activeDevice) {
         await createDeviceMutation.mutateAsync({
           data: { registrationId: activeDevice.registrationId, type: deviceType, active: false },
@@ -158,8 +159,8 @@ const useMessaging = (): MessagingState => {
   };
 
   const enabled = native
-    ? Boolean(devicesListQuery.data?.some(d => d.active && d.type === deviceType))
-    : Boolean(webToken && devicesListQuery.data?.some(d => d.active && d.registrationId === webToken));
+    ? Boolean(devices.some(d => d.active && d.type === deviceType))
+    : Boolean(webToken && devices.some(d => d.active && d.registrationId === webToken));
 
   const permissionDenied = native
     ? nativePermissionDenied

--- a/packages/web/src/hooks/useNotificationPermissionPrompt.ts
+++ b/packages/web/src/hooks/useNotificationPermissionPrompt.ts
@@ -28,10 +28,12 @@ const useNotificationPermissionPrompt = () => {
     enabled: loggedIn,
   });
 
-  const hasActiveNonSandboxGame =
-    activeGamesData?.pages.some(page =>
-      page.results.some(game => !game.sandbox)
-    ) ?? false;
+  const hasActiveNonSandboxGame = Array.isArray(activeGamesData?.pages)
+    ? activeGamesData.pages.some(
+        page =>
+          Array.isArray(page.results) && page.results.some(game => !game.sandbox)
+      )
+    : false;
 
   const { data: devicesData, isLoading: devicesLoading } = useDevicesList({
     query: { enabled: loggedIn },
@@ -48,7 +50,7 @@ const useNotificationPermissionPrompt = () => {
 
   // Silently re-register if permission is already granted but device record is missing
   useEffect(() => {
-    if (!loggedIn || devicesLoading || devicesData === undefined) return;
+    if (!loggedIn || devicesLoading || !Array.isArray(devicesData)) return;
 
     const deviceType = isNativePlatform()
       ? isIosPlatform() ? "ios" : "android"

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -222,6 +222,48 @@ describe("OrdersScreen confirm orders button", () => {
   });
 });
 
+describe("OrdersScreen resilience to malformed list data", () => {
+  beforeEach(() => {
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "active", supplyCenters: [], units: [],
+    });
+    mockPhaseStatesData.mockReturnValue([]);
+  });
+
+  it("renders without crashing when game.members is not an array", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: undefined,
+    });
+    mockOrdersData.mockReturnValue([]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+  });
+
+  it("renders without crashing when orders is not an array", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember()],
+    });
+    mockOrdersData.mockReturnValue(undefined);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+  });
+});
+
 describe("OrdersScreen named coast display", () => {
   beforeEach(() => {
     mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -247,20 +247,49 @@ describe("OrdersScreen resilience to malformed list data", () => {
     expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
   });
 
+  it("falls back to an unmatched member instead of crashing when game.members is not an array and there are past orders to group by nation", () => {
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "completed",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: undefined,
+    });
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "completed", supplyCenters: [], units: [],
+    });
+    mockOrdersData.mockReturnValue([
+      {
+        nation: { name: "England" },
+        source: { id: "lon", name: "London" },
+        summary: "Hold",
+        resolution: null,
+      },
+    ]);
+
+    renderOrdersScreen();
+
+    expect(screen.getByText("England")).toBeInTheDocument();
+  });
+
   it("renders without crashing when orders is not an array", () => {
     mockGameData.mockReturnValue({
       variantId: "classical",
-      status: "active",
+      status: "completed",
       sandbox: false,
       deadlineMode: "duration",
       phaseConfirmed: false,
       members: [baseMember()],
     });
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "completed", supplyCenters: [], units: [],
+    });
     mockOrdersData.mockReturnValue(undefined);
 
     renderOrdersScreen();
 
-    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+    expect(screen.getByText(/no orders created/i)).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -60,7 +60,7 @@ import {
   getGamePhaseStatesListQueryKey,
   getGameOptionsRetrieveQueryKey,
   Order,
-  GameRetrieve,
+  Member,
   Unit,
 } from "@/api/generated/endpoints";
 import { useGameVariant } from "@/hooks/useGameVariant";
@@ -93,7 +93,7 @@ const buildNationGroups = (
   phaseStates: readonly PhaseState[],
   orders: readonly Order[],
   phase: PhaseRetrieve,
-  game: GameRetrieve
+  members: readonly Member[]
 ): NationGroup[] => {
   if (isActivePhase) {
     return phaseStates
@@ -119,7 +119,7 @@ const buildNationGroups = (
   );
 
   return Object.entries(ordersByNation).map(([nation, nationOrders]) => {
-    const member = game.members.find(m => m.nation === nation);
+    const member = members.find(m => m.nation === nation);
     if (!member && import.meta.env.DEV) {
       console.warn(`buildNationGroups: no member found for nation "${nation}"`);
     }
@@ -186,7 +186,9 @@ const OrdersScreen: React.FC = () => {
   const isActivePhase = phase.status === "active";
   const isGameFinished =
     game.status === "completed" || game.status === "abandoned";
-  const currentMember = game.members.find(m => m.isCurrentUser);
+  const members = Array.isArray(game.members) ? game.members : [];
+  const safeOrders = Array.isArray(orders) ? orders : [];
+  const currentMember = members.find(m => m.isCurrentUser);
   const isCurrentMemberInCivilDisorder = currentMember?.civilDisorder ?? false;
   const canModifyOrders =
     isActivePhase && !isGameFinished && !isCurrentMemberInCivilDisorder;
@@ -268,9 +270,9 @@ const OrdersScreen: React.FC = () => {
   const nationGroups = buildNationGroups(
     isActivePhase,
     phaseStates,
-    orders,
+    safeOrders,
     phase,
-    game
+    members
   );
   const hasContent = nationGroups.length > 0;
 

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -188,6 +188,7 @@ const OrdersScreen: React.FC = () => {
     game.status === "completed" || game.status === "abandoned";
   const members = Array.isArray(game.members) ? game.members : [];
   const safeOrders = Array.isArray(orders) ? orders : [];
+  const safePhaseStates = Array.isArray(phaseStates) ? phaseStates : [];
   const currentMember = members.find(m => m.isCurrentUser);
   const isCurrentMemberInCivilDisorder = currentMember?.civilDisorder ?? false;
   const canModifyOrders =
@@ -269,7 +270,7 @@ const OrdersScreen: React.FC = () => {
 
   const nationGroups = buildNationGroups(
     isActivePhase,
-    phaseStates,
+    safePhaseStates,
     safeOrders,
     phase,
     members

--- a/packages/web/src/screens/Home/FindGames.test.tsx
+++ b/packages/web/src/screens/Home/FindGames.test.tsx
@@ -193,6 +193,45 @@ describe("FindGames", () => {
     expect(screen.getAllByTestId("game-card")).toHaveLength(1);
   });
 
+  it("renders the empty state instead of crashing when pages is not an array", () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: { pages: undefined },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/no games found/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state instead of crashing when page.results is not an array", () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: { pages: [{ results: undefined }] },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getByText(/no games found/i)).toBeInTheDocument();
+  });
+
+  it("does not crash when a game's members is not an array", () => {
+    const game = {
+      id: "g1",
+      variantId: "classical",
+      phases: [1],
+      members: undefined,
+    };
+    mockUseGamesListInfinite.mockReturnValue({
+      ...defaultGamesListResult,
+      data: { pages: [{ results: [game] }] },
+    } as unknown as ReturnType<typeof useGamesListInfinite>);
+
+    renderFindGames();
+
+    expect(screen.getAllByTestId("game-card")).toHaveLength(1);
+  });
+
   it("does not render the Fastest Start or More games headers when the top game has fewer than 3 members", () => {
     const buildMember = (id: number) => ({ id, user: { id, username: `u${id}` } });
     const buildGame = (id: string, memberCount: number) => ({

--- a/packages/web/src/screens/Home/FindGames.tsx
+++ b/packages/web/src/screens/Home/FindGames.tsx
@@ -50,7 +50,9 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
     });
   const { data: variants } = useVariantsListSuspense();
 
-  const games = data.pages.flatMap(page => page.results);
+  const games = (Array.isArray(data.pages) ? data.pages : []).flatMap(page =>
+    Array.isArray(page.results) ? page.results : []
+  );
 
   const sentinelRef = useInfiniteScroll(
     fetchNextPage,
@@ -58,7 +60,9 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
     isFetchingNextPage
   );
 
-  const variantMap = new Map(variants.map(v => [v.id, v]));
+  const variantMap = new Map(
+    (Array.isArray(variants) ? variants : []).map(v => [v.id, v])
+  );
   const knownGames = games.filter(game => variantMap.has(game.variantId));
 
   const handleVariantChange = (value: string) => {
@@ -127,7 +131,8 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
 
       {knownGames.length > 0 ? (
         <>
-          {knownGames[0].members.length >= EXPRESS_MIN_MEMBERS ? (
+          {(Array.isArray(knownGames[0].members) ? knownGames[0].members.length : 0) >=
+          EXPRESS_MIN_MEMBERS ? (
             <>
               <div className="flex items-center gap-2 pt-2">
                 <Zap className="size-4" />

--- a/packages/web/src/screens/Home/FindGames.tsx
+++ b/packages/web/src/screens/Home/FindGames.tsx
@@ -60,9 +60,8 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
     isFetchingNextPage
   );
 
-  const variantMap = new Map(
-    (Array.isArray(variants) ? variants : []).map(v => [v.id, v])
-  );
+  const safeVariants = Array.isArray(variants) ? variants : [];
+  const variantMap = new Map(safeVariants.map(v => [v.id, v]));
   const knownGames = games.filter(game => variantMap.has(game.variantId));
 
   const handleVariantChange = (value: string) => {
@@ -102,7 +101,7 @@ const FindGames: React.FC<FindGamesProps> = ({ isFilterOpen }) => {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={ALL_VARIANTS_VALUE}>All variants</SelectItem>
-              {variants.map(v => (
+              {safeVariants.map(v => (
                 <SelectItem key={v.id} value={v.id}>
                   {v.name}
                 </SelectItem>

--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -182,6 +182,55 @@ describe("MyGames draft variant fallback", () => {
   });
 });
 
+describe("MyGames resilience to malformed list data", () => {
+  it("renders the empty state instead of crashing when pages is not an array", async () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: undefined },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    expect(
+      await screen.findByText(/your active games will appear here/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state instead of crashing when page.results is not an array", async () => {
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: undefined, next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    expect(
+      await screen.findByText(/your active games will appear here/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not crash computing the eliminated section when a game's members is not an array", async () => {
+    const game = { ...mockActiveGames[0], members: undefined };
+    mockUseGamesListInfinite.mockReturnValue({
+      data: { pages: [{ results: [game], next: null }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseVariantsListSuspense.mockReturnValue({ data: mockVariants });
+
+    renderMyGames();
+
+    expect(await screen.findByText(game.name)).toBeInTheDocument();
+  });
+});
+
 describe("MyGames phase fetching", () => {
   it("renders without fanning out per-game phase fetches", async () => {
     const game = mockActiveGames[0];

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -119,7 +119,9 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useGamesListInfinite({ mine: true, status: statusFilter, ordering });
 
-  const games = data.pages.flatMap(page => page.results);
+  const games = (Array.isArray(data.pages) ? data.pages : []).flatMap(page =>
+    Array.isArray(page.results) ? page.results : []
+  );
 
   const sentinelRef = useInfiniteScroll(
     fetchNextPage,
@@ -136,7 +138,13 @@ const GameTabContent: React.FC<GameTabContentProps> = ({
 
   const firstEliminatedIndex =
     status === "active"
-      ? games.findIndex(game => !game.sandbox && game.members.find(m => m.isCurrentUser)?.eliminated)
+      ? games.findIndex(
+          game =>
+            !game.sandbox &&
+            (Array.isArray(game.members) ? game.members : []).find(
+              m => m.isCurrentUser
+            )?.eliminated
+        )
       : -1;
 
   return (


### PR DESCRIPTION
## What this PR does

Seven Sentry issues (Firefox-only, DIPLICITY-REACT-V/Y/D/X/W/J/S) share one signature: code assumes list-shaped API data (`members`, `orders`, `variants`, `games`, `devices`) is always an array and throws when it arrives as `undefined` or otherwise non-array — `.some`/`.find`/`.map is not a function`, or a broken optional chain like `game?.members.some(...)` where `?.` only guards `game`, not `members`.

Sentry breadcrumbs for DIPLICITY-REACT-V show the crash landing in the same render tick as an aborted XHR to the game-retrieve endpoint (`status_code: 0`, no response body) immediately after rapid phase navigation — the in-flight refetch gets superseded mid-render. That's a more concrete lead than the extension/service-worker theories in the issue, though I couldn't fully confirm the exact mechanism by which the resolved data ends up non-array. Given that, this PR does part 1 of the issue's two-part approach — harden every call site so a transient bad value can't crash the render — rather than speculate further on part 2.

Adds `Array.isArray` guards (or completes optional chains) at every list-consumption site reachable from the flagged screens: `GameDetailLayout`, `OrdersScreen` (`orders`, `game.members`, `phaseStates`), `MyGames`/`FindGames` (`data.pages`, `page.results`, `game.members`, `variants`), `GameCard` (`game.members` — the shared render path both Home tabs route through; confirmed via DIPLICITY-REACT-D's stack trace, which resolves into this component despite its chunk being labelled `MyGames`), and `useMessaging`/`useNotificationPermissionPrompt` (`devices`, `activeGamesData.pages`).

One deliberate omission: `GameCard`'s `game.victory?.members` (3 usages, pre-existing code) is left unguarded. Victory data is set once server-side when a game ends, isn't one of the five fields named in the crash reports, and I didn't want to guard code with no supporting evidence of the same failure mode.

Closes #1046


---
_Generated by [Claude Code](https://claude.ai/code/session_01UrRpyRDdUZk3382bAzvA37)_