### PR TITLE
Route GameMapCanvas import through stale-chunk healing

### DIFF
--- a/packages/web/src/components/MapView.tsx
+++ b/packages/web/src/components/MapView.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import type { ComponentType } from "react";
 import type {
   GameListCurrentPhase,
   Order,
@@ -10,12 +11,15 @@ import { useDsvg } from "../hooks/useDsvg";
 import { DiplicityMap } from "./InteractiveMap/mapRenderer";
 import { toRenderState } from "./InteractiveMap/toRenderState";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { GameMapCanvasProps } from "./GameMapCanvas/GameMapCanvas";
 import type { MapMode } from "./GameMapCanvas/GameMapController";
+import { healLazyImport, StaleChunkFallback } from "../utils/lazyScreen";
 
 const GameMapCanvas = lazy(() =>
-  import("./GameMapCanvas/GameMapCanvas").then((module) => ({
-    default: module.GameMapCanvas,
-  }))
+  healLazyImport<ComponentType<GameMapCanvasProps>>(
+    async () => (await import("./GameMapCanvas/GameMapCanvas"))?.GameMapCanvas,
+    StaleChunkFallback
+  )
 );
 
 type MapPhase = PhaseRetrieve | VariantTemplatePhase | GameListCurrentPhase;

--- a/packages/web/src/utils/lazyScreen.test.ts
+++ b/packages/web/src/utils/lazyScreen.test.ts
@@ -9,7 +9,7 @@ vi.mock("./staleChunk", () => ({
     error instanceof Error && error.message.includes("dynamically imported"),
 }));
 
-import { resolveScreenModule } from "./lazyScreen";
+import { healLazyImport, resolveScreenModule } from "./lazyScreen";
 
 const Screen: ComponentType = () => null;
 
@@ -70,6 +70,43 @@ describe("resolveScreenModule", () => {
         }>,
         "Screen"
       )
+    ).rejects.toThrow("a real bug");
+    expect(reloadForStaleChunk).not.toHaveBeenCalled();
+  });
+});
+
+describe("healLazyImport", () => {
+  beforeEach(() => {
+    reloadForStaleChunk.mockClear();
+  });
+
+  it("returns the loaded component", async () => {
+    const result = await healLazyImport(() => Promise.resolve(Screen), Screen);
+
+    expect(result.default).toBe(Screen);
+    expect(reloadForStaleChunk).not.toHaveBeenCalled();
+  });
+
+  it("reloads when the load resolves to undefined", async () => {
+    const result = await healLazyImport(() => Promise.resolve(undefined), Screen);
+
+    expect(reloadForStaleChunk).toHaveBeenCalledOnce();
+    expect(result.default).toBe(Screen);
+  });
+
+  it("reloads when the load rejects with a stale-chunk error", async () => {
+    const result = await healLazyImport(
+      () => Promise.reject(new Error("Failed to fetch dynamically imported module")),
+      Screen
+    );
+
+    expect(reloadForStaleChunk).toHaveBeenCalledOnce();
+    expect(result.default).toBe(Screen);
+  });
+
+  it("rethrows errors that are not stale-chunk errors", async () => {
+    await expect(
+      healLazyImport(() => Promise.reject(new Error("a real bug")), Screen)
     ).rejects.toThrow("a real bug");
     expect(reloadForStaleChunk).not.toHaveBeenCalled();
   });

--- a/packages/web/src/utils/lazyScreen.ts
+++ b/packages/web/src/utils/lazyScreen.ts
@@ -1,44 +1,45 @@
 import { lazy } from "react";
-import type { ComponentType } from "react";
+import type { ComponentType, FC } from "react";
 import { isStaleChunkError, reloadForStaleChunk } from "./staleChunk";
 
 // Rendered for the instant before reloadForStaleChunk() navigates to the fresh
 // deploy, instead of crashing into the error boundary.
-const StaleChunkFallback: ComponentType = () => null;
+export const StaleChunkFallback: FC = () => null;
 
-// Resolves a screen's lazy module, healing the stale-chunk failure modes that
-// the global `vite:preloadError` handler misses. On WebKit (Safari) and some
-// Android Chrome builds, a dynamic import for a chunk that no longer exists
-// after a deploy neither fires `vite:preloadError` nor rejects with a known
-// message — it resolves to `undefined`, so `module.ScreenName` throws a
+// Resolves a lazily-loaded component, healing the stale-chunk failure modes
+// that the global `vite:preloadError` handler misses. On WebKit (Safari) and
+// some Android Chrome builds, a dynamic import for a chunk that no longer
+// exists after a deploy neither fires `vite:preloadError` nor rejects with a
+// known message — it resolves to `undefined`, so `module.ScreenName` throws a
 // TypeError ("undefined is not an object (evaluating 't.PlayerInfoScreen')")
 // that lands in the error boundary and Sentry. Here we detect the undefined
 // module / missing export and the known rejection messages, and reload to the
 // latest deploy instead. reloadForStaleChunk() debounces via sessionStorage,
 // so this cannot loop.
-export const resolveScreenModule = async <
-  K extends string,
-  M extends Record<K, ComponentType>,
->(
-  factory: () => Promise<M>,
-  name: K
-): Promise<{ default: ComponentType }> => {
+export const healLazyImport = async <T>(
+  load: () => Promise<T | undefined>,
+  fallback: T
+): Promise<{ default: T }> => {
   try {
-    const module: M | undefined = await factory();
-    const component = module?.[name];
+    const component = await load();
     if (!component) {
       reloadForStaleChunk();
-      return { default: StaleChunkFallback };
+      return { default: fallback };
     }
     return { default: component };
   } catch (error) {
     if (isStaleChunkError(error)) {
       reloadForStaleChunk();
-      return { default: StaleChunkFallback };
+      return { default: fallback };
     }
     throw error;
   }
 };
+
+export const resolveScreenModule = <K extends string, M extends Record<K, ComponentType>>(
+  factory: () => Promise<M>,
+  name: K
+) => healLazyImport<ComponentType>(async () => (await factory())?.[name], StaleChunkFallback);
 
 export const lazyScreen = <K extends string, M extends Record<K, ComponentType>>(
   factory: () => Promise<M>,


### PR DESCRIPTION
## What this PR does

`MapView` loaded `GameMapCanvas` with a raw `lazy()` import, so a stale chunk after a deploy throws into the error boundary and Sentry (`DIPLICITY-REACT-M`, `DIPLICITY-REACT-T`) instead of self-healing the way the `lazyScreen`-based screens already do. `GameMapCanvas` now heals the same way, via `reloadForStaleChunk`.

`resolveScreenModule`'s existing generic bound only supports prop-less components (`Record<K, ComponentType>`, i.e. `ComponentType<{}>`), because `GameMapCanvas` has required props (`variant`, `phase`, `orders`, `selected`), and TypeScript's function-parameter contravariance rejects a props-bearing component against that bound — the same reason React's own `lazy()` signature falls back to `ComponentType<any>` internally, which this repo's "never use `any`" rule rules out for our code.

Instead of widening `resolveScreenModule`'s generic (which would need an `any`-typed bound to work), this PR extracts the shared try/catch healing logic from `resolveScreenModule` into a new `healLazyImport<T>` helper with a single unconstrained type parameter — safe because it's never structurally compared against `ComponentType`. `resolveScreenModule` now delegates to it and is otherwise unchanged for its existing prop-less screen callers; `MapView` calls `healLazyImport` directly with `GameMapCanvas`'s concrete props type.

Closes #1047

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — not available in this environment (no `gh` CLI); reviewed manually against the Code Philosophy tenets instead
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — not applicable, no visible UI change


---
_Generated by [Claude Code](https://claude.ai/code/session_01EaPpXhYKTzDPjCbeLXzpXY)_