### PR TITLE
Add Google Play badge to Login screen

### DIFF
--- a/packages/web/src/screens/Login.test.tsx
+++ b/packages/web/src/screens/Login.test.tsx
@@ -131,6 +131,32 @@ describe("Login", () => {
     expect(screen.getByRole("button", { name: /sign in with apple/i })).toBeInTheDocument();
   });
 
+  it("shows App Store and Google Play badges linking to their store listings", () => {
+    renderLogin();
+
+    const appStoreLinks = screen.getAllByRole("link", {
+      name: /download on the app store/i,
+    });
+    expect(appStoreLinks.length).toBeGreaterThan(0);
+    appStoreLinks.forEach((link) =>
+      expect(link).toHaveAttribute(
+        "href",
+        "https://apps.apple.com/app/id6759169536"
+      )
+    );
+
+    const playStoreLinks = screen.getAllByRole("link", {
+      name: /get it on google play/i,
+    });
+    expect(playStoreLinks.length).toBeGreaterThan(0);
+    playStoreLinks.forEach((link) =>
+      expect(link).toHaveAttribute(
+        "href",
+        "https://play.google.com/store/apps/details?id=com.diplicityreact.app"
+      )
+    );
+  });
+
   it("signs in with Apple and stores tokens on success", async () => {
     mockAppleMutateAsync.mockResolvedValue({
       id: 2,

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -249,18 +249,32 @@ const Login: React.FC = () => {
             Diplomacy is the legendary game of negotiation, alliance, and betrayal — a war where every move is decided by the people playing, not by chance. Outwit, out-talk, and outlast everyone else to take the map.
           </p>
           {(!isNativePlatform() || isIosPlatform()) && (
-            <a
-              href="https://apps.apple.com/app/id6759169536"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-block mt-8"
-            >
-              <img
-                src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us"
-                alt="Download on the App Store"
-                className="h-10"
-              />
-            </a>
+            <div className="flex items-center gap-3 mt-8">
+              <a
+                href="https://apps.apple.com/app/id6759169536"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img
+                  src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us"
+                  alt="Download on the App Store"
+                  className="h-10"
+                />
+              </a>
+              {!isNativePlatform() && (
+                <a
+                  href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <img
+                    src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+                    alt="Get it on Google Play"
+                    className="h-10"
+                  />
+                </a>
+              )}
+            </div>
           )}
         </div>
 
@@ -386,20 +400,34 @@ const Login: React.FC = () => {
           </div>
         </div>
 
-        {/* App Store badge — mobile only, inside hero below login card */}
+        {/* App/Play Store badges — mobile only, inside hero below login card */}
         {(!isNativePlatform() || isIosPlatform()) && (
-          <a
-            href="https://apps.apple.com/app/id6759169536"
-            target="_blank"
-            rel="noreferrer"
-            className="relative z-10 lg:hidden mt-6"
-          >
-            <img
-              src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us"
-              alt="Download on the App Store"
-              className="h-10"
-            />
-          </a>
+          <div className="relative z-10 lg:hidden mt-6 flex items-center gap-3">
+            <a
+              href="https://apps.apple.com/app/id6759169536"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <img
+                src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us"
+                alt="Download on the App Store"
+                className="h-10"
+              />
+            </a>
+            {!isNativePlatform() && (
+              <a
+                href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img
+                  src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+                  alt="Get it on Google Play"
+                  className="h-10"
+                />
+              </a>
+            )}
+          </div>
         )}
 
       </section>


### PR DESCRIPTION
## What this PR does

Adds a "Get it on Google Play" badge next to the existing "Download on the App Store" badge on the Login screen, in both the desktop hero blurb and the mobile section below the login card. The new badge links to the Play Store listing and is gated on `!isNativePlatform()` only, so it's hidden inside both native apps and shown on desktop web and mobile web — matching the Apple badge's markup and sizing (`h-10`, `target="_blank"`, `rel="noreferrer"`).

Closes #1091

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] I reviewed this PR's diff against the code philosophy in CLAUDE.md (the `/review-pr` skill depends on the `gh` CLI, unavailable in this environment, so I did a manual pass instead)
- [x] Tests cover the change
- [x] Screenshots taken confirming badge placement and visibility gating (desktop hero and mobile, logged out). Note: in this sandboxed environment the badge images themselves fail to load because Google's and Apple's image CDNs aren't in the network egress allowlist — this only affects local screenshotting, not production, where the same hosted Apple badge already renders fine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1t712RqWunRMBdqY9nnLW)_