### PR TITLE
Colocate the elimination and civil-disorder write sites

### DIFF
--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -605,6 +605,16 @@ class PhaseManager(models.Manager):
 
         return all(m.civil_disorder for m in active_members)
 
+    def _apply_member_status_changes(self, previous_phase, adjudication_data):
+        newly_cd_members = self._check_civil_disorder(previous_phase)
+        surviving_cd_members = self._reconcile_civil_disorder_eliminations(
+            newly_cd_members, adjudication_data
+        )
+        new_phase = self.create_from_adjudication_data(previous_phase, adjudication_data)
+        self._check_eliminations(previous_phase, new_phase)
+        self._notify_civil_disorder(previous_phase, surviving_cd_members)
+        return new_phase
+
     def resolve(self, phase):
         with tracer.start_as_current_span("phase.manager.resolve") as span:
             span.set_attribute("phase.id", phase.id)
@@ -617,15 +627,8 @@ class PhaseManager(models.Manager):
             with tracer.start_as_current_span("phase.transaction_atomic"):
                 with transaction.atomic():
                     self._set_orders_outcome(phase)
-                    newly_cd_members = self._check_civil_disorder(phase)
                     adjudication_data = resolve(phase)
-
-                    surviving_cd_members = self._reconcile_civil_disorder_eliminations(
-                        newly_cd_members, adjudication_data
-                    )
-                    new_phase = self.create_from_adjudication_data(phase, adjudication_data)
-                    self._check_eliminations(phase, new_phase)
-                    self._notify_civil_disorder(phase, surviving_cd_members)
+                    new_phase = self._apply_member_status_changes(phase, adjudication_data)
 
                     victory = Victory.objects.try_create_victory(new_phase)
 


### PR DESCRIPTION
## What this PR does

Closes #1083. Part of #1069 (emit-driven, model-first notification redesign) — behaviour-preserving groundwork for the `emit` migration.

The `Member.eliminated` and `Member.civil_disorder` writes were scattered across three points in `PhaseManager.resolve()`, interleaved with adjudication and phase creation:

```
newly_cd_members = self._check_civil_disorder(phase)          # civil_disorder = True
adjudication_data = resolve(phase)
surviving_cd_members = self._reconcile_civil_disorder_eliminations(...)  # civil_disorder = False
new_phase = self.create_from_adjudication_data(phase, adjudication_data)
self._check_eliminations(phase, new_phase)                    # eliminated = True
self._notify_civil_disorder(phase, surviving_cd_members)
```

They now live behind a single, clearly-named `_apply_member_status_changes(previous_phase, adjudication_data)` step that `resolve()` calls once, giving a later PR one site from which to drive the `emit(...)` calls.

Why the writes still straddle phase creation inside the new step: `create_from_adjudication_data` reads `member.civil_disorder` from the DB to set `orders_confirmed` on the new phase's states, so the civil-disorder writes must land before it, while elimination detection needs the created phase. The new step keeps that ordering intact.

## Notes

- **Bulk semantics unchanged.** `_check_civil_disorder`, `_reconcile_civil_disorder_eliminations` and `_check_eliminations` are untouched and keep their `bulk_update` writes — no conversion to per-instance saves (the original signal-plan conversion is dropped per #1069).
- **No `emit` wiring and no recipient-rule change** — those are PR 4 (#1085) and PR 8 (#1076).
- **Behaviour-preserving.** The only reordering is that adjudication (`resolve(phase)`, which is read-only against the DB) now runs before civil-disorder detection; both are derived from the same DB state, so the outcome is identical.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — existing `phase` tests pass unchanged (190 passed); wider `phase` + `game` + `notification` suites green (704 passed, 8 skipped)
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNHEmhGescVs2aiciHGDFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNHEmhGescVs2aiciHGDFj)_