### PR TITLE
Consolidate imperative notification triggers into signals

### DIFF
--- a/.claude/skills/backend/SKILL.md
+++ b/.claude/skills/backend/SKILL.md
@@ -228,9 +228,12 @@ def send_phase_resolved_notification(sender, instance, created, **kwargs):
     ...
 ```
 
-Two rules the pattern depends on:
+Some triggers can't be read off a model field transition — a request-scoped actor is baked into the copy (deadline extended by X), the same write is ambiguous (a `Member` delete may be a kick, a civil-disorder removal, or a voluntary leave), or the fact is ephemeral (which members just used an NMR extension). For those, define an explicit `django.dispatch.Signal` in `notification/events.py`, `.send()` it from the trigger site with the context the receiver needs, and connect the receiver in `notification/signals.py`. The domain code emits a fact; recipients and copy still live only in `notification/signals.py` — no notification `send` in a view, serializer, or model method.
+
+Three rules the pattern depends on:
 
 - **Bulk writes emit no signals.** `bulk_update`, `bulk_create` (partially), and queryset `.delete()` bypass `pre_save`/`post_save`, so any notification wired to those transitions silently never fires. Save per-instance, or emit an explicit signal, whenever the write must notify.
+- **When a model save can't carry the trigger, emit an explicit signal.** Reach for a `notification/events.py` signal when the copy needs a request-scoped actor, when the same write is ambiguous, or when the triggering fact isn't persisted — not as a default over a clean field transition.
 - **Time-based notifications are signal-armed, not swept.** A notification derived from a persisted timestamp (e.g. a deadline) should be scheduled via `schedule_at` when that timestamp is set and re-evaluated at fire time (see `phase/signals.py::arm_deadline_resolution`), not polled by an every-minute cron. Reserve `@app.periodic` sweeps for genuinely open-ended work with no triggering row.
 
 ## API Codegen

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -30,7 +30,6 @@ from common.constants import (
     duration_to_seconds,
 )
 from common.models import BaseModel
-from notification.tasks import send_notification
 from phase.models import Phase, PhaseState
 from phase.utils import calculate_next_fixed_deadline, FREQUENCY_INTERVALS
 from member.models import Member
@@ -607,14 +606,6 @@ class Game(BaseModel):
             new_admin = random.choice(candidates).user
             self.admin = new_admin
             self.save(update_fields=["admin"])
-
-            send_notification.defer(
-                user_ids=[new_admin.id],
-                title=self.name,
-                body="The previous manager is no longer available, so you are now managing this game.",
-                notification_type="game_admin_reassigned",
-                data={"game_id": str(self.id), "link": f"{settings.FRONTEND_URL}/game/{self.id}"},
-            )
 
     def notification_user_ids(self, exclude_user_id=None, active_only=False):
         members = self.members.filter(eliminated=False, kicked=False) if active_only else self.members.all()

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -1,6 +1,5 @@
 from zoneinfo import ZoneInfo
 
-from django.conf import settings
 from rest_framework import serializers
 from django.db import transaction
 from django.db.models import Subquery, OuterRef
@@ -12,8 +11,7 @@ from user_profile.utils import get_player_stats, tier_allows_min_reliability
 from member.serializers import MemberSerializer
 from unit.models import Unit
 from supply_center.models import SupplyCenter
-from notification import utils as notification_utils
-from phase.utils import format_deadline
+from notification.events import game_deadline_extended
 
 from victory.serializers import VictorySerializer
 from variant.models import Variant
@@ -31,19 +29,6 @@ def _phase_state_order_count(phase_state):
     if count is None:
         count = phase_state.orders.count()
     return count
-
-
-def send_game_management_notification(game, title, body, notification_type, exclude_user_id):
-    def _send():
-        user_ids = game.notification_user_ids(exclude_user_id=exclude_user_id)
-        notification_utils.send_notification_to_users(
-            user_ids=user_ids,
-            title=title,
-            body=body,
-            notification_type=notification_type,
-            data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
-        )
-    transaction.on_commit(_send)
 
 
 class GameMasterSerializer(serializers.Serializer):
@@ -636,16 +621,7 @@ class GamePauseSerializer(serializers.Serializer):
         return attrs
 
     def update(self, instance, validated_data):
-        actor = self.context["request"].user
         instance.pause()
-        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
-        send_game_management_notification(
-            instance,
-            title=instance.name,
-            body=f"Game paused by {instance.manager_label}{actor_suffix}",
-            notification_type="game_paused",
-            exclude_user_id=actor.id,
-        )
         return instance
 
     def to_representation(self, instance):
@@ -659,18 +635,7 @@ class GameUnpauseSerializer(serializers.Serializer):
         return attrs
 
     def update(self, instance, validated_data):
-        actor = self.context["request"].user
         instance.unpause()
-        new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
-        deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
-        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
-        send_game_management_notification(
-            instance,
-            title=instance.name,
-            body=f"Game resumed by {instance.manager_label}{actor_suffix}. New deadline: {deadline_str}",
-            notification_type="game_resumed",
-            exclude_user_id=actor.id,
-        )
         return instance
 
     def to_representation(self, instance):
@@ -693,18 +658,8 @@ class GameExtendDeadlineSerializer(serializers.Serializer):
         return attrs
 
     def update(self, instance, validated_data):
-        actor = self.context["request"].user
         instance.extend_deadline(validated_data["duration"])
-        new_deadline = instance.current_phase.scheduled_resolution if instance.current_phase else None
-        deadline_str = format_deadline(new_deadline, instance.fixed_deadline_timezone) if new_deadline else "N/A"
-        actor_suffix = "" if instance.anonymity_active else f" ({actor.username})"
-        send_game_management_notification(
-            instance,
-            title=instance.name,
-            body=f"Deadline extended by {instance.manager_label}{actor_suffix}. New deadline: {deadline_str}",
-            notification_type="game_deadline_extended",
-            exclude_user_id=actor.id,
-        )
+        game_deadline_extended.send(sender=Game, game=instance)
         return instance
 
     def to_representation(self, instance):

--- a/service/game/tests/test_game_admin.py
+++ b/service/game/tests/test_game_admin.py
@@ -53,7 +53,7 @@ class TestGameAdminField:
         game.members.create(user=secondary_user)
 
         api_client.force_authenticate(user=creator)
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             response = api_client.delete(reverse(leave_viewname, args=[game.id]))
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -73,7 +73,7 @@ class TestGameAdminField:
         game.members.create(user=secondary_user)
 
         api_client.force_authenticate(user=secondary_user)
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             response = api_client.delete(reverse(leave_viewname, args=[game.id]))
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -89,7 +89,7 @@ class TestReassignAdmin:
         game = pending_game_factory()
         game.members.create(user=secondary_user)
 
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             game.reassign_admin()
 
         game.refresh_from_db()
@@ -106,7 +106,7 @@ class TestReassignAdmin:
         member_factory(game=game, civil_disorder=True)
         eligible_member = member_factory(game=game)
 
-        with patch("game.models.send_notification"):
+        with patch("notification.signals.send_notification"):
             game.reassign_admin()
 
         game.refresh_from_db()
@@ -117,7 +117,7 @@ class TestReassignAdmin:
         game = pending_game_factory()
         original_admin = game.admin
 
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             game.reassign_admin()
 
         game.refresh_from_db()

--- a/service/game/views.py
+++ b/service/game/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -151,11 +152,12 @@ class GameDeleteView(SelectedGameMixin, generics.DestroyAPIView):
             and instance.game_master_id is not None
             and instance.game_master_id == self.request.user.id
         )
-        if is_game_master_delete:
-            game_deleted_by_master.send(
-                sender=Game, game=instance, actor_id=self.request.user.id
-            )
-        instance.delete()
+        with transaction.atomic():
+            if is_game_master_delete:
+                game_deleted_by_master.send(
+                    sender=Game, game=instance, actor_id=self.request.user.id
+                )
+            instance.delete()
 
 
 class GameExtendDeadlineView(SelectedGameMixin, generics.UpdateAPIView):

--- a/service/game/views.py
+++ b/service/game/views.py
@@ -1,4 +1,3 @@
-from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -23,7 +22,7 @@ from common.views import SelectedGameMixin
 from common.serializers import EmptySerializer
 from common.permissions import IsActiveGame, IsGameMember, IsGameManager, CanDeleteGame
 from common.pagination import StandardPageNumberPagination
-from notification.tasks import send_notification
+from notification.events import game_deleted_by_master
 from .filters import GameFilter
 
 tracer = trace.get_tracer(__name__)
@@ -152,18 +151,11 @@ class GameDeleteView(SelectedGameMixin, generics.DestroyAPIView):
             and instance.game_master_id is not None
             and instance.game_master_id == self.request.user.id
         )
-        user_ids = instance.notification_user_ids(exclude_user_id=self.request.user.id)
-        game_name = instance.name
-        instance.delete()
-        if is_game_master_delete and user_ids:
-            transaction.on_commit(
-                lambda: send_notification.defer(
-                    user_ids=user_ids,
-                    title=game_name,
-                    body="The game was deleted by the Game Master.",
-                    notification_type="game_deleted",
-                )
+        if is_game_master_delete:
+            game_deleted_by_master.send(
+                sender=Game, game=instance, actor_id=self.request.user.id
             )
+        instance.delete()
 
 
 class GameExtendDeadlineView(SelectedGameMixin, generics.UpdateAPIView):

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -879,7 +879,7 @@ class TestKickBotMember:
         game = pending_game_created_by_primary_user
         member = game.members.create(user=roster_bot_user)
 
-        with patch("member.views.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             url = reverse(kick_viewname, args=[game.id, member.id])
             response = authenticated_client.delete(url)
 
@@ -894,7 +894,7 @@ class TestKickBotMember:
         game = pending_game_created_by_primary_user
         member = game.members.create(user=secondary_user)
 
-        with patch("member.views.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             url = reverse(kick_viewname, args=[game.id, member.id])
             response = authenticated_client.delete(url)
 

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -1,6 +1,5 @@
 from rest_framework import permissions, generics, status
 from rest_framework.response import Response
-from django.conf import settings
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
@@ -10,8 +9,7 @@ from .serializers import MemberSerializer
 from common.serializers import EmptySerializer
 from common.permissions import IsActiveGame, IsGameMember, IsGameManager, IsInCivilDisorder, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsReliabilityRequirement
 from common.views import SelectedGameMixin
-import notification.utils as notification_utils
-from notification.tasks import send_notification
+from notification.events import member_kicked_from_staging
 
 
 class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
@@ -63,13 +61,7 @@ class MemberKickView(SelectedGameMixin, generics.DestroyAPIView):
         with transaction.atomic():
             instance.delete()
             if user_id and not is_bot:
-                send_notification.defer(
-                    user_ids=[user_id],
-                    title=game.name,
-                    body=f"You were removed from this game by {game.manager_label}.",
-                    notification_type="kicked_from_staging",
-                    data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
-                )
+                member_kicked_from_staging.send(sender=Member, game=game, user_id=user_id)
 
 
 class CivilDisorderRecoveryView(SelectedGameMixin, generics.GenericAPIView):
@@ -95,20 +87,6 @@ class CivilDisorderRecoveryView(SelectedGameMixin, generics.GenericAPIView):
                 current_phase.phase_states.filter(member=member).update(
                     orders_confirmed=False
                 )
-
-            user_ids = game.notification_user_ids(exclude_user_id=request.user.id)
-            nation_name = member.nation.name if member.nation else "A player"
-
-            def send_notifications():
-                notification_utils.send_notification_to_users(
-                    user_ids=user_ids,
-                    title="Player Returned",
-                    body=f"{nation_name} has returned from civil disorder.",
-                    notification_type="civil_disorder_recovery",
-                    data={"game_id": str(game.id)},
-                )
-
-            transaction.on_commit(send_notifications)
 
         serializer = MemberSerializer(member, context=self.get_serializer_context())
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/service/notification/events.py
+++ b/service/notification/events.py
@@ -1,0 +1,7 @@
+from django.dispatch import Signal
+
+game_deleted_by_master = Signal()
+game_deadline_extended = Signal()
+member_kicked_from_staging = Signal()
+member_removed_from_staging = Signal()
+nmr_extensions_applied = Signal()

--- a/service/notification/signals.py
+++ b/service/notification/signals.py
@@ -9,11 +9,20 @@ from draw_proposal.models import DrawProposal
 from email_service.tasks import send_email_notification
 from email_service.templates import notification_email
 from game.models import Game
+from member.models import Member
 from common.constants import DeadlineMode, GameStatus
 from notification.decorators import capture_phase_status, on_phase_resolved
+from notification.events import (
+    game_deadline_extended,
+    game_deleted_by_master,
+    member_kicked_from_staging,
+    member_removed_from_staging,
+    nmr_extensions_applied,
+)
 from notification.tasks import send_notification
 from notification.utils import send_notification_to_users
 from phase.models import Phase
+from phase.utils import format_deadline
 from victory.models import Victory
 
 logger = logging.getLogger(__name__)
@@ -61,6 +70,7 @@ def send_draw_proposal_notification(sender, instance, created, **kwargs):
 
 
 _game_status_cache = {}
+_previous_game_management_state = {}
 
 
 @receiver(post_save, sender=ChannelMessage)
@@ -104,6 +114,10 @@ def cache_game_status(sender, instance, **kwargs):
         try:
             old_instance = Game.objects.get(pk=instance.pk)
             _game_status_cache[instance.pk] = old_instance.status
+            _previous_game_management_state[instance.pk] = {
+                "admin_id": old_instance.admin_id,
+                "paused_at": old_instance.paused_at,
+            }
         except sender.DoesNotExist:
             pass
 
@@ -227,5 +241,224 @@ def send_phase_resolved_notification(sender, instance, created, **kwargs):
                 link=link,
             ),
         )
+
+    transaction.on_commit(_send)
+
+
+def _game_manager_suffix(game):
+    return "" if game.anonymity_active else f" ({game.admin.username})"
+
+
+def _notify_admin_reassigned(game):
+    if game.admin_id is None:
+        return
+    send_notification.defer(
+        user_ids=[game.admin_id],
+        title=game.name,
+        body="The previous manager is no longer available, so you are now managing this game.",
+        notification_type="game_admin_reassigned",
+        data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+    )
+
+
+def _notify_game_paused(game):
+    user_ids = game.notification_user_ids(exclude_user_id=game.admin_id)
+    if not user_ids:
+        return
+    body = f"Game paused by {game.manager_label}{_game_manager_suffix(game)}"
+
+    def _send():
+        send_notification_to_users(
+            user_ids=user_ids,
+            title=game.name,
+            body=body,
+            notification_type="game_paused",
+            data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+        )
+
+    transaction.on_commit(_send)
+
+
+def _notify_game_resumed(game):
+    user_ids = game.notification_user_ids(exclude_user_id=game.admin_id)
+    if not user_ids:
+        return
+    new_deadline = game.current_phase.scheduled_resolution if game.current_phase else None
+    deadline_str = format_deadline(new_deadline, game.fixed_deadline_timezone) if new_deadline else "N/A"
+    body = f"Game resumed by {game.manager_label}{_game_manager_suffix(game)}. New deadline: {deadline_str}"
+
+    def _send():
+        send_notification_to_users(
+            user_ids=user_ids,
+            title=game.name,
+            body=body,
+            notification_type="game_resumed",
+            data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+        )
+
+    transaction.on_commit(_send)
+
+
+@receiver(post_save, sender=Game)
+def send_game_management_notifications(sender, instance, created, **kwargs):
+    previous_state = _previous_game_management_state.pop(instance.pk, None)
+    if created or previous_state is None:
+        return
+
+    if previous_state["admin_id"] != instance.admin_id:
+        _notify_admin_reassigned(instance)
+
+    if previous_state["paused_at"] is None and instance.paused_at is not None:
+        _notify_game_paused(instance)
+    elif previous_state["paused_at"] is not None and instance.paused_at is None:
+        _notify_game_resumed(instance)
+
+
+_previous_member_state = {}
+
+
+@receiver(pre_save, sender=Member)
+def capture_member_state(sender, instance, **kwargs):
+    if instance.pk:
+        _previous_member_state[instance.pk] = (
+            Member.objects.filter(pk=instance.pk).values("eliminated", "civil_disorder").first()
+        )
+
+
+def _notify_elimination(member):
+    if member.user_id is None:
+        return
+    game = member.game
+    send_notification.defer(
+        user_ids=[member.user_id],
+        title=game.name,
+        body="You've been eliminated. You are not required to enter any orders anymore. You can still chat with players. Better luck next time!",
+        notification_type="elimination",
+        data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+    )
+
+
+def _notify_civil_disorder_recovery(member):
+    game = member.game
+    user_ids = game.notification_user_ids(exclude_user_id=member.user_id)
+    if not user_ids:
+        return
+    nation_name = member.nation.name if member.nation else "A player"
+
+    def _send():
+        send_notification_to_users(
+            user_ids=user_ids,
+            title="Player Returned",
+            body=f"{nation_name} has returned from civil disorder.",
+            notification_type="civil_disorder_recovery",
+            data={"game_id": str(game.id)},
+        )
+
+    transaction.on_commit(_send)
+
+
+@receiver(post_save, sender=Member)
+def send_member_notifications(sender, instance, created, **kwargs):
+    previous_state = _previous_member_state.pop(instance.pk, None)
+    if created or previous_state is None:
+        return
+
+    if not previous_state["eliminated"] and instance.eliminated:
+        _notify_elimination(instance)
+
+    if previous_state["civil_disorder"] and not instance.civil_disorder:
+        _notify_civil_disorder_recovery(instance)
+
+
+@receiver(game_deleted_by_master)
+def send_game_deleted_notification(sender, game, actor_id, **kwargs):
+    user_ids = game.notification_user_ids(exclude_user_id=actor_id)
+    if not user_ids:
+        return
+    game_name = game.name
+
+    def _send():
+        send_notification.defer(
+            user_ids=user_ids,
+            title=game_name,
+            body="The game was deleted by the Game Master.",
+            notification_type="game_deleted",
+        )
+
+    transaction.on_commit(_send)
+
+
+@receiver(game_deadline_extended)
+def send_game_deadline_extended_notification(sender, game, **kwargs):
+    user_ids = game.notification_user_ids(exclude_user_id=game.admin_id)
+    if not user_ids:
+        return
+    new_deadline = game.current_phase.scheduled_resolution if game.current_phase else None
+    deadline_str = format_deadline(new_deadline, game.fixed_deadline_timezone) if new_deadline else "N/A"
+    body = f"Deadline extended by {game.manager_label}{_game_manager_suffix(game)}. New deadline: {deadline_str}"
+
+    def _send():
+        send_notification_to_users(
+            user_ids=user_ids,
+            title=game.name,
+            body=body,
+            notification_type="game_deadline_extended",
+            data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+        )
+
+    transaction.on_commit(_send)
+
+
+@receiver(member_kicked_from_staging)
+def send_kicked_from_staging_notification(sender, game, user_id, **kwargs):
+    send_notification.defer(
+        user_ids=[user_id],
+        title=game.name,
+        body=f"You were removed from this game by {game.manager_label}.",
+        notification_type="kicked_from_staging",
+        data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
+    )
+
+
+@receiver(member_removed_from_staging)
+def send_removed_from_staging_notification(sender, user_id, game, **kwargs):
+    send_notification.defer(
+        user_ids=[user_id],
+        title="Removed from staging games",
+        body=f"You were removed from {game.name} because you entered civil disorder in an active game.",
+        notification_type="removed_from_staging",
+    )
+
+
+@receiver(nmr_extensions_applied)
+def send_nmr_extension_notifications(sender, phase, extension_members, deadline_str, **kwargs):
+    game = phase.game
+    link = f"{settings.FRONTEND_URL}/game/{game.id}"
+
+    def _send():
+        for member in extension_members:
+            if member.user_id is None:
+                continue
+            send_notification_to_users(
+                user_ids=[member.user_id],
+                title=game.name,
+                body=f"You did not submit orders and used an automatic extension ({member.nmr_extensions_remaining} remaining). The current phase is extended until {deadline_str}.",
+                notification_type="nmr_extension_used",
+                data={"game_id": str(game.id), "link": link},
+            )
+
+        extension_ids = {m.user_id for m in extension_members if m.user_id is not None}
+        other_ids = [
+            user_id for user_id in game.notification_user_ids()
+            if user_id not in extension_ids
+        ]
+        if other_ids:
+            send_notification_to_users(
+                user_ids=other_ids,
+                title=game.name,
+                body=f"Some player(s) did not submit orders and used an extension. The current phase is extended until {deadline_str}.",
+                notification_type="nmr_extension_applied",
+                data={"game_id": str(game.id), "link": link},
+            )
 
     transaction.on_commit(_send)

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -7,6 +7,7 @@ from channel.models import Channel, ChannelMessage
 from common.constants import DeadlineMode, GameStatus, PhaseFrequency, PhaseStatus
 from draw_proposal.models import DrawProposal
 from game.models import Game
+from member.models import Member
 from phase.models import Phase
 from victory.models import Victory
 from notification.signals import _truncate_body
@@ -442,3 +443,137 @@ class TestGameStartEmailNotification:
         assert "Game Started" in args["subject"]
         assert game.name in args["subject"]
         assert game.name in args["html"]
+
+
+def _managed_game(factory, admin_user, paused=False):
+    game, phase, italy, germany = factory()
+    Game.objects.filter(pk=game.id).update(
+        admin=admin_user, paused_at=timezone.now() if paused else None
+    )
+    return Game.objects.get(pk=game.id), phase, italy, germany
+
+
+class TestGameManagementNotifications:
+
+    @pytest.mark.django_db
+    def test_admin_change_notifies_new_admin(
+        self, end_game_notification_game_factory, primary_user, secondary_user, in_memory_procrastinate
+    ):
+        game, _, _, _ = _managed_game(end_game_notification_game_factory, primary_user)
+
+        game.admin = secondary_user
+        game.save()
+
+        jobs = _notification_jobs(in_memory_procrastinate, "game_admin_reassigned")
+        assert len(jobs) == 1
+        assert jobs[0]["args"]["user_ids"] == [secondary_user.id]
+
+    @pytest.mark.django_db
+    def test_creating_game_does_not_notify_admin(
+        self, end_game_notification_game_factory, in_memory_procrastinate
+    ):
+        end_game_notification_game_factory()
+
+        assert _notification_jobs(in_memory_procrastinate, "game_admin_reassigned") == []
+
+    @pytest.mark.django_db
+    def test_pause_notifies_players_excluding_admin(
+        self,
+        end_game_notification_game_factory,
+        primary_user,
+        secondary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game, _, _, _ = _managed_game(end_game_notification_game_factory, primary_user)
+
+        game.paused_at = timezone.now()
+        game.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "game_paused"
+        assert primary_user.id not in call.kwargs["user_ids"]
+        assert secondary_user.id in call.kwargs["user_ids"]
+
+    @pytest.mark.django_db
+    def test_resume_notifies_players(
+        self,
+        end_game_notification_game_factory,
+        secondary_user,
+        primary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game, _, _, _ = _managed_game(end_game_notification_game_factory, primary_user, paused=True)
+
+        game.paused_at = None
+        game.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "game_resumed"
+        assert secondary_user.id in call.kwargs["user_ids"]
+
+    @pytest.mark.django_db
+    def test_resaving_paused_game_does_not_renotify(
+        self,
+        end_game_notification_game_factory,
+        primary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game, _, _, _ = _managed_game(end_game_notification_game_factory, primary_user)
+
+        game.paused_at = timezone.now()
+        game.save()
+        game.save()
+
+        assert mock_send_notification_to_users.call_count == 1
+
+
+class TestMemberTransitionNotifications:
+
+    @pytest.mark.django_db
+    def test_elimination_notifies_member(
+        self, end_game_notification_game_factory, primary_user, in_memory_procrastinate
+    ):
+        game, phase, italy, germany = end_game_notification_game_factory()
+
+        italy.eliminated = True
+        italy.save()
+
+        jobs = _notification_jobs(in_memory_procrastinate, "elimination")
+        assert len(jobs) == 1
+        assert jobs[0]["args"]["user_ids"] == [primary_user.id]
+
+    @pytest.mark.django_db
+    def test_resaving_eliminated_member_does_not_renotify(
+        self, end_game_notification_game_factory, in_memory_procrastinate
+    ):
+        game, phase, italy, germany = end_game_notification_game_factory()
+
+        italy.eliminated = True
+        italy.save()
+        italy.save()
+
+        assert len(_notification_jobs(in_memory_procrastinate, "elimination")) == 1
+
+    @pytest.mark.django_db
+    def test_civil_disorder_recovery_notifies_others(
+        self,
+        end_game_notification_game_factory,
+        primary_user,
+        secondary_user,
+        mock_send_notification_to_users,
+        mock_immediate_on_commit,
+    ):
+        game, phase, italy, germany = end_game_notification_game_factory()
+        Member.objects.filter(pk=germany.pk).update(civil_disorder=True)
+        germany = Member.objects.get(pk=germany.pk)
+
+        germany.civil_disorder = False
+        germany.save()
+
+        call = mock_send_notification_to_users.call_args
+        assert call.kwargs["notification_type"] == "civil_disorder_recovery"
+        assert secondary_user.id not in call.kwargs["user_ids"]
+        assert primary_user.id in call.kwargs["user_ids"]

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -23,7 +23,7 @@ from victory.models import Victory
 from email_service.tasks import send_email_notification
 from email_service.templates import notification_email
 from notification import utils as notification_utils
-from notification.tasks import send_notification
+from notification.events import member_removed_from_staging, nmr_extensions_applied
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -231,33 +231,12 @@ class PhaseManager(models.Manager):
 
         deadline_str = format_deadline(phase.scheduled_resolution, phase.game.fixed_deadline_timezone)
 
-        def send_notifications():
-            for member in members_with_extensions:
-                if member.user_id is None:
-                    continue
-                notification_utils.send_notification_to_users(
-                    user_ids=[member.user_id],
-                    title=phase.game.name,
-                    body=f"You did not submit orders and used an automatic extension ({member.nmr_extensions_remaining} remaining). The current phase is extended until {deadline_str}.",
-                    notification_type="nmr_extension_used",
-                    data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
-                )
-
-            extension_ids = {m.user_id for m in members_with_extensions if m.user_id is not None}
-            other_ids = [
-                user_id for user_id in phase.game.notification_user_ids()
-                if user_id not in extension_ids
-            ]
-            if other_ids:
-                notification_utils.send_notification_to_users(
-                    user_ids=other_ids,
-                    title=phase.game.name,
-                    body=f"Some player(s) did not submit orders and used an extension. The current phase is extended until {deadline_str}.",
-                    notification_type="nmr_extension_applied",
-                    data={"game_id": str(phase.game.id), "link": f"{settings.FRONTEND_URL}/game/{phase.game.id}"},
-                )
-
-        transaction.on_commit(send_notifications)
+        nmr_extensions_applied.send(
+            sender=Phase,
+            phase=phase,
+            extension_members=members_with_extensions,
+            deadline_str=deadline_str,
+        )
 
         return members_with_extensions
 
@@ -542,13 +521,10 @@ class PhaseManager(models.Manager):
         Member.objects.filter(id__in=[m.id for m in staging_members]).delete()
 
         for user_id, games in games_by_user.items():
-            game_names = ", ".join(g.name for g in games)
-            send_notification.defer(
-                user_ids=[user_id],
-                title="Removed from staging games",
-                body=f"You were removed from {game_names} because you entered civil disorder in an active game.",
-                notification_type="removed_from_staging",
-            )
+            for game in games:
+                member_removed_from_staging.send(
+                    sender=Member, user_id=user_id, game=game
+                )
 
         from game.models import Game
         for game in Game.objects.filter(id__in=game_ids, status=GameStatus.PENDING):
@@ -580,20 +556,7 @@ class PhaseManager(models.Manager):
 
         for m in newly_eliminated:
             m.eliminated = True
-        Member.objects.bulk_update(newly_eliminated, ["eliminated"])
-
-        game = previous_phase.game
-
-        for member in newly_eliminated:
-            if member.user_id is None:
-                continue
-            send_notification.defer(
-                user_ids=[member.user_id],
-                title=game.name,
-                body="You've been eliminated. You are not required to enter any orders anymore. You can still chat with players. Better luck next time!",
-                notification_type="elimination",
-                data={"game_id": str(game.id), "link": f"{settings.FRONTEND_URL}/game/{game.id}"},
-            )
+            m.save(update_fields=["eliminated"])
 
     def _check_abandonment(self, game):
         if game.sandbox:

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3343,7 +3343,7 @@ class TestCivilDisorderDetection:
         )
         Phase.objects._set_orders_outcome(phase2)
 
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             newly_cd_members = Phase.objects._check_civil_disorder(phase2)
         Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
@@ -3395,7 +3395,7 @@ class TestCivilDisorderDetection:
         )
         Phase.objects._set_orders_outcome(phase2)
 
-        with patch("game.models.send_notification") as mock_send:
+        with patch("notification.signals.send_notification") as mock_send:
             newly_cd_members = Phase.objects._check_civil_disorder(phase2)
         Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
 
@@ -3594,6 +3594,59 @@ class TestCivilDisorderStagingRemoval:
         assert len(staging_removal_jobs) == 1
         assert staging_removal_jobs[0]["args"]["user_ids"] == [primary_user.id]
 
+    @pytest.mark.django_db
+    def test_cd_staging_removal_sends_one_notification_per_game(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+
+        first_staging = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="First Staging Game",
+            status=GameStatus.PENDING,
+            created_by=secondary_user,
+        )
+        first_staging.members.create(user=primary_user)
+        first_staging.members.create(user=secondary_user)
+
+        second_staging = Game.objects.create(
+            variant=italy_vs_germany_variant,
+            name="Second Staging Game",
+            status=GameStatus.PENDING,
+            created_by=secondary_user,
+        )
+        second_staging.members.create(user=primary_user)
+        second_staging.members.create(user=secondary_user)
+
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
+
+        staging_removal_jobs = [
+            j for j in in_memory_procrastinate.jobs.values()
+            if j["task_name"] == "notification.send_notification"
+            and j["args"].get("notification_type") == "removed_from_staging"
+        ]
+        assert len(staging_removal_jobs) == 2
+        bodies = sorted(j["args"]["body"] for j in staging_removal_jobs)
+        assert bodies == [
+            "You were removed from First Staging Game because you entered civil disorder in an active game.",
+            "You were removed from Second Staging Game because you entered civil disorder in an active game.",
+        ]
+        assert all(j["args"]["user_ids"] == [primary_user.id] for j in staging_removal_jobs)
 
     @pytest.mark.django_db
     def test_cd_does_not_remove_game_creator_from_staging(
@@ -5286,8 +5339,7 @@ class TestCheckEliminations:
         in_memory_procrastinate,
     ):
         game, italy, germany = elimination_game_factory()
-        italy.eliminated = True
-        italy.save()
+        Member.objects.filter(pk=italy.pk).update(eliminated=True)
 
         previous_phase = Phase.objects.create(
             game=game, variant=italy_vs_germany_variant,


### PR DESCRIPTION
## What this PR does

Moves every remaining imperative notification trigger into signal receivers in `notification/signals.py`, so that file is the single, complete description of every notification trigger and no notification send is invoked from a view, serializer, or model method. Part of #1069; builds on PR 2's transition-decorator infrastructure. Closes #1072.

Two mechanisms, chosen per trigger:

**Model-field transitions** — a `pre_save` capture remembers the prior value and a `post_save` receiver fires on the named transition (the PR 2 pattern):
- `game_admin_reassigned`, `game_paused`, `game_resumed` — off `Game.admin` / `Game.paused_at`. The management-state capture piggybacks on the existing `cache_game_status` `pre_save`, so no extra query is added per `Game` save. The paused/resumed/extended copy reconstructs the acting manager from `game.admin` (the `IsGameManager` permission guarantees the actor *is* the admin), preserving the existing "(username)" suffix.
- `elimination`, `civil_disorder_recovery` — off `Member.eliminated` / `Member.civil_disorder`. `_check_eliminations` now saves per-instance instead of `bulk_update` so the `post_save` transition fires (cardinality is one or two rows in practice).

**Explicit signals** (`notification/events.py`) — for triggers a bare model save can't express, dispatched from the trigger site with the context the receiver needs; recipients and copy still live only in `notification/signals.py`:
- `game_deadline_extended` — only mutates `Phase.scheduled_resolution`, indistinguishable from unpause / NMR-reset / normal scheduling.
- `member_kicked_from_staging`, `member_removed_from_staging` — both are `Member` deletes in pending games, ambiguous against each other and a voluntary leave by model state alone.
- `nmr_extensions_applied` — driven by a `bulk_update` plus the ephemeral "which members used an extension".
- `game_deleted_by_master` — `post_delete` can't tell a GM delete from an auto-cleanup delete, and needs recipients captured before the cascade.

Behaviour-preserving otherwise: each trigger keeps its existing send path (`send_notification.defer` vs. direct `send_notification_to_users` in `transaction.on_commit`) and its copy.

**Product decisions called out** (per #1072):
- (a) `removed_from_staging` now sends **one notification per game** ("You were removed from *Game X*…") instead of one grouped "removed from A, B" message.
- (b) Converting elimination to per-instance saves fires no *other* `Member` `post_save` receiver — the only receivers on `Member` are the ones added here (verified: no pre-existing `sender=Member` receivers in the codebase), and the sole other per-instance `eliminated`/`civil_disorder` writes go through `bulk_update` (no signal).

Deadline-warning notifications (periodic sweep) and the "entered civil disorder" broadcast are out of scope for this issue and unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0146oJHcT7q5LEiFqMHbPctR)_