### PR TITLE
Fix contested-rotation stall in strength-and-cut solver (DIPLICITY-API-9B)

### DIFF
--- a/service/adjudicator/resolution.py
+++ b/service/adjudicator/resolution.py
@@ -21,7 +21,7 @@ The internal representation is an explicit Decision graph:
     Popping one computes its value and re-checks every decision that
     depends on it; newly-ready ones are enqueued.
   * When the queue empties but decisions remain, we look for closed
-    dependency cycles. Two kinds get resolved:
+    dependency cycles. Three kinds get resolved:
 
       - Clean N-move cycles (A→B→C→A): if every member's attack
         strictly exceeds every external competitor's prevent, all
@@ -34,8 +34,16 @@ The internal representation is an explicit Decision graph:
         Szykman's rule, 6.F.13ff). This matches the modern
         adjudication consensus.
 
-    Cycles that match neither shape are unresolvable in the current
-    solver and will exhaust the `_MAX_CYCLE_PASSES` cap, raising
+      - Contested rotations: a rotational cycle (DATC 6.C) whose
+        members are attacked from outside by an equal-or-greater
+        force is not clean, but each member is still individually
+        determined. Any member whose maximum possible attack
+        strength cannot exceed a resolved competitor's prevent is
+        forced to bounce; the rest of the cycle then collapses
+        through normal propagation.
+
+    Cycles that match none of these shapes are unresolvable in the
+    current solver and will exhaust the `_MAX_CYCLE_PASSES` cap, raising
     `RuntimeError`. Such cycles should not arise from valid
     Diplomacy positions; if one does, it indicates a solver bug.
   * Cycle-resolution passes are capped at `_MAX_CYCLE_PASSES`; exceeding
@@ -186,6 +194,11 @@ class _Solver:
                     raise RuntimeError("Decision graph did not converge")
                 continue
             if self._try_resolve_szykman_paradoxes():
+                passes += 1
+                if passes > self._MAX_CYCLE_PASSES:
+                    raise RuntimeError("Decision graph did not converge")
+                continue
+            if self._try_resolve_guaranteed_bounces():
                 passes += 1
                 if passes > self._MAX_CYCLE_PASSES:
                     raise RuntimeError("Decision graph did not converge")
@@ -1084,6 +1097,77 @@ class _Solver:
             if found_entry:
                 cycle_members.append(node)
         return cycle_members
+
+    # --- Guaranteed bounces (contested rotations) ---
+
+    def _try_resolve_guaranteed_bounces(self) -> bool:
+        """Force an unresolved MOVE_STATUS to BOUNCE when the move cannot
+        possibly enter its target regardless of how the remaining
+        decisions settle.
+
+        A Move needs its attack strength to *strictly exceed* every
+        competitor's prevent strength. The most attack strength a Move
+        could ever muster is one plus each of its matched supports —
+        support cuts and the own-nation exclusion only ever reduce it.
+        So if that ceiling is no greater than some already-resolved
+        competitor's prevent strength, the Move is beaten no matter what
+        the unresolved decisions turn out to be, and it bounces.
+
+        This is the last-resort breaker: it runs only after the clean-
+        cycle and Szykman handlers have declined. It resolves rotational
+        cycles (DATC 6.C) whose members are contested from outside by an
+        equal-or-greater attack — the external competition makes the
+        cycle un-clean (so the clean-cycle handler rejects it) while
+        leaving each member individually determined. Forcing the beaten
+        member to bounce collapses the rest of the cycle through normal
+        propagation.
+
+        Only fires for a convoyed Move once its convoy path is known
+        intact, so a broken-convoy failure is never mislabelled as a
+        competitive bounce.
+        """
+        parsed = self._parsed
+        variant = self._variant
+        resolutions = self._initial_resolutions
+        changed = False
+        for i, order in enumerate(parsed):
+            if not isinstance(order, MoveOrder):
+                continue
+            key = (_MOVE_STATUS, i)
+            decision = self._decisions.get(key)
+            if decision is None or decision.value is not None:
+                continue
+            if resolutions[i].via_convoy and (
+                self._dec_value((_CONVOY_PATH_INTACT, i)) is not True
+            ):
+                continue
+            ceiling = 1 + len(_matching_attack_supports(self._state, i))
+            target_parent = variant.parent_of(order.target)
+            for j, other in enumerate(parsed):
+                if j == i:
+                    continue
+                if not isinstance(other, MoveOrder):
+                    continue
+                if resolutions[j].status == Status.ILLEGAL:
+                    continue
+                if variant.parent_of(other.target) != target_parent:
+                    continue
+                prevent = self._dec_value((_PREVENT_STRENGTH, j))
+                if prevent is None:
+                    continue
+                if ceiling <= prevent:
+                    self._decisions[key] = replace(
+                        decision,
+                        value=(
+                            Status.BOUNCE,
+                            "The attack was prevented by a competing move "
+                            "of equal or greater strength.",
+                        ),
+                    )
+                    self._enqueue_dependents(key)
+                    changed = True
+                    break
+        return changed
 
     # --- Completeness check ---
 

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -8984,6 +8984,52 @@ def test_szykman_handles_multi_convoy_paradox():
     assert solver._decisions[k_m3].value is None
 
 
