### PR TITLE
Introduce transition-decorator infrastructure for notifications

### DIFF
--- a/.claude/skills/backend/SKILL.md
+++ b/.claude/skills/backend/SKILL.md
@@ -215,6 +215,24 @@ def create(self, validated_data):
 
 Use `Prefetch` objects for complex prefetch strategies with custom querysets (e.g. `to_attr="template_phases"`). See `GameQuerySet` for canonical patterns.
 
+## Notifications
+
+Player-facing notifications are triggered from signals, not imperatively. All triggering lives in `notification/signals.py`, expressed with `@on_` transition decorators from `notification/decorators.py` — a `pre_save` capture helper remembers the prior field value, and a decorator fires the receiver only on the transition it names. This mirrors `agent/signals.py` (`capture_phase_status` + `@on_phase_activated`); each receiver reads as "on this transition, notify these recipients with this copy."
+
+```python
+pre_save.connect(capture_phase_status, sender=Phase)
+
+@receiver(post_save, sender=Phase)
+@on_phase_resolved
+def send_phase_resolved_notification(sender, instance, created, **kwargs):
+    ...
+```
+
+Two rules the pattern depends on:
+
+- **Bulk writes emit no signals.** `bulk_update`, `bulk_create` (partially), and queryset `.delete()` bypass `pre_save`/`post_save`, so any notification wired to those transitions silently never fires. Save per-instance, or emit an explicit signal, whenever the write must notify.
+- **Time-based notifications are signal-armed, not swept.** A notification derived from a persisted timestamp (e.g. a deadline) should be scheduled via `schedule_at` when that timestamp is set and re-evaluated at fire time (see `phase/signals.py::arm_deadline_resolution`), not polled by an every-minute cron. Reserve `@app.periodic` sweeps for genuinely open-ended work with no triggering row.
+
 ## API Codegen
 
 The OpenAPI schema and TypeScript client are auto-generated:

--- a/service/notification/decorators.py
+++ b/service/notification/decorators.py
@@ -1,0 +1,23 @@
+import functools
+
+from common.constants import PhaseStatus
+from phase.models import Phase
+
+_previous_phase_status = {}
+
+
+def capture_phase_status(sender, instance, **kwargs):
+    if instance.pk:
+        _previous_phase_status[instance.pk] = (
+            Phase.objects.filter(pk=instance.pk).values_list("status", flat=True).first()
+        )
+
+
+def on_phase_resolved(func):
+    @functools.wraps(func)
+    def wrapper(sender, instance, created, **kwargs):
+        previous_status = _previous_phase_status.pop(instance.pk, None)
+        if previous_status == PhaseStatus.ACTIVE and instance.status == PhaseStatus.COMPLETED:
+            return func(sender=sender, instance=instance, created=created, **kwargs)
+
+    return wrapper

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -9,7 +9,8 @@ from draw_proposal.models import DrawProposal
 from email_service.tasks import send_email_notification
 from email_service.templates import notification_email
 from game.models import Game
-from common.constants import DeadlineMode, GameStatus, PhaseStatus
+from common.constants import DeadlineMode, GameStatus
+from notification.decorators import capture_phase_status, on_phase_resolved
 from notification.tasks import send_notification
 from notification.utils import send_notification_to_users
 from phase.models import Phase
@@ -186,60 +187,45 @@ def send_game_status_notifications(sender, instance, created, **kwargs):
         _send_game_end_notification(instance.id, instance.name, instance.notification_user_ids())
 
 
-_phase_status_cache = {}
-
-
-@receiver(pre_save, sender=Phase)
-def cache_phase_status(sender, instance, **kwargs):  # noqa: ARG001
-    if instance.pk:
-        try:
-            old_instance = Phase.objects.get(pk=instance.pk)
-            _phase_status_cache[instance.pk] = old_instance.status
-        except sender.DoesNotExist:
-            pass
+pre_save.connect(capture_phase_status, sender=Phase)
 
 
 @receiver(post_save, sender=Phase)
-def send_phase_resolved_notification(sender, instance, created, **kwargs):  # noqa: ARG001
-    if created:
-        return
+@on_phase_resolved
+def send_phase_resolved_notification(sender, instance, created, **kwargs):
+    resolved_early = (
+        instance.game.deadline_mode == DeadlineMode.FIXED_TIME
+        and instance.scheduled_resolution is not None
+        and timezone.now() < instance.scheduled_resolution
+    )
 
