### PR TITLE
Make local dev work with no .env and document onboarding

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,3 +1,10 @@
+# You do NOT need this file to run the app locally. `docker compose up` works
+# with no .env at all — the defaults baked into docker-compose.yml and the
+# Django settings match these values. Copy this file to .env only when you want
+# to enable optional features that need real credentials (Google/Apple sign-in,
+# Firebase push notifications, Sentry, Honeycomb). Leave any value you are not
+# using empty rather than filling in a placeholder.
+
 # DATABASE: For local development, this should match what is defined in
 # docker-compose.yml. The values here are applicable for local development.
 DATABASE_NAME="diplicity"
@@ -20,7 +27,7 @@ DJANGO_SUPERUSER_PASSWORD="example-password"
 # 4. Click "Generate New Private Key" button
 # 5. Save the JSON file and use its contents to fill in these values:
 FIREBASE_TYPE="service_account"
-FIREBASE_PROJECT_ID="your-project-id"
+FIREBASE_PROJECT_ID=""
 FIREBASE_PRIVATE_KEY_ID="your-private-key-id"
 # Note: The private key should include the full key including
 # the "-----BEGIN PRIVATE KEY-----" and "-----END PRIVATE KEY-----"
@@ -44,8 +51,8 @@ GOOGLE_OAUTH_CLIENT_SECRET="your-client-secret"
 
 # DJANGO: For local development, we use the default Django secret key.
 
-# Sign into sentry.io
-SENTRY_DSN="your-sentry-dsn"
+# Sign into sentry.io. Leave empty to disable Sentry error tracking locally.
+SENTRY_DSN=""
 
 # SOCIAL SECRET: This is a secret key used as a password for social auth.
 # For local development, this can be any random string.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -4,29 +4,121 @@ This is a hobby project maintained by volunteers from the Diplomacy community. N
 
 The repo is built to be developed with an AI coding agent. A detailed [`CLAUDE.md`](CLAUDE.md) documents the architecture, conventions, and testing patterns, so a freshly-installed agent already knows how the codebase is organized. You'll move faster using one — strongly recommended.
 
-## Setup
+## Prerequisites
 
