### PR TITLE
Compress overlong fixed-time phases after early resolution

### DIFF
--- a/packages/web/src/components/DeadlineSummary.test.tsx
+++ b/packages/web/src/components/DeadlineSummary.test.tsx
@@ -111,6 +111,26 @@ describe("DeadlineSummary", () => {
       expect(screen.getByText(/daily at 9:00 PM ET/i)).toBeInTheDocument();
     });
 
+    it("tells the creator fixed-time phases resolve sooner when all confirm", () => {
+      render(
+        <DeadlineSummary
+          game={{
+            movementPhaseDuration: null,
+            deadlineMode: "fixed_time",
+            fixedDeadlineTime: "21:00",
+            fixedDeadlineTimezone: "America/New_York",
+            movementFrequency: "daily",
+          }}
+        />
+      );
+      expect(
+        screen.getByText(/or sooner if all players confirm their orders/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/regardless of whether players confirmed/i)
+      ).not.toBeInTheDocument();
+    });
+
     it("renders fixed-time summary with hourly frequency", () => {
       render(
         <DeadlineSummary

--- a/packages/web/src/components/DeadlineSummary.tsx
+++ b/packages/web/src/components/DeadlineSummary.tsx
@@ -108,7 +108,7 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
         return (
           <span>
             The first phase ends at {firstEnd} {tz}, after that every hour,
-            regardless of whether players confirmed their orders.
+            or sooner if all players confirm their orders.
           </span>
         );
       }
@@ -116,8 +116,8 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
       return (
         <span>
           The first phase ends at {firstEnd} {tz}, after that Movement: every
-          hour and Retreat/Adjustment: {retreatDisplay}, regardless of whether
-          players confirmed their orders.
+          hour and Retreat/Adjustment: {retreatDisplay}, or sooner if all
+          players confirm their orders.
         </span>
       );
     }
@@ -127,8 +127,8 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
       return (
         <span>
           Movement resolves {formatFreqTime(movementFrequency, time, tz)}.
-          Retreat/Adjustment resolves {intervalLabel} later, regardless
-          of whether players confirmed their orders.
+          Retreat/Adjustment resolves {intervalLabel} later, or sooner
+          if all players confirm their orders.
         </span>
       );
     }
@@ -137,7 +137,7 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
       return (
         <span>
           Phases resolve {formatFreqTime(movementFrequency, time, tz)},
-          regardless of whether players confirmed their orders.
+          or sooner if all players confirm their orders.
         </span>
       );
     }
@@ -145,8 +145,8 @@ export const DeadlineSummary: React.FC<DeadlineSummaryProps> = ({ game }) => {
     return (
       <span>
         Phases resolve Movement: {formatFreqTime(movementFrequency, time, tz)},
-        Retreat: {formatFreqTime(retreatFrequency!, time, tz)}, regardless of
-        whether players confirmed their orders.
+        Retreat: {formatFreqTime(retreatFrequency!, time, tz)}, or sooner if
+        all players confirm their orders.
       </span>
     );
   }

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -3,12 +3,13 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+from django.utils import timezone
 from channel.models import ChannelMessage
 from draw_proposal.models import DrawProposal
 from email_service.tasks import send_email_notification
 from email_service.templates import notification_email
 from game.models import Game
-from common.constants import GameStatus, PhaseStatus
+from common.constants import DeadlineMode, GameStatus, PhaseStatus
 from notification.tasks import send_notification
 from notification.utils import send_notification_to_users
 from phase.models import Phase
@@ -206,21 +207,34 @@ def send_phase_resolved_notification(sender, instance, created, **kwargs):  # no
     old_status = _phase_status_cache.pop(instance.pk, None)
     if old_status == PhaseStatus.ACTIVE and instance.status == PhaseStatus.COMPLETED:
 
+        resolved_early = (
+            instance.game.deadline_mode == DeadlineMode.FIXED_TIME
+            and instance.scheduled_resolution is not None
+            and timezone.now() < instance.scheduled_resolution
+        )
+
         def _send():
             user_ids = instance.game.notification_user_ids()
             link = f"{settings.FRONTEND_URL}/game/{instance.game.id}"