-    old_status = _phase_status_cache.pop(instance.pk, None)
-    if old_status == PhaseStatus.ACTIVE and instance.status == PhaseStatus.COMPLETED:
+    def _send():
+        user_ids = instance.game.notification_user_ids()
+        link = f"{settings.FRONTEND_URL}/game/{instance.game.id}"
+        if resolved_early:
+            body = f"{instance.name} resolved early — all players confirmed their orders."
+            notification_type = "phase_resolved_early"
+            subject = f"{instance.game.name} — {instance.name} Resolved Early"
+        else:
+            body = f"{instance.name} has been resolved"
+            notification_type = "phase_resolved"
+            subject = f"{instance.game.name} — {instance.name} Resolved"
 
-        resolved_early = (
-            instance.game.deadline_mode == DeadlineMode.FIXED_TIME
-            and instance.scheduled_resolution is not None
-            and timezone.now() < instance.scheduled_resolution
+        send_notification_to_users(
+            user_ids=user_ids,
+            title=instance.game.name,
+            body=body,
+            notification_type=notification_type,
+            data={"game_id": str(instance.game.id), "link": link},
         )
-
-        def _send():
-            user_ids = instance.game.notification_user_ids()
-            link = f"{settings.FRONTEND_URL}/game/{instance.game.id}"
-            if resolved_early:
-                body = f"{instance.name} resolved early — all players confirmed their orders."
-                notification_type = "phase_resolved_early"
-                subject = f"{instance.game.name} — {instance.name} Resolved Early"
-            else:
-                body = f"{instance.name} has been resolved"
-                notification_type = "phase_resolved"
-                subject = f"{instance.game.name} — {instance.name} Resolved"
-
-            send_notification_to_users(
-                user_ids=user_ids,
+        send_email_notification.defer(
+            user_ids=user_ids,
+            subject=subject,
+            html=notification_email(
                 title=instance.game.name,
                 body=body,
-                notification_type=notification_type,
-                data={"game_id": str(instance.game.id), "link": link},
-            )
-            send_email_notification.defer(
-                user_ids=user_ids,
-                subject=subject,
-                html=notification_email(
-                    title=instance.game.name,
-                    body=body,
-                    link=link,
-                ),
-            )
+                link=link,
+            ),
+        )
 
-        transaction.on_commit(_send)
+    transaction.on_commit(_send)

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -406,6 +406,22 @@ class TestPhaseResolvedNotification:
         assert len(jobs) == 1
         assert "Resolved Early" in jobs[0]["args"]["subject"]
 
+    @pytest.mark.django_db
+    def test_resaving_completed_phase_does_not_renotify(
+        self,
+        classical_variant,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+        in_memory_procrastinate,
+    ):
+        phase = self._make_active_phase(classical_variant, timezone.now() - timedelta(minutes=1))
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+        phase.save()
+
+        assert mock_send_notification_to_users.call_count == 1
+
 
 class TestGameStartEmailNotification:
 


### PR DESCRIPTION
## What this PR does

Establishes the transition-decorator pattern the rest of the notification redesign (#1069) depends on, so subsequent consolidation is repetitive rather than inventive. Adds reusable `pre_save` capture + `@on_` decorators to the notification app (mirroring `agent/signals.py`) and converts the `phase_resolved` notification to use them, retiring its ad-hoc status-cache dict. Closes #1071.

Details:
- New `notification/decorators.py` with `capture_phase_status` (`pre_save`) and the `@on_phase_resolved` decorator, so `send_phase_resolved_notification` reads as "on this transition, notify" — mirroring `agent/decorators.py`'s `capture_phase_status` / `@on_phase_activated`.
- `notification/signals.py` wires the capture via `pre_save.connect(...)` and decorates the receiver; the module-level `_phase_status_cache` dict and its bespoke `cache_phase_status` handler are removed.
- Documents the first cut of the notification convention in the backend skill: signals-only triggering, the bulk-write footgun (bulk writes emit no signals), and the cron-vs-signal boundary (time-based notifications are signal-armed, not swept).

Behavior-preserving: still calls `send_notification_to_users` and defers the existing email notification with the same copy and types. The game-status handlers (`_game_status_cache`) are intentionally left for a later sub-issue.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8EZRHtQ11hU5qkdHgjYDc)_