+def test_convoyed_move_into_rotational_cycle_resolves():
+    # Regression from production game "The Fracas of the Garrulous Gun",
+    # phase 51376 (Fall 1904, Movement) — Sentry DIPLICITY-API-9B. The
+    # strength-and-cut solver raised "Strength-and-cut solver terminated
+    # with unresolved decisions" on this position and on every retry,
+    # leaving the phase permanently overdue (DIPLICITY-API-9C/9D). This
+    # refutes the section note above: a Szykman-shaped stall *is*
+    # reachable from a valid Diplomacy position.
+    #
+    # A convoyed, supported move (wal -> spa, convoyed by mao and eng and
+    # supported by por) targets the tail of a rotational 3-cycle
+    # spa -> gas -> mar -> spa, where gas -> mar is supported by bur and
+    # mar -> spa is supported by wes. The dependency cycle this produces
+    # has no _CONVOY_PATH_INTACT member, so the Szykman breaker does not
+    # fire and the solver stalls with move/hold/attack decisions
+    # unresolved. The engine must resolve the position rather than raise.
+    variant = _datc_classical_variant()
+    state = (
+        _DatcStateBuilder(variant)
+        .at_phase("Fall", 1904, "Movement")
+        .with_unit("england", "Fleet", "mao")
+        .with_unit("england", "Fleet", "por")
+        .with_unit("england", "Army", "wal")
+        .with_unit("germany", "Army", "bur")
+        .with_unit("germany", "Fleet", "eng")
+        .with_unit("germany", "Army", "gas")
+        .with_unit("italy", "Army", "mar")
+        .with_unit("italy", "Army", "spa")
+        .with_unit("italy", "Fleet", "wes")
+        .with_order("england", "mao", "Convoy", aux="wal", target="spa")
+        .with_order("england", "por", "Support", aux="wal", target="spa")
+        .with_order("england", "wal", "Move", target="spa", via_convoy=True)
+        .with_order("germany", "bur", "Support", aux="gas", target="mar")
+        .with_order("germany", "eng", "Convoy", aux="wal", target="spa")
+        .with_order("germany", "gas", "Move", target="mar")
+        .with_order("italy", "mar", "Move", target="spa")
+        .with_order("italy", "spa", "Move", target="gas")
+        .with_order("italy", "wes", "Support", aux="mar", target="spa")
+        .build()
+    )
+
+    result = _datc_adjudicate_one(variant, state)
+
+    assert result["resolutions"] is not None
+
+
 # ======================================================================
 # Convoy path-finding
 # ======================================================================

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -8989,17 +8989,20 @@ def test_convoyed_move_into_rotational_cycle_resolves():
     # phase 51376 (Fall 1904, Movement) — Sentry DIPLICITY-API-9B. The
     # strength-and-cut solver raised "Strength-and-cut solver terminated
     # with unresolved decisions" on this position and on every retry,
-    # leaving the phase permanently overdue (DIPLICITY-API-9C/9D). This
-    # refutes the section note above: a Szykman-shaped stall *is*
-    # reachable from a valid Diplomacy position.
+    # leaving the phase permanently overdue (DIPLICITY-API-9C/9D). It
+    # refutes the section note above: a stall *is* reachable from a valid
+    # Diplomacy position — here without any convoy in the cycle, so the
+    # Szykman breaker cannot resolve it.
     #
     # A convoyed, supported move (wal -> spa, convoyed by mao and eng and
     # supported by por) targets the tail of a rotational 3-cycle
     # spa -> gas -> mar -> spa, where gas -> mar is supported by bur and