-            body = f"{instance.name} has been resolved"
+            if resolved_early:
+                body = f"{instance.name} resolved early — all players confirmed their orders."
+                notification_type = "phase_resolved_early"
+                subject = f"{instance.game.name} — {instance.name} Resolved Early"
+            else:
+                body = f"{instance.name} has been resolved"
+                notification_type = "phase_resolved"
+                subject = f"{instance.game.name} — {instance.name} Resolved"
 
             send_notification_to_users(
                 user_ids=user_ids,
                 title=instance.game.name,
                 body=body,
-                notification_type="phase_resolved",
+                notification_type=notification_type,
                 data={"game_id": str(instance.game.id), "link": link},
             )
             send_email_notification.defer(
                 user_ids=user_ids,
-                subject=f"{instance.game.name} — {instance.name} Resolved",
+                subject=subject,
                 html=notification_email(
                     title=instance.game.name,
                     body=body,

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -1,7 +1,13 @@
+from datetime import timedelta
+
 import pytest
+from django.utils import timezone
+
 from channel.models import Channel, ChannelMessage
-from common.constants import GameStatus
+from common.constants import DeadlineMode, GameStatus, PhaseFrequency, PhaseStatus
 from draw_proposal.models import DrawProposal
+from game.models import Game
+from phase.models import Phase
 from victory.models import Victory
 from notification.signals import _truncate_body
 
@@ -279,6 +285,126 @@ class TestGameEndNotifications:
         assert secondary_user.id in args["user_ids"]
         assert italy.name in args["body"]
         assert "Better luck" in args["body"]
+
+
+class TestPhaseResolvedNotification:
+
+    def _make_active_phase(self, variant, scheduled_resolution):
+        game = Game.objects.create(
+            variant=variant,
+            name="Notify Test",
+            status=GameStatus.ACTIVE,
+            deadline_mode=DeadlineMode.FIXED_TIME,
+            movement_frequency=PhaseFrequency.DAILY,
+        )
+        return Phase.objects.create(
+            game=game,
+            variant=variant,
+            season="Spring",
+            year=1901,
+            type="Movement",
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=scheduled_resolution,
+        )
+
+    @pytest.mark.django_db
+    def test_resolution_before_deadline_sends_phase_resolved_early(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        phase = self._make_active_phase(classical_variant, timezone.now() + timedelta(hours=12))
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "phase_resolved_early"
+        assert call.kwargs["body"] == f"{phase.name} resolved early — all players confirmed their orders."
+
+    @pytest.mark.django_db
+    def test_resolution_at_deadline_sends_phase_resolved(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        phase = self._make_active_phase(classical_variant, timezone.now() - timedelta(minutes=1))
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "phase_resolved"
+        assert call.kwargs["body"] == f"{phase.name} has been resolved"
+
+    @pytest.mark.django_db
+    def test_game_ending_phase_without_deadline_sends_phase_resolved(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        phase = self._make_active_phase(classical_variant, None)
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "phase_resolved"
+
+    @pytest.mark.django_db
+    def test_duration_game_early_resolution_still_sends_phase_resolved(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        game = Game.objects.create(
+            variant=classical_variant,
+            name="Duration Notify Test",
+            status=GameStatus.ACTIVE,
+            deadline_mode=DeadlineMode.DURATION,
+        )
+        phase = Phase.objects.create(
+            game=game,
+            variant=classical_variant,
+            season="Spring",
+            year=1901,
+            type="Movement",
+            ordinal=1,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=timezone.now() + timedelta(hours=12),
+        )
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "phase_resolved"
+
+    @pytest.mark.django_db
+    def test_early_resolution_email_subject_marks_resolved_early(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        phase = self._make_active_phase(classical_variant, timezone.now() + timedelta(hours=12))
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        jobs = _email_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        assert "Resolved Early" in jobs[0]["args"]["subject"]
 
 
 class TestGameStartEmailNotification:

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -14,7 +14,7 @@ from common.constants import PhaseStatus, PhaseType, GameStatus, DeadlineMode, O
 from adjudication.service import resolve
 from member.models import Member
 from order.models import OrderResolution, Order
-from phase.utils import transform_options, format_time_remaining, format_deadline, build_notification_body
+from phase.utils import transform_options, format_time_remaining, format_deadline, build_notification_body, compress_deadline
 from province.models import Province
 from supply_center.models import SupplyCenter
 from unit.models import Unit
@@ -752,6 +752,15 @@ class PhaseManager(models.Manager):
                     adjudication_data["type"],
                     reference_time=previous_phase.scheduled_resolution,
                 )
+                if (
+                    scheduled_resolution is not None
+                    and previous_phase.game.deadline_mode == DeadlineMode.FIXED_TIME
+                ):
+                    scheduled_resolution = compress_deadline(
+                        scheduled_resolution,
+                        previous_phase.game.get_phase_frequency(adjudication_data["type"]),
+                        timezone.now(),
+                    )
                 new_ordinal = previous_phase.ordinal + 1
 
                 logger.info(

--- a/service/phase/test_background_resolution.py
+++ b/service/phase/test_background_resolution.py
@@ -375,3 +375,74 @@ class TestDeadlineGridPreservation:
         expected = datetime(2026, 1, 4, 21, 0, 0, tzinfo=dt_timezone.utc)
         assert next_with_reference == expected
         assert next_from_now != expected
+
+    @pytest.mark.django_db
+    def test_drifted_early_resolution_compresses_next_deadline_into_range(
+        self, italy_vs_germany_phase_with_orders, mock_adjudication_data_basic
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        game = phase.game
+        game.deadline_mode = DeadlineMode.FIXED_TIME
+        game.movement_frequency = PhaseFrequency.DAILY
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
+        game.save()
+
+        now = timezone.now()
+        grid_slot = now.replace(hour=12, minute=0, second=0, microsecond=0)
+        if grid_slot <= now:
+            grid_slot += timedelta(days=1)
+        far_slot = grid_slot + timedelta(days=4)
+        phase.scheduled_resolution = far_slot
+        phase.save()
+
+        uncompressed = game.get_scheduled_resolution("Retreat", reference_time=far_slot)
+        assert uncompressed - timezone.now() > timedelta(hours=48)
+
+        new_phase = Phase.objects.create_from_adjudication_data(phase, mock_adjudication_data_basic)
+
+        run = new_phase.scheduled_resolution - timezone.now()
+        assert timedelta(hours=24) <= run < timedelta(hours=48)
+        assert new_phase.scheduled_resolution < uncompressed
+        assert new_phase.scheduled_resolution.astimezone(dt_timezone.utc).hour == 12
+        assert new_phase.scheduled_resolution.minute == 0
+
+    @pytest.mark.django_db
+    def test_on_grid_resolution_leaves_next_deadline_uncompressed(
+        self, italy_vs_germany_phase_with_orders, mock_adjudication_data_basic
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        game = phase.game
+        game.deadline_mode = DeadlineMode.FIXED_TIME
+        game.movement_frequency = PhaseFrequency.DAILY
+        game.fixed_deadline_time = time(12, 0)
+        game.fixed_deadline_timezone = "UTC"
+        game.save()
+
+        now = timezone.now()
+        near_slot = now.replace(hour=12, minute=0, second=0, microsecond=0)
+        if near_slot <= now:
+            near_slot += timedelta(days=1)
+        phase.scheduled_resolution = near_slot
+        phase.save()
+
+        uncompressed = game.get_scheduled_resolution("Retreat", reference_time=near_slot)
+
+        new_phase = Phase.objects.create_from_adjudication_data(phase, mock_adjudication_data_basic)
+
+        run = new_phase.scheduled_resolution - timezone.now()
+        assert timedelta(hours=24) <= run < timedelta(hours=48)
+        assert new_phase.scheduled_resolution == uncompressed
+
+    @pytest.mark.django_db
+    def test_duration_game_deadline_is_not_compressed(
+        self, italy_vs_germany_phase_with_orders, mock_adjudication_data_basic
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        assert phase.game.deadline_mode == DeadlineMode.DURATION
+
+        new_phase = Phase.objects.create_from_adjudication_data(phase, mock_adjudication_data_basic)
+
+        run = new_phase.scheduled_resolution - timezone.now()
+        expected = phase.game.movement_phase_duration_seconds
+        assert abs(run.total_seconds() - expected) < 2

--- a/service/phase/test_utils.py
+++ b/service/phase/test_utils.py
@@ -1,11 +1,11 @@
-from datetime import time, datetime
+from datetime import time, datetime, timedelta, timezone as dt_timezone
 from zoneinfo import ZoneInfo
 
 import pytest
 from django.utils import timezone
 
 from common.constants import PhaseFrequency
-from phase.utils import calculate_next_fixed_deadline
+from phase.utils import calculate_next_fixed_deadline, compress_deadline, FREQUENCY_INTERVALS
 
 
 class TestCalculateNextFixedDeadline:
@@ -279,3 +279,151 @@ class TestCalculateNextFixedDeadline:
 
         result = calculate_next_fixed_deadline(target_time, PhaseFrequency.DAILY, tz_name)
         assert result.tzinfo is not None
+
+
+NOW = datetime(2026, 1, 10, 9, 0, 0, tzinfo=dt_timezone.utc)
+DAY = timedelta(hours=24)
+HOUR = timedelta(hours=1)
+WEEK = timedelta(days=7)
+TWO_DAYS = timedelta(days=2)
+
+
+class TestCompressDeadline:
+
+    def test_daily_on_time_resolution_one_cycle_out_is_unchanged(self):
+        next_deadline = NOW + DAY
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + DAY
+
+    def test_daily_run_of_one_and_a_quarter_cycles_is_unchanged(self):
+        next_deadline = NOW + timedelta(hours=30)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=30)
+
+    def test_daily_run_just_under_two_cycles_is_unchanged(self):
+        next_deadline = NOW + timedelta(hours=47)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=47)
+
+    def test_daily_run_of_exactly_two_cycles_compresses_to_one_cycle(self):
+        next_deadline = NOW + timedelta(hours=48)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=24)
+
+    def test_daily_run_of_two_and_a_half_cycles_compresses_to_one_and_a_half(self):
+        next_deadline = NOW + timedelta(hours=60)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=36)
+
+    def test_daily_run_of_three_cycles_compresses_to_one_cycle(self):
+        next_deadline = NOW + timedelta(hours=72)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=24)
+
+    def test_daily_run_of_three_and_a_third_cycles_compresses_into_range(self):
+        next_deadline = NOW + timedelta(hours=80)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, NOW)
+
+        assert result == NOW + timedelta(hours=32)
+
+    def test_compression_preserves_wall_clock_grid_slot(self):
+        now = datetime(2026, 1, 10, 9, 0, 0, tzinfo=dt_timezone.utc)
+        next_deadline = datetime(2026, 1, 13, 21, 0, 0, tzinfo=dt_timezone.utc)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.DAILY, now)
+
+        assert result == datetime(2026, 1, 11, 21, 0, 0, tzinfo=dt_timezone.utc)
+
+    def test_hourly_run_of_one_and_a_half_cycles_is_unchanged(self):
+        next_deadline = NOW + timedelta(minutes=90)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.HOURLY, NOW)
+
+        assert result == NOW + timedelta(minutes=90)
+
+    def test_hourly_run_of_two_cycles_compresses_to_one_hour(self):
+        next_deadline = NOW + timedelta(minutes=120)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.HOURLY, NOW)
+
+        assert result == NOW + timedelta(minutes=60)
+
+    def test_hourly_run_of_two_and_a_half_cycles_compresses_to_ninety_minutes(self):
+        next_deadline = NOW + timedelta(minutes=150)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.HOURLY, NOW)
+
+        assert result == NOW + timedelta(minutes=90)
+
+    def test_every_2_days_run_of_two_and_a_half_cycles_compresses(self):
+        next_deadline = NOW + timedelta(hours=120)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.EVERY_2_DAYS, NOW)
+
+        assert result == NOW + timedelta(hours=72)
+
+    def test_weekly_run_of_two_cycles_compresses_to_one_week(self):
+        next_deadline = NOW + timedelta(days=14)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.WEEKLY, NOW)
+
+        assert result == NOW + timedelta(days=7)
+
+    def test_weekly_run_of_almost_three_cycles_compresses_into_range(self):
+        next_deadline = NOW + timedelta(days=20)
+
+        result = compress_deadline(next_deadline, PhaseFrequency.WEEKLY, NOW)
+
+        assert result == NOW + timedelta(days=13)
+
+    def test_unknown_frequency_returns_deadline_unchanged(self):
+        next_deadline = NOW + timedelta(hours=200)
+
+        result = compress_deadline(next_deadline, "invalid", NOW)
+
+        assert result == NOW + timedelta(hours=200)
+
+    @pytest.mark.parametrize("frequency", [
+        PhaseFrequency.HOURLY,
+        PhaseFrequency.DAILY,
+        PhaseFrequency.EVERY_2_DAYS,
+        PhaseFrequency.WEEKLY,
+    ])
+    @pytest.mark.parametrize("cycles", [1.0, 1.1, 1.5, 1.99, 2.0, 2.5, 3.0, 3.5, 5.0, 10.0])
+    def test_result_always_lands_in_one_to_two_cycle_range(self, frequency, cycles):
+        interval = FREQUENCY_INTERVALS[frequency]
+        next_deadline = NOW + interval * cycles
+
+        result = compress_deadline(next_deadline, frequency, NOW)
+
+        run = result - NOW
+        assert interval <= run < 2 * interval
+
+    @pytest.mark.parametrize("frequency", [
+        PhaseFrequency.HOURLY,
+        PhaseFrequency.DAILY,
+        PhaseFrequency.EVERY_2_DAYS,
+        PhaseFrequency.WEEKLY,
+    ])
+    @pytest.mark.parametrize("cycles", [1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 5.0, 10.0])
+    def test_compression_only_subtracts_whole_intervals(self, frequency, cycles):
+        interval = FREQUENCY_INTERVALS[frequency]
+        next_deadline = NOW + interval * cycles
+
+        result = compress_deadline(next_deadline, frequency, NOW)
+
+        pulled_in = next_deadline - result
+        assert pulled_in.total_seconds() % interval.total_seconds() == 0

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -43,7 +43,7 @@ def build_notification_body(
                 return None
             return (
                 f"All orders ready. Confirm to advance the game early — "
-                f"the next deadline stays on schedule. {time_left} remaining."
+                f"the next deadline may move sooner too. {time_left} remaining."
             )
         if orders_given > 0:
             return (
@@ -385,6 +385,16 @@ FREQUENCY_INTERVALS = {
     PhaseFrequency.EVERY_2_DAYS: timedelta(days=2),
     PhaseFrequency.WEEKLY: timedelta(weeks=1),
 }
+
+
+def compress_deadline(next_deadline, frequency, now):
+    interval = FREQUENCY_INTERVALS.get(frequency)
+    if not interval:
+        return next_deadline
+    candidate = next_deadline
+    while (candidate - interval) - now >= interval:
+        candidate -= interval
+    return candidate
 
 
 def calculate_next_fixed_deadline(


### PR DESCRIPTION
## What this PR does

Grid-anchored early resolution (#866) can hand a following phase far more than a normal cycle of wall-clock time: when players keep confirming early, each phase's deadline marches forward on the fixed grid while wall-clock does not, so the gap between "now" and the next grid deadline keeps growing. This compresses those overlong deadlines and adds the explainability to go with an always-on rollout. Closes #844.

**Governing rule (from the issue discussion):** a phase created after compression must run **at least one full cycle and under two cycles** from the resolution moment.

Following the latest issue discussion, compression is **always-on** for fixed-time games — no create-game checkbox, no per-game model field, no migration. Explainability is handled through a distinct notification and corrected copy instead.

### Changes

- **`compress_deadline()`** (`service/phase/utils.py`) — pulls a grid-anchored deadline inward by whole intervals to the earliest grid slot still at least one full cycle after `now`. Because grid slots are one interval apart, the result always lands in `[1 cycle, 2 cycles)`. Compression therefore triggers only when the grid-anchored run would be ≥ 2 cycles (the accumulated-drift case); a single early resolution and on-time resolution are left untouched. Subtracting whole intervals keeps the deadline on the fixed wall-clock grid. No tunable constant — the `[1, 2)`-cycle rule fully determines the result, frequency-agnostic across hourly→weekly.
- **Applied at the one creation site** (`service/phase/models.py`, `create_from_adjudication_data`) — only for fixed-time games, after the existing grid-anchored deadline is computed. Deliberately not inside `get_scheduled_resolution`, so first-phase, NMR-extension, and pause/extend paths are unaffected.
- **`phase_resolved_early` notification** (`service/notification/signals.py`) — when a fixed-time phase resolves before its scheduled deadline, send a distinct push + email notification ("… resolved early — all players confirmed their orders.") so players who never saw the create-game UI understand why the deadline moved. Gated to fixed-time; duration games keep the existing `phase_resolved` behaviour.
- **Corrected fixed-time deadline copy** (`packages/web/src/components/DeadlineSummary.tsx`) — the summary said phases resolve "regardless of whether players confirmed their orders", which has been inaccurate since #866. It now reads "… or sooner if all players confirm their orders." Also reworded the fixed-time deadline-warning body ("stays on schedule" → "may move sooner too").

### Notification name

Per the request on the issue, the new notification type is **`phase_resolved_early`**.

## Screenshot

The corrected fixed-time deadline copy, shown on the Game Info screen:

> Phase deadlines — **Phases resolve daily at 9:00 PM ET, or sooner if all players confirm their orders.**

(Screenshot shared in the working session; not committed per repo policy.)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

### Tests

- `service/phase/test_utils.py::TestCompressDeadline` — concrete on-time / drift / boundary examples across daily, hourly, every-2-days, weekly, plus parametrized invariants asserting the result always lands in `[1 cycle, 2 cycles)` and only ever subtracts whole intervals.
- `service/phase/test_background_resolution.py::TestDeadlineGridPreservation` — drift compresses into range; on-grid resolution is unchanged; duration games are never compressed (exercises `create_from_adjudication_data`).
- `service/notification/tests.py::TestPhaseResolvedNotification` — early vs on-time vs game-ending copy/type/email-subject; duration early-resolution still sends `phase_resolved`.
- `packages/web/src/components/DeadlineSummary.test.tsx` — asserts the new fixed-time copy and the absence of the old phrase.

Full backend suite (1897 passed) and frontend suite (520 passed) green; changed frontend files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzZqpmiToaD7Rg5cuFD5WE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzZqpmiToaD7Rg5cuFD5WE)_