-1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
-2. Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) (or another AI agent — point it at `CLAUDE.md`).
-3. Clone the repo.
-4. DM **Johnpooch** on the [Diplicity Hub Discord](https://discord.gg/2TkZbBRPW) for the dev `.env` file. Drop it in the repo root. Keep the keys to yourself — they're shared on trust.
-5. Start the app:
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (this is how you run the whole app locally).
+- [git](https://git-scm.com/), to clone the repo.
+- Optionally, an AI coding agent such as [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started). Point it at `CLAUDE.md` and it will already understand the codebase.
+
+You do **not** need any secrets, API keys, or a `.env` file to run the app locally. Everything needed for local development ships with sensible defaults. (Optional features like Google sign-in and push notifications need real credentials — see [When you need more keys](#when-you-need-more-keys) — but nothing in the core "run it and play a game" flow does.)
+
+## Start the app
+
+1. Clone the repo and `cd` into it.
+2. Start every service:
    ```bash
-   docker compose up service web db phase-resolver
+   docker compose up service web db worker phase-resolver
    ```
-   Then open http://localhost:5173.
+   The first run builds the images and can take several minutes. Leave this terminal open — it streams logs from all the containers, which is useful for debugging.
+3. Open http://localhost:5173 in your browser.
 
-If you're using Claude Code, you can also just point it at this guide and ask it to set up the dev environment for you.
+That's it. If you see the Diplicity home page, the stack is running.
+
+### What each service does
+
+The command above starts five containers, all on one Docker network:
+
+| Service | What it is | Where |
+| --- | --- | --- |
+| `web` | React frontend (Vite dev server, hot reload) | http://localhost:5173 |
+| `service` | Django REST API | http://localhost:8000 |
+| `db` | PostgreSQL database | localhost:5432 |
+| `worker` | Procrastinate background worker (notifications, bot moves, scheduled jobs) | — |
+| `phase-resolver` | Polls the API every 10s to advance game phases whose deadline has passed | — |
+
+Plain `docker compose up` (no service list) also works and additionally runs a one-off `codegen` container. That container regenerates the API types and then exits with code `0` — that exit is expected, not an error.
+
+## Create a user
+
+There is no seeded account, and a couple of things that work in production do **not** work on a local machine, so read this before trying to log in:
+
+- **Your real diplicity.com account does not exist locally.** The local database is empty and separate from production.
+- **Signing up through the web form does not complete locally.** Registration creates an inactive account and emails a verification link pointing at `diplicity.com`. Local dev has no email delivery, so the account never activates.
+
+The reliable way to get a working local account is the `create_test_user` management command. With the stack running, open a second terminal and run:
+
+```bash
+docker compose exec service python manage.py create_test_user
+```
+
+This creates (or resets) an **active** account you can log in with immediately:
+
+- **Email:** `test@example.com`
+- **Password:** `password`
+
+The command is idempotent — run it again any time to reset the account. You can also pass your own values:
+
+```bash
+docker compose exec service python manage.py create_test_user \
+  --email you@example.com --name "Your Name" --password hunter2
+```
+
+### Create an admin (superuser)
+
+To reach the Django admin panel you need a superuser. The easiest way is the same command with `--superuser`:
+
+```bash
+docker compose exec service python manage.py create_test_user --superuser
+```
+
+That gives `test@example.com` / `password` admin rights. (If you prefer the standard interactive Django flow instead, `docker compose exec service python manage.py createsuperuser` also works.)
+
+## Log in and test manually
+
+1. Go to http://localhost:5173.
+2. Log in with **email** `test@example.com` and password `password`.
+3. Create a game, join it, and submit orders to check the flow end to end. The `phase-resolver` service advances phases automatically once a deadline passes.
+
+To exercise multiplayer flows (multiple players in one game), create extra users with different emails and log in as each in a separate browser or a private/incognito window:
+
+```bash
+docker compose exec service python manage.py create_test_user --email player2@example.com --name "Player Two"
+```
+
+## Access the admin panel locally
+
+The Django admin is a web UI for inspecting and editing database records directly — handy for debugging game state.
+
+1. Make sure you have a superuser (see [Create an admin](#create-an-admin-superuser)).
+2. Open http://localhost:8000/admin.
+3. Log in with the **username** (not the email) and password. For the default superuser the username is the part of the email before the `@`, so `test@example.com` logs in as username `test`, password `password`.
+
+## Running tests
+
+Backend (Django, pytest):
+
+```bash
+docker compose run --rm service python -m pytest -v                        # full suite
+docker compose run --rm service python -m pytest game/tests/test_game_create.py -v   # one file
+```
+
+Frontend (from `packages/web`):
+
+```bash
+npm run test        # Vitest
+npm run lint        # ESLint
+```
 
 ## When you need more keys
 
-The default `.env` covers Google login and the basics. Other features need extra credentials:
+The core local flow needs nothing extra. Some optional features do need real credentials, provided via a `.env` file in the repo root (copy [`.example.env`](.example.env) and fill in only what you need — leave the rest empty):
 
+- Google / Apple sign-in — OAuth client IDs
 - Push notifications — Firebase service account
 - Telemetry and error tracking — Honeycomb and Sentry
 - iOS native builds — Apple signing certs (more involved; talk to Johnpooch before starting work in this area)
 
-DM Johnpooch if you're working on any of those.
+DM **Johnpooch** on the [Diplicity Hub Discord](https://discord.gg/2TkZbBRPW) if you're working on any of those.
 
 ## Deploying a PR to staging
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ Diplicity React is a React-based web application which integrates with a Django 
 
 ## Getting Started
 
+See [DEVELOPER.md](DEVELOPER.md) for the full setup guide, including how to create a local user and access the admin panel.
+
 ### Prerequisites
-
-#### Secrets
-
-Google sign in and other functionality will not work locally unless you have the required secrets. See the [.env.example](.env.example) file for more information.
 
 #### Docker
 
@@ -26,16 +24,24 @@ Developing using Docker is the recommended way to run the application.
 
 Download and install Docker Desktop from [here](https://www.docker.com/products/docker-desktop/).
 
+No secrets or `.env` file are needed to run the app locally. Optional features (Google sign-in, push notifications, error tracking) need real credentials — see [When you need more keys](DEVELOPER.md#when-you-need-more-keys).
+
 ### Running the project locally
 
 Open a terminal window and run the following command to build the entire project:
 ```bash
-docker compose up service web db phase-resolver
+docker compose up service web db worker phase-resolver
 ```
 
 **Note** The terminal window will show logs from all of the containers which is useful for debugging.
 
 The experience will now be available in your browser at `http://localhost:5173/`.
+
+To log in you first need a local user — the app has no seeded account and your diplicity.com account does not exist locally. Create one with:
+```bash
+docker compose exec service python manage.py create_test_user
+```
+Then log in with `test@example.com` / `password`. See [DEVELOPER.md](DEVELOPER.md) for creating an admin user and manual testing.
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   codegen:
     container_name: diplicity-codegen
@@ -11,7 +10,8 @@ services:
       - /app/packages/web/node_modules
       - /app/packages/native
     env_file:
-      - .env
+      - path: .env
+        required: false
     networks:
       - diplicity-network
     depends_on:
@@ -38,9 +38,11 @@ services:
       - ./packages/web:/app
       - /app/node_modules
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - CHOKIDAR_USEPOLLING=true
+      - VITE_DIPLICITY_API_BASE_URL=http://localhost:8000
     networks:
       - diplicity-network
 
@@ -55,7 +57,8 @@ services:
     volumes:
       - .:/app
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - DJANGO_DEBUG=True
       - ROOT_LOG_LEVEL=INFO
@@ -94,7 +97,8 @@ services:
     volumes:
       - .:/app
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - DJANGO_DEBUG=True
       - ROOT_LOG_LEVEL=INFO
@@ -119,7 +123,8 @@ services:
     volumes:
       - .:/app
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - DJANGO_DEBUG=True
       - ROOT_LOG_LEVEL=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
         required: false
     environment:
       - CHOKIDAR_USEPOLLING=true
-      - VITE_DIPLICITY_API_BASE_URL=http://localhost:8000
     networks:
       - diplicity-network
 

--- a/packages/web/src/api/axiosInstance.ts
+++ b/packages/web/src/api/axiosInstance.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
 import { tokenStorage } from '../auth/tokenStorage';
 
-const diplictityApiBaseUrl = import.meta.env.VITE_DIPLICITY_API_BASE_URL;
+const diplictityApiBaseUrl =
+  import.meta.env.VITE_DIPLICITY_API_BASE_URL || 'http://localhost:8000';
 
 const axiosInstance = axios.create({
   baseURL: diplictityApiBaseUrl,

--- a/service/login/management/commands/create_test_user.py
+++ b/service/login/management/commands/create_test_user.py
@@ -9,14 +9,16 @@ from user_profile.models import UserProfile
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("--email", type=str, required=True)
-        parser.add_argument("--name", type=str, required=True)
-        parser.add_argument("--password", type=str, required=False)
+        parser.add_argument("--email", type=str, default="test@example.com")
+        parser.add_argument("--name", type=str, default="Test User")
+        parser.add_argument("--password", type=str, default="password")
+        parser.add_argument("--superuser", action="store_true")
 
     def handle(self, *args, **options):
         email = options["email"]
         name = options["name"]
         password = options.get("password")
+        superuser = options["superuser"]
 
         user, created = AuthUser.objects.get_or_create(
             email=email,
@@ -26,9 +28,12 @@ class Command(BaseCommand):
             },
         )
 
+        user.is_active = True
+        user.is_staff = superuser
+        user.is_superuser = superuser
         if password:
             user.set_password(password)
-            user.save()
+        user.save()
 
         UserProfile.objects.update_or_create(
             user=user,
@@ -43,6 +48,8 @@ class Command(BaseCommand):
                     "refreshToken": str(refresh),
                     "email": email,
                     "name": name,
+                    "password": password,
+                    "superuser": superuser,
                 }
             )
         )

--- a/service/login/tests.py
+++ b/service/login/tests.py
@@ -1,4 +1,7 @@
+import json
+
 import pytest
+from django.core.management import call_command
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework import status
@@ -196,3 +199,71 @@ def test_unknown_audience_rejected(unauthenticated_client, mock_google_auth):
     url = reverse(viewname)
     response = unauthenticated_client.post(url, {"id_token": "bad_token"}, format="json")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_create_test_user_defaults_create_active_loginable_user(capsys, unauthenticated_client):
+    call_command("create_test_user")
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["email"] == "test@example.com"
+    assert output["password"] == "password"
+    assert output["superuser"] is False
+
+    user = User.objects.get(email="test@example.com")
+    assert user.is_active is True
+    assert user.is_staff is False
+    assert user.is_superuser is False
+    assert UserProfile.objects.get(user=user).name == "Test User"
+
+    response = unauthenticated_client.post(
+        reverse("email-login"),
+        {"email": "test@example.com", "password": "password"},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_create_test_user_superuser_flag_grants_admin_access(capsys):
+    call_command("create_test_user", "--superuser")
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["superuser"] is True
+
+    user = User.objects.get(email="test@example.com")
+    assert user.is_staff is True
+    assert user.is_superuser is True
+
+
+@pytest.mark.django_db
+def test_create_test_user_is_idempotent(capsys):
+    call_command("create_test_user")
+    call_command("create_test_user")
+
+    assert User.objects.filter(email="test@example.com").count() == 1
+    assert UserProfile.objects.filter(user__email="test@example.com").count() == 1
+
+
+@pytest.mark.django_db
+def test_create_test_user_custom_arguments(capsys, unauthenticated_client):
+    call_command(
+        "create_test_user",
+        "--email",
+        "custom@example.com",
+        "--name",
+        "Custom Name",
+        "--password",
+        "custompass123",
+    )
+
+    user = User.objects.get(email="custom@example.com")
+    assert user.username == "custom"
+    assert UserProfile.objects.get(user=user).name == "Custom Name"
+
+    response = unauthenticated_client.post(
+        reverse("email-login"),
+        {"email": "custom@example.com", "password": "custompass123"},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_201_CREATED


### PR DESCRIPTION
## What this PR does

New contributors kept getting stuck bringing the app up locally: `docker compose up` aborted with `.env not found`, and copying `.example.env` shipped a truthy placeholder `SENTRY_DSN="your-sentry-dsn"` that crashes `sentry_sdk.init` on startup (`BadDsn: Unsupported scheme ''`) — taking down the backend so the `phase-resolver` looped `Failed to call phase resolve endpoint` and login/registration failed. This PR makes the stack run out of the box with **no `.env` at all**, gives contributors a one-command way to get a usable local account, and rewrites the developer guide so the whole flow is documented.

Root cause and fix verified against the native venv:
- Reproduced the crash: `SENTRY_DSN="your-sentry-dsn"` → `BadDsn` on settings import.
- With no env: settings import cleanly (`SENTRY_DSN = None`); `docker compose config` parses with no `.env` present.

Changes:
- **`docker-compose.yml`** — mark `env_file: .env` as `required: false` on every service (a missing file no longer aborts the stack) and drop the obsolete `version` key (the warning contributors saw). The backend already defaults `DATABASE_*` and `SECRET_KEY`, so nothing else is needed.
- **`packages/web/src/api/axiosInstance.ts`** — fall back to `http://localhost:8000` when `VITE_DIPLICITY_API_BASE_URL` is unset, matching the existing pattern in `observability.ts`. This is what makes the frontend work with no `.env`.
- **`.example.env`** — blank the placeholders that crash on init (`SENTRY_DSN`, `FIREBASE_PROJECT_ID`), and add a header clarifying the file is optional and only for real credentials.
- **`create_test_user`** — default to an active, loginable `test@example.com` / `password` account (previously `--email`/`--name` were required), and add `--superuser` for admin-panel access. Existing explicit-argument callers are unaffected.
- **`DEVELOPER.md` / `README.md`** — rewrite setup to run every service (including `worker`) with no secrets, create a user and superuser, log in with email/password, and reach the Django admin at `:8000/admin`. Removes the misleading "DM Johnpooch for the `.env` file" step and the reference to a non-existent `.env.example`.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

Notes on the checklist:
- Self-review: `/review-pr` couldn't run in this environment (its `gh` CLI isn't wired to the proxied git remote), so I did a manual self-review of the diff. It caught one issue, now fixed: an earlier commit set `VITE_DIPLICITY_API_BASE_URL` in the `web` service's `environment:`, which would override any value a contributor sets in `.env` (compose `environment` beats `env_file`); the axios fallback already covers the default, so the compose entry was removed.
- Tests: four new tests in `service/login/tests.py` cover the defaults (active + loginable via the email-login endpoint), the `--superuser` flag, idempotency, and custom arguments. Full `login` suite: 16 passed.
- Screenshots: N/A — no user-visible UI changes (the axios fallback only affects the API base URL; the rest is config/docs).