-    # mar -> spa is supported by wes. The dependency cycle this produces
-    # has no _CONVOY_PATH_INTACT member, so the Szykman breaker does not
-    # fire and the solver stalls with move/hold/attack decisions
-    # unresolved. The engine must resolve the position rather than raise.
+    # mar -> spa is supported by wes. The rotation is not clean: mar -> spa
+    # is contested from outside by wal -> spa at equal strength (2 v 2), so
+    # mar bounces. gas -> mar then dislodges the stayed mar unit (2 v 1),
+    # spa -> gas follows into the vacated Gascony, and wal bounces against
+    # mar. The contested-rotation breaker forces the beaten mar move to
+    # bounce, which collapses the rest of the cycle.
     variant = _datc_classical_variant()
     state = (
         _DatcStateBuilder(variant)
@@ -9027,7 +9030,13 @@ def test_convoyed_move_into_rotational_cycle_resolves():
 
     result = _datc_adjudicate_one(variant, state)
 
-    assert result["resolutions"] is not None
+    assert _datc_resolution_for(result, "gas") == "OK"
+    assert _datc_resolution_for(result, "spa") == "OK"
+    assert _datc_resolution_for(result, "mar") == "BOUNCE"
+    assert _datc_resolution_for(result, "wal") == "BOUNCE"
+    assert _datc_has_unit(result, "germany", "Army", "mar")
+    assert _datc_has_unit(result, "italy", "Army", "gas")
+    assert _datc_has_unit(result, "italy", "Army", "mar", dislodged=True)
 
 
 # ======================================================================


### PR DESCRIPTION
## What this PR does

Production game "The Fracas of the Garrulous Gun", phase 51376 (Fall 1904 Movement), reached a position the strength-and-cut solver could not resolve. Every resolution attempt raised `RuntimeError: Strength-and-cut solver terminated with unresolved decisions`, so the phase was never adjudicated and sat permanently overdue — the source of Sentry issues DIPLICITY-API-9B (the `RuntimeError`, 2197 events) and the overdue-canary issues DIPLICITY-API-9C/9D (2158 events).

### Root cause

The board contains a rotational 3-cycle `spa → gas → mar → spa` (DATC 6.C). It is **not clean**: `mar → spa` is contested from outside the cycle by an equal-strength convoyed move `wal → spa` (both attack strength 2). So:

- the clean-cycle handler rejects it (a member doesn't strictly beat every external competitor),
- the cycle contains no `_CONVOY_PATH_INTACT` decision, so the Szykman breaker doesn't fire,
- the queue drains with the `move_status` / `hold_strength` / `attack_strength` decisions for the three cycle members mutually blocked, and `_assert_decisions_complete` raises.

Yet the position is fully determinate: `mar` bounces against `wal` (2 v 2), `gas → mar` then dislodges the stayed `mar` unit (2 v 1), `spa → gas` follows into the vacated Gascony, and `wal` bounces against `mar`.

### The fix

Add a last-resort cycle-breaker, `_try_resolve_guaranteed_bounces`, that runs only after the clean-cycle and Szykman handlers decline. A Move succeeds only if its attack strength *strictly exceeds* every competitor's prevent strength; the most attack it could ever reach is `1 + (matched supports)` — support cuts and the own-nation exclusion only reduce it. When that **ceiling** cannot exceed an already-resolved competitor's prevent strength, the Move is beaten no matter how the remaining decisions settle, so it is forced to bounce. That collapses the rest of the cycle through normal propagation. The deduction is unconditionally sound, so it cannot produce a wrong bounce. Convoyed Moves are skipped until their path is known intact, so a broken-convoy failure is never mislabelled as a competitive bounce.

### Test

`test_convoyed_move_into_rotational_cycle_resolves` (added first as a red repro of the exact production position, pulled from the production DB with province ids mapped to the DATC test variant, `mid → mao`, `gol → lyo`) now asserts the correct resolution: `mar`/`wal` bounce, `gas` dislodges the Marseilles army, and `spa` follows into Gascony.

### Verification

- New regression test passes.
- The full 34-unit production board resolves (no `RuntimeError`).
- No regressions: `adjudicator` (376), plus `adjudication`/`phase`/`integration`/`game` (723) all pass.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165S5T2noZTbMbFZfCHmegz