### PR TITLE
Fix white screen on Android launch by wiring up Android 12 splash API

### DIFF
--- a/packages/web/android/app/src/main/res/values/colors.xml
+++ b/packages/web/android/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
+    <color name="splashBackground">#291b1b</color>
 </resources>

--- a/packages/web/android/app/src/main/res/values/styles.xml
+++ b/packages/web/android/app/src/main/res/values/styles.xml
@@ -17,6 +17,9 @@
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splashBackground</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
         <item name="android:background">@drawable/splash</item>
     </style>
 </resources>

--- a/packages/web/capacitor.config.ts
+++ b/packages/web/capacitor.config.ts
@@ -4,6 +4,7 @@ const config: CapacitorConfig = {
   appId: "com.diplicity.app",
   appName: "Diplicity",
   webDir: "dist",
+  backgroundColor: "#291b1b",
   ios: {
     webContentsDebuggingEnabled: true,
   },
@@ -15,8 +16,7 @@ const config: CapacitorConfig = {
   },
   plugins: {
     SplashScreen: {
-      launchAutoHide: true,
-      launchShowDuration: 2000,
+      launchAutoHide: false,
       launchFadeOutDuration: 500,
       backgroundColor: "#291b1b",
       showSpinner: false,

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ import { Toaster } from "./components/ui/sonner";
 import { isNativePlatform } from "./utils/platform";
 import { initializeNativeSocialLogin } from "./auth/nativeGoogleAuth";
 import { App as CapacitorApp } from "@capacitor/app";
+import { SplashScreen } from "@capacitor/splash-screen";
 import { deepLinkStorage, parseDeepLinkUrl } from "./deepLink";
 import { onNotificationClick } from "./messaging";
 import { addNotificationTapListener } from "./messaging-native";
@@ -64,6 +65,12 @@ function App() {
   useEffect(() => {
     if (isNativePlatform()) {
       initializeNativeSocialLogin();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isNativePlatform()) {
+      SplashScreen.hide();
     }
   }, []);
 

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -6,10 +6,16 @@ import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 import App from "./App.tsx";
+import { SplashScreen } from "@capacitor/splash-screen";
 import { initializeObservability } from "./observability";
 import { initializeSentry } from "./sentry";
 import { themeStorage } from "./theme/themeStorage";
+import { isNativePlatform } from "./utils/platform";
 import { reloadForStaleChunk } from "./utils/staleChunk";
+
+if (isNativePlatform()) {
+  setTimeout(() => SplashScreen.hide(), 10000);
+}
 
 themeStorage.initialize();
 initializeObservability();


### PR DESCRIPTION
## What this PR does

On Android 12+ (our `targetSdkVersion` is 36, so every supported device) the launch splash is drawn by the system Splash Screen API from the `windowSplashScreenBackground`/`windowSplashScreenAnimatedIcon` theme attributes. Our launch theme only set `android:background`, which that API ignores, so users saw a default white system splash; it then auto-hid on a fixed 2.5s timer while the WebView was still white waiting for React's first paint — a long white screen instead of a splash.

Changes:

- **`styles.xml`**: set `windowSplashScreenBackground` (`#291b1b`, the color already configured for the splash in `capacitor.config.ts`), `windowSplashScreenAnimatedIcon` (the launcher icon, which also fixes the icon on pre-12 devices via the compat library), and `postSplashScreenTheme` so the activity drops back to the normal theme after launch. The legacy `android:background` line is kept for the pre-12 window background.
- **`capacitor.config.ts`**: top-level `backgroundColor: "#291b1b"` so the WebView behind the splash is no longer default white; `launchAutoHide: false` (and drop the now-unused `launchShowDuration`) so the splash covers the actual load time instead of a fixed timer.
- **`App.tsx`**: call `SplashScreen.hide()` on mount (native platforms only, matching the existing `isNativePlatform()` effect pattern). Verified against the plugin source that this releases the Android 12 `setKeepOnScreenCondition` hold and plays the configured `launchFadeOutDuration` fade.
- **`main.tsx`**: arm a 10s `setTimeout` fallback `SplashScreen.hide()` at module scope, before the init calls, so a boot failure before React mounts (chunk parse error, module-scope init exception) can't strand users on the splash now that the fixed-timer auto-hide is gone. After a normal boot the extra `hide()` is a no-op. (Added in response to a `/review-pr` finding.)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — small config/theme change; behavior verified against the `@capacitor/splash-screen` Android source
- [x] Tests cover the change — native splash behavior isn't reachable from Vitest; `npm run lint` and `npx tsc -b --noEmit` pass
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — the change is native Android launch behavior, which can't be captured in this environment; needs a quick check on the Pixel 8a (`npx cap run android`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VixvS5ejvYeCsEMjrwdGQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VixvS5ejvYeCsEMjrwdGQb)_
