### PR TITLE
[ANDROID LOAD FIX] Skip the PNG encode/decode round-trip when mounting the base map raster

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
+++ b/packages/web/src/components/GameMapCanvas/GameMapCanvas.tsx
@@ -48,7 +48,6 @@ type GameMapCanvasProps = {
 const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const controllerRef = useRef<GameMapController | null>(null);
-  const basePngRef = useRef<string | null>(null);
   const initialRecordedRef = useRef(false);
 
   const mode = props.mode ?? "interactive";
@@ -153,10 +152,6 @@ const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
       resizeObserver.disconnect();
       controller.destroy();
       controllerRef.current = null;
-      if (basePngRef.current) {
-        URL.revokeObjectURL(basePngRef.current);
-        basePngRef.current = null;
-      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- create the map once per parsed dSVG; live values flow through refs and dedicated effects
   }, [parsed]);
@@ -195,16 +190,11 @@ const GameMapCanvas: React.FC<GameMapCanvasProps> = (props) => {
     const t0 = performance.now();
     const { width, height } = parsed.viewBox;
     rasterizeSvg(baseSvg, width, height)
-      .then((pngUrl) => {
+      .then((canvas) => {
         if (cancelled) {
-          URL.revokeObjectURL(pngUrl);
           return;
         }
-        controller.setBase(pngUrl);
-        if (basePngRef.current) {
-          URL.revokeObjectURL(basePngRef.current);
-        }
-        basePngRef.current = pngUrl;
+        controller.setBase(canvas);
         if (!initialRecordedRef.current) {
           initialRecordedRef.current = true;
           const renderMs = performance.now() - t0;

--- a/packages/web/src/components/GameMapCanvas/GameMapController.ts
+++ b/packages/web/src/components/GameMapCanvas/GameMapController.ts
@@ -63,6 +63,23 @@ const hitTestStyle = (): L.PathOptions => ({
   fillOpacity: 0,
 });
 
+const CanvasOverlay = L.ImageOverlay.extend({
+  _initImage(this: { _url: HTMLCanvasElement; _image: HTMLCanvasElement; _zoomAnimated: boolean }) {
+    const canvas = this._url;
+    this._image = canvas;
+    canvas.classList.add("leaflet-image-layer");
+    if (this._zoomAnimated) {
+      canvas.classList.add("leaflet-zoom-animated");
+    }
+    canvas.onselectstart = () => false;
+    canvas.onmousemove = () => false;
+  },
+}) as unknown as new (
+  canvas: HTMLCanvasElement,
+  bounds: L.LatLngBoundsExpression,
+  options?: L.ImageOverlayOptions
+) => L.ImageOverlay;
+
 export class GameMapController {
   private readonly map: L.Map;
   private readonly bounds: L.LatLngBounds;
@@ -292,8 +309,8 @@ export class GameMapController {
     this.map.on("moveend", () => this.endGesture());
   }
 
-  setBase(pngUrl: string): void {
-    const next = L.imageOverlay(pngUrl, this.bounds, {
+  setBase(canvas: HTMLCanvasElement): void {
+    const next = new CanvasOverlay(canvas, this.bounds, {
       interactive: false,
       pane: "baseMap",
     }).addTo(this.map);

--- a/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
+++ b/packages/web/src/components/GameMapCanvas/rasterizeSvg.ts
@@ -26,16 +26,19 @@ export const computeRasterDimensions = (
   return { width: width * scale, height: height * scale };
 };
 
-// Rasterises an SVG string to a PNG object URL once. Per the map re-architecture
+// Rasterises an SVG string to a canvas once. Per the map re-architecture
 // proposal, the static base is rasterised a single time and thereafter only
 // moved by the camera, so the ~17k path commands are never repainted per frame.
 // The board is drawn at its native viewBox resolution, capped to a pixel-area
-// budget (the accepted "soft base map at 4× zoom" trade).
+// budget (the accepted "soft base map at 4× zoom" trade). The canvas is handed
+// to Leaflet as-is: encoding it to a PNG blob and decoding it back was measured
+// at ~5s per map on an Android WebView (Pixel 8a), versus ~0.5s for the raster
+// itself.
 export const rasterizeSvg = (
   svg: string,
   width: number,
   height: number
-): Promise<string> =>
+): Promise<HTMLCanvasElement> =>
   new Promise((resolve, reject) => {
     const rasterDimensions = computeRasterDimensions(width, height);
     const sizedSvg = injectSvgDimensions(
@@ -63,13 +66,7 @@ export const rasterizeSvg = (
           throw new Error("Could not acquire a 2D canvas context");
         }
         context.drawImage(image, 0, 0, canvas.width, canvas.height);
-        canvas.toBlob((png) => {
-          if (!png) {
-            reject(new Error("Failed to rasterise base map to PNG"));
-            return;
-          }
-          resolve(URL.createObjectURL(png));
-        }, "image/png");
+        resolve(canvas);
       } catch (error) {
         reject(error);
       } finally {


### PR DESCRIPTION
## Summary

Fixes the 10–15 second white map on Android (RFC #1066). The canvas map pipeline rasterised the board SVG onto a canvas, then encoded that ~2 MP canvas to a PNG blob (`canvas.toBlob("image/png")`) only for Leaflet's `ImageOverlay` to immediately decode it back into pixels. On an Android WebView that encode step alone takes ~5 seconds per map.

This PR removes the round-trip: `rasterizeSvg` now resolves with the canvas itself, and `GameMapController.setBase` mounts it through a small `L.ImageOverlay` subclass whose element is the supplied canvas instead of an `<img>`. Leaflet positions and composites it identically, so pan/zoom behaviour is unchanged, and the object-URL lifecycle bookkeeping in `GameMapCanvas` disappears.

## Root cause evidence (measured on a Pixel 8a via WebView remote debugging)

Sub-step benchmark inside the live production app, classical-size board (2.4 MB SVG, 1524×1357):

| step | duration |
|---|---|
| SVG load + raster into `<img>` | 436 ms |
| `drawImage` to canvas | 66 ms |
| `canvas.toBlob("image/png")` | **5,387 ms** |
| (alternatives: WebP 3,421 ms · JPEG 4,277 ms · `createImageBitmap` 5 ms) | |

`map.initial_render` telemetry read from the device, same variant:

- before: **10,647 ms**
- after: **79 ms**

Chrome on the same phone was always fast because its PNG encoder is quicker; desktop never noticed for the same reason. Web gets the same win for free.

## Testing

- `vitest run rasterizeSvg.test.ts MapView.test.tsx GameMap.test.tsx` — 13 passed
- `npx eslint` on changed files and `npx tsc -b --noEmit` — clean
- On-device verification on the Pixel 8a: map appears in a few seconds instead of 13 (remaining wait is API request waterfall, tracked separately in #1066)
- Desktop rendering verified against the mocked dev server: board, units, and order arrows aligned — output is pixel-identical to the previous path, so no screenshots (no visual change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
