### PR TITLE
[ONE LINE CODE CHANGE - HOT FIX VARIANT CREATOR LINK]

### DIFF
--- a/packages/web/src/screens/Home/Community.tsx
+++ b/packages/web/src/screens/Home/Community.tsx
@@ -6,7 +6,7 @@ import { ScreenContainer } from "@/components/ui/screen-container";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { Button } from "@/components/ui/button";
 
-const VARIANT_CREATOR_URL = "https://variantcreator.diplicity.com";
+const VARIANT_CREATOR_URL = "http://variantcreator.diplicity.com";
 
 const DISCORD_URL = "https://discord.gg/cwjzxEqTuN";
 


### PR DESCRIPTION
## What this PR does

The variant creator link on the Community screen (`VARIANT_CREATOR_URL` in `packages/web/src/screens/Home/Community.tsx`) points at `https://variantcreator.diplicity.com`, which fails at the TLS handshake because the domain has no valid certificate. This switches the scheme to `http://`, which responds with a 301 redirect to the hosted variant creator site (`diplicityvariantcreator.netlify.app`), making the button work again.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — N/A, trivial one-line change
- [ ] Tests cover the change — N/A, URL constant swap with no logic change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual change; the button renders identically, only the target URL changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1vGZEyK5rxwYV3gqhYAEN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1vGZEyK5rxwYV3gqhYAEN)_