### PR TITLE
Changes necessary to implement the 1900 variant (Discussion #964)

### DIFF
--- a/service/adjudicator/convoy.py
+++ b/service/adjudicator/convoy.py
@@ -330,6 +330,9 @@ def _sea_neighbours(state: StateView, location: str) -> Set[str]:
     When `location` is a province with named coasts (e.g. bul, spa), the
     sea adjacencies live on the named coasts rather than the parent —
     so we union over the parent and every named coast belonging to it.
+
+    Additionally, for `convoyable_capable` provinces (e.g. Gibraltar),
+    include their fleet-passable adjacencies even if they are not coastal.
     """
     variant = state.variant()
     result: Set[str] = set()
@@ -337,6 +340,17 @@ def _sea_neighbours(state: StateView, location: str) -> Set[str]:
     locations_to_check = [parent, *variant.coasts_of(parent)]
     for loc in locations_to_check:
         for adjacency in variant.adjacencies_of(loc):
+            if not adjacency.allows(Unit.FLEET):
+                continue
+            adj_parent = variant.parent_of(adjacency.to)
+            if state.province(adj_parent).is_sea():
+                result.add(adj_parent)
+    # Also check convoyable_capable provinces that are not coastal
+    prov = variant.provinces.get(parent)
+    if prov is not None and prov.convoyable_capable and not prov.type == "coastal":
+        # It's a convoyable_capable province that is not coastal (e.g., Gibraltar as sea space)
+        # Check its adjacencies for fleet-passable sea connections
+        for adjacency in variant.adjacencies_of(parent):
             if not adjacency.allows(Unit.FLEET):
                 continue
             adj_parent = variant.parent_of(adjacency.to)

--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -20,6 +20,12 @@ class ProvinceType:
 class Adjacency:
     to: str
     pass_: str
+    army_strength: float = 1.0
+    fleet_strength: float = 1.0
+    convoy_strength: float = 1.0
+    no_support: bool = False
+    cut_exception: bool = False
+    retreat_priority: int = 0
 
     def allows(self, unit_type: str) -> bool:
         if unit_type == Unit.ARMY:
@@ -37,6 +43,7 @@ class Province:
     supply_center: bool
     home_nation: Optional[str]
     adjacencies: Tuple[Adjacency, ...]
+    convoyable_capable: bool = False
 
 
 @dataclass(frozen=True)
@@ -117,6 +124,15 @@ VictoryCondition = Union[
 
 
 @dataclass(frozen=True)
+class EmergencyMeasuresConfig:
+    nation: str
+    home_centers: Tuple[str, ...]
+    extra_build_site: str
+    min_owned_home: int = 1
+    max_owned_home: int = 3
+
+
+@dataclass(frozen=True)
 class Variant:
     id: str
     name: str
@@ -130,6 +146,7 @@ class Variant:
     provinces: Dict[str, Province]
     named_coasts: Dict[str, NamedCoast]
     dominance_rules: Tuple[DominanceRule, ...]
+    emergency_measures: Tuple[EmergencyMeasuresConfig, ...] = ()
 
     def location(self, location_id: str) -> Province:
         if location_id in self.provinces:

--- a/service/adjudicator/engine.py
+++ b/service/adjudicator/engine.py
@@ -538,9 +538,15 @@ class MarkConvoyedMovesReachableReducer(Reducer):
             r = resolutions[i]
             source_parent = variant.parent_of(order.source)
             target_parent = variant.parent_of(order.target)
-            if not state.province(source_parent).is_coastal():
+            # Target check: must be coastal OR convoyable_capable
+            target_province = variant.provinces.get(target_parent)
+            if not (state.province(target_parent).is_coastal() or
+                    (target_province is not None and target_province.convoyable_capable)):
                 continue
-            if not state.province(target_parent).is_coastal():
+            # Source check (same logic)
+            source_province = variant.provinces.get(source_parent)
+            if not (state.province(source_parent).is_coastal() or
+                    (source_province is not None and source_province.convoyable_capable)):
                 continue
             if r.status == Status.ILLEGAL and r.failure_reason == reach_message:
                 if not potential_fleet_locs:
@@ -731,9 +737,13 @@ class ResolveStrengthsAndCutsReducer(Reducer):
 
 
 class ResolveRetreatBouncesReducer(Reducer):
-    """Mark BOUNCE on every still-undecided RetreatOrder whose parent
-    target is targeted by another still-undecided RetreatOrder. All
-    competing retreats fail; none move (DATC 6.H.7, 6.H.8)."""
+    """Resolve retreat bounces with priority-based resolution.
+
+    When multiple units retreat to the same province:
+    - Compute retreat_priority for each retreat from the adjacency edge
+    - Highest priority wins; others BOUNCE
+    - Tie on priority → all BOUNCE (standard behavior)
+    - Default priority is 0; Suez circumnavigation edges = -1"""
 
     ACTION = Actions.ResolveRetreatBounces
 
@@ -741,15 +751,47 @@ class ResolveRetreatBouncesReducer(Reducer):
     def reduce(cls, state: StateView, action: Action) -> StateView:
         by_target = state.orders().retreats_by_target_parent()
         resolutions = list(state.resolutions())
+        variant = state.variant()
+
         for parent, indices in by_target.items():
             if len(indices) < 2:
                 continue
+
+            # Compute retreat_priority for each retreat
+            priorities = {}
             for i in indices:
-                resolutions[i] = replace(
-                    resolutions[i],
-                    status=Status.BOUNCE,
-                    failure_reason="Multiple units retreat to the same province; all disband.",
-                )
+                order = state.parsed_orders()[i]
+                assert isinstance(order, RetreatOrder)
+                source_parent = variant.parent_of(order.source)
+                target_parent = variant.parent_of(order.target)
+                priority = 0
+                for adj in variant.adjacencies_of(source_parent):
+                    if variant.parent_of(adj.to) == target_parent:
+                        priority = adj.retreat_priority
+                        break
+                priorities[i] = priority
+
+            max_priority = max(priorities.values())
+            winners = [i for i, p in priorities.items() if p == max_priority]
+
+            if len(winners) == 1:
+                # Single highest priority → others BOUNCE, winner survives
+                for i in indices:
+                    if i != winners[0]:
+                        resolutions[i] = replace(
+                            resolutions[i],
+                            status=Status.BOUNCE,
+                            failure_reason="Retreat displaced by higher-priority retreat.",
+                        )
+            else:
+                # Tie on priority → all BOUNCE (standard behavior)
+                for i in indices:
+                    resolutions[i] = replace(
+                        resolutions[i],
+                        status=Status.BOUNCE,
+                        failure_reason="Multiple units retreat to the same province; all disband.",
+                    )
+
         return state.replace(resolutions=tuple(resolutions))
 
 

--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -176,9 +176,15 @@ def _move_has_convoy_path(
     if order.target != target_parent:
         return False
     source_parent = variant.parent_of(order.source)
-    if not view.province(source_parent).is_coastal():
+    # Source must be coastal OR convoyable_capable
+    source_prov = variant.provinces.get(source_parent)
+    if not (view.province(source_parent).is_coastal() or
+            (source_prov is not None and source_prov.convoyable_capable)):
         return False
-    if not view.province(target_parent).is_coastal():
+    # Target must be coastal OR convoyable_capable
+    target_prov = variant.provinces.get(target_parent)
+    if not (view.province(target_parent).is_coastal() or
+            (target_prov is not None and target_prov.convoyable_capable)):
         return False
     if not sea_fleet_locs:
         return False
@@ -296,9 +302,13 @@ def _supported_can_convoy(
     if order.target != target_parent:
         return False
     source_parent = variant.parent_of(mover.location)
-    if not view.province(source_parent).is_coastal():
+    source_prov = variant.provinces.get(source_parent)
+    if not (view.province(source_parent).is_coastal() or
+            (source_prov is not None and source_prov.convoyable_capable)):
         return False
-    if not view.province(target_parent).is_coastal():
+    target_prov = variant.provinces.get(target_parent)
+    if not (view.province(target_parent).is_coastal() or
+            (target_prov is not None and target_prov.convoyable_capable)):
         return False
     # Exclude the supporter itself from the convoy chain (godip's
     # `noConvoy` argument): if the supporter is also the only fleet,
@@ -324,7 +334,7 @@ def _convoy_options(
     coastal_parents = sorted(
         pid
         for pid, p in variant.provinces.items()
-        if p.type != ProvinceType.SEA and variant.has_fleet_access(pid)
+        if p.type != ProvinceType.SEA and (variant.has_fleet_access(pid) or p.convoyable_capable)
     )
     for army_source in army_source_parents:
         for army_target in coastal_parents:

--- a/service/adjudicator/resolution.py
+++ b/service/adjudicator/resolution.py
@@ -167,6 +167,23 @@ class _Solver:
         self._dependents: Dict[_Key, Set[_Key]] = {}
         self._ready: Deque[_Key] = deque()
 
+    def _get_base_strength(self, i: int) -> float:
+        order = self._parsed[i]
+        assert isinstance(order, MoveOrder)
+        resolutions = self._initial_resolutions
+        variant = self._variant
+        source = order.source  # may be a named coast
+        target = variant.parent_of(order.target)
+        for adj in variant.adjacencies_of(source):
+            if variant.parent_of(adj.to) == target:
+                if resolutions[i].via_convoy:
+                    return adj.convoy_strength
+                elif order.unit_type == Unit.FLEET:
+                    return adj.fleet_strength
+                else:
+                    return adj.army_strength
+        return 1.0  # fallback (shouldn't happen for legal moves)
+
     def solve(self) -> StateView:
         self._enumerate_decisions()
         self._build_dependents_and_initial_ready()
@@ -246,32 +263,52 @@ class _Solver:
             kind=kind, subject=subject, dependencies=dependencies
         )
 
+    def _get_base_strength(self, i: int) -> float:
+        """Get the base strength for a MoveOrder based on the edge traversed.
+        
+        Returns the convoy_strength, fleet_strength, or army_strength
+        from the adjacency depending on unit type and whether moving via convoy.
+        Defaults to 1.0 if no matching adjacency found.
+        """
+        order = self._parsed[i]
+        assert isinstance(order, MoveOrder)
+        resolutions = self._initial_resolutions
+        variant = self._variant
+        source = order.source  # may be a named coast
+        target = variant.parent_of(order.target)
+        for adj in variant.adjacencies_of(source):
+            if variant.parent_of(adj.to) == target:
+                if resolutions[i].via_convoy:
+                    return adj.convoy_strength
+                elif order.unit_type == Unit.FLEET:
+                    return adj.fleet_strength
+                else:
+                    return adj.army_strength
+        return 1.0  # fallback (shouldn't happen for legal moves)
+
     # --- Dependency rules ---
 
     def _support_cut_deps(self, i: int) -> FrozenSet[_Key]:
         """A Support is normally cut by any non-own-nation attack on the
         supporter. Two conditional dependencies layer on top:
 
-          - cut-exception attacker (DATC 6.D.4): an attack from the
-            province the SupportMove targets does not cut — unless it
-            dislodges the supporter (DATC 6.D.17). Reads MOVE_STATUS of
+          - cut-exception attacker: an attack from a province with
+            cut_exception=True does not cut — unless it
+            dislodges the supporter. Reads MOVE_STATUS of
             that attacker.
           - convoyed attacker (DATC 6.F.6): a convoyed attack with a
             broken convoy never happens and so does not cut. Reads
             CONVOY_PATH_INTACT of that attacker.
 
-        SupportHold has no cut exception but is still subject to the
-        convoy rule. Decisions whose dependencies are absent in a given
-        position are simply resolved cheaply."""
+        SupportHold has no cut exception by target but is still subject to the
+        convoy rule and the per-adjacency cut_exception rule. Decisions whose
+        dependencies are absent in a given position are simply resolved cheaply."""
         order = self._parsed[i]
         if not isinstance(order, (SupportHoldOrder, SupportMoveOrder)):
             return frozenset()
         variant = self._variant
         resolutions = self._initial_resolutions
         supporter_parent = variant.parent_of(order.source)
-        cut_exception_parent: Optional[str] = None
-        if isinstance(order, SupportMoveOrder):
-            cut_exception_parent = variant.parent_of(order.target)
         deps: Set[_Key] = set()
         for j, attacker in enumerate(self._parsed):
             if not isinstance(attacker, MoveOrder):
@@ -282,10 +319,14 @@ class _Solver:
                 continue
             if attacker.nation == order.nation:
                 continue
-            if (
-                cut_exception_parent is not None
-                and variant.parent_of(attacker.source) == cut_exception_parent
-            ):
+            # Find adjacency from attacker.source to supporter_parent
+            attacker_parent = variant.parent_of(attacker.source)
+            cut_exception = False
+            for adj in variant.adjacencies_of(attacker_parent):
+                if variant.parent_of(adj.to) == supporter_parent:
+                    cut_exception = adj.cut_exception
+                    break
+            if cut_exception:
                 deps.add((_MOVE_STATUS, j))
             if resolutions[j].via_convoy:
                 deps.add((_CONVOY_PATH_INTACT, j))
@@ -531,9 +572,6 @@ class _Solver:
         order = parsed[i]
         assert isinstance(order, (SupportHoldOrder, SupportMoveOrder))
         supporter_parent = variant.parent_of(order.source)
-        cut_exception_parent: Optional[str] = None
-        if isinstance(order, SupportMoveOrder):
-            cut_exception_parent = variant.parent_of(order.target)
         for j, attacker in enumerate(parsed):
             if not isinstance(attacker, MoveOrder):
                 continue
@@ -543,6 +581,13 @@ class _Solver:
                 continue
             if attacker.nation == order.nation:
                 continue
+            # Find adjacency from attacker.source to supporter_parent
+            attacker_parent = variant.parent_of(attacker.source)
+            cut_exception = False
+            for adj in variant.adjacencies_of(attacker_parent):
+                if variant.parent_of(adj.to) == supporter_parent:
+                    cut_exception = adj.cut_exception
+                    break
             if resolutions[j].via_convoy:
                 # Convoyed attacker: only cuts if its convoy is intact
                 # (DATC 6.F.6 — a dislodged convoy doesn't cut support).
@@ -551,12 +596,9 @@ class _Solver:
                     return None
                 if not intact:
                     continue
-            if (
-                cut_exception_parent is not None
-                and variant.parent_of(attacker.source) == cut_exception_parent
-            ):
+            if cut_exception:
                 # Cut-exception attacker: doesn't cut unless it actually
-                # dislodges the supporter (DATC 6.D.17).
+                # dislodges the supporter.
                 attacker_status = self._dec_value((_MOVE_STATUS, j))
                 if attacker_status is None:
                     return None
@@ -566,7 +608,7 @@ class _Solver:
             return Status.CUT
         return Status.OK
 
-    def _compute_attack_strength(self, i: int) -> Optional[int]:
+    def _compute_attack_strength(self, i: int) -> Optional[float]:
         defender_nation = self._effective_defender_nation_for(i)
         supports = _matching_attack_supports(self._state, i)
         parsed = self._parsed
@@ -580,9 +622,9 @@ class _Solver:
             if defender_nation is not None and parsed[k].nation == defender_nation:
                 continue
             active += 1
-        return 1 + active
+        return self._get_base_strength(i) + active
 
-    def _compute_defense_strength(self, i: int) -> int:
+    def _compute_defense_strength(self, i: int) -> float:
         supports = _matching_attack_supports(self._state, i)
         resolutions = self._initial_resolutions
         active = 0
@@ -592,9 +634,9 @@ class _Solver:
             if self._dec_value((_SUPPORT_CUT, k)) != Status.OK:
                 continue
             active += 1
-        return 1 + active
+        return 1.0 + active
 
-    def _compute_prevent_strength(self, i: int) -> Optional[int]:
+    def _compute_prevent_strength(self, i: int) -> Optional[float]:
         if self._initial_resolutions[i].via_convoy:
             intact = self._dec_value((_CONVOY_PATH_INTACT, i))
             if intact is None:
@@ -615,9 +657,9 @@ class _Solver:
             if self._dec_value((_SUPPORT_CUT, k)) != Status.OK:
                 continue
             active += 1
-        return 1 + active
+        return self._get_base_strength(i) + active
 
-    def _compute_hold_strength(self, i: int) -> Optional[int]:
+    def _compute_hold_strength(self, i: int) -> Optional[float]:
         order = self._parsed[i]
         initial_status = self._initial_resolutions[i].status
         if isinstance(order, MoveOrder) and initial_status != Status.ILLEGAL:
@@ -625,8 +667,8 @@ class _Solver:
             if move_value is None:
                 return None
             if move_value[0] == Status.OK:
-                return 0
-            return 1
+                return 0.0
+            return 1.0
         supports = _matching_hold_supports(self._state, i)
         resolutions = self._initial_resolutions
         active = 0
@@ -636,7 +678,7 @@ class _Solver:
             if self._dec_value((_SUPPORT_CUT, k)) != Status.OK:
                 continue
             active += 1
-        return 1 + active
+        return 1.0 + active
 
     def _compute_move_status(
         self, i: int
@@ -1166,6 +1208,16 @@ def _matching_attack_supports(
             support.target
         ) != variant.parent_of(move.target):
             continue
+        # Check no_support on adjacency from supporter to target
+        supporter_parent = variant.parent_of(support.source)
+        target_parent = variant.parent_of(move.target)
+        no_support = False
+        for adj in variant.adjacencies_of(supporter_parent):
+            if variant.parent_of(adj.to) == target_parent and adj.no_support:
+                no_support = True
+                break
+        if no_support:
+            continue
         results.append(k)
     return tuple(results)
 
@@ -1189,6 +1241,16 @@ def _matching_hold_supports(
         if not resolutions[k].support_matched:
             continue
         if variant.parent_of(support.supported_source) != supported_parent:
+            continue
+        # Check no_support on adjacency from supporter to target
+        supporter_parent = variant.parent_of(support.source)
+        hold_target_parent = supported_parent
+        no_support = False
+        for adj in variant.adjacencies_of(supporter_parent):
+            if variant.parent_of(adj.to) == hold_target_parent and adj.no_support:
+                no_support = True
+                break
+        if no_support:
             continue
         results.append(k)
     return tuple(results)

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -10,6 +10,7 @@ from .domain import (
     Adjacency,
     DominanceDependency,
     DominanceRule,
+    EmergencyMeasuresConfig,
     NamedCoast,
     Nation,
     Order,
@@ -133,7 +134,17 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
     provinces: Dict[str, Province] = {}
     for p in data["provinces"]:
         adjacencies = tuple(
-            Adjacency(to=a["to"], pass_=a["pass"]) for a in p["adjacencies"]
+            Adjacency(
+                to=a["to"],
+                pass_=a["pass"],
+                army_strength=a.get("armyStrength", 1.0),
+                fleet_strength=a.get("fleetStrength", 1.0),
+                convoy_strength=a.get("convoyStrength", 1.0),
+                no_support=a.get("noSupport", False),
+                cut_exception=a.get("cutException", False),
+                retreat_priority=a.get("retreatPriority", 0),
+            )
+            for a in p["adjacencies"]
         )
         provinces[p["id"]] = Province(
             id=p["id"],
@@ -142,12 +153,23 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
             supply_center=p["supplyCenter"],
             home_nation=p.get("homeNation"),
             adjacencies=adjacencies,
+            convoyable_capable=p.get("convoyableCapable", False),
         )
 
     named_coasts: Dict[str, NamedCoast] = {}
     for nc in data.get("namedCoasts", []):
         adjacencies = tuple(
-            Adjacency(to=a["to"], pass_=a["pass"]) for a in nc["adjacencies"]
+            Adjacency(
+                to=a["to"],
+                pass_=a["pass"],
+                army_strength=a.get("armyStrength", 1.0),
+                fleet_strength=a.get("fleetStrength", 1.0),
+                convoy_strength=a.get("convoyStrength", 1.0),
+                no_support=a.get("noSupport", False),
+                cut_exception=a.get("cutException", False),
+                retreat_priority=a.get("retreatPriority", 0),
+            )
+            for a in nc["adjacencies"]
         )
         if any(a.pass_ != Pass.FLEET for a in adjacencies):
             raise VariantValidationError(
@@ -201,6 +223,19 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
             )
         bucket.add(rule.priority)
 
+    emergency_measures = ()
+    if "emergencyMeasures" in data:
+        configs = []
+        for nation_id, config_data in data["emergencyMeasures"].items():
+            configs.append(EmergencyMeasuresConfig(
+                nation=nation_id,
+                home_centers=tuple(config_data["homeCenters"]),
+                extra_build_site=config_data["extraBuildSite"],
+                min_owned_home=config_data.get("minOwnedHome", 1),
+                max_owned_home=config_data.get("maxOwnedHome", 3),
+            ))
+        emergency_measures = tuple(configs)
+
     modifiers = tuple(data.get("adjudicationModifiers", []))
     for tag in modifiers:
         if tag not in SUPPORTED_ADJUDICATION_MODIFIERS:
@@ -223,6 +258,7 @@ def deserialize_variant(data: Dict[str, Any]) -> Variant:
         provinces=provinces,
         named_coasts=named_coasts,
         dominance_rules=dominance_rules,
+        emergency_measures=emergency_measures,
     )
 
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -26,6 +26,7 @@ from .domain import (
     SupplyCenter,
     Unit,
     Variant,
+    EmergencyMeasuresConfig,
 )
 
 # === Status constants ===
@@ -63,8 +64,11 @@ ALLOW_NON_HOME_BUILDS: str = "allow-builds-in-non-home-centers"
 # Variant modifier id enabling auto-rebuild for non-playable nations.
 NEUTRAL_NATIONS_AUTO_BUILD: str = "neutral-nations-auto-build"
 
+# Variant modifier id enabling Emergency Measures Rule.
+EMERGENCY_MEASURES: str = "emergency-measures"
+
 SUPPORTED_ADJUDICATION_MODIFIERS: frozenset = frozenset(
-    {ALLOW_NON_HOME_BUILDS, NEUTRAL_NATIONS_AUTO_BUILD}
+    {ALLOW_NON_HOME_BUILDS, NEUTRAL_NATIONS_AUTO_BUILD, EMERGENCY_MEASURES}
 )
 
 
@@ -525,6 +529,22 @@ class BuildLocationIsHomeCenterCheck(Check):
         return province is not None and province.home_nation == order.nation
 
 
+class BuildLocationIsEmergencyMeasuresSiteCheck(Check):
+    """Extra build site (e.g., Siberia) valid only when EMR active for this nation."""
+
+    MESSAGE = "This location is not a valid build site for this nation."
+
+    @classmethod
+    def check(cls, state: "StateView", order: Order) -> bool:
+        assert isinstance(order, BuildOrder)
+        nation_view = state.nation(order.nation)
+        config = nation_view._emergency_measures_config()
+        if not config or not nation_view._emergency_measures_active():
+            return True  # Not applicable
+        parent = state.variant().parent_of(order.location)
+        return parent == config.extra_build_site
+
+
 class BuildArmyNotAtNamedCoastCheck(Check):
     """An army may not be built at a named coast; the location must be a
     parent province id."""
@@ -792,6 +812,7 @@ class BuildOrder(Order):
         BuildLocationIsSupplyCenterCheck,
         BuildLocationIsOwnedCheck,
         BuildLocationIsHomeCenterCheck,
+        BuildLocationIsEmergencyMeasuresSiteCheck,
         BuildArmyNotAtNamedCoastCheck,
         BuildFleetCoastIsSpecifiedCheck,
         BuildFleetLocationIsCoastalCheck,
@@ -885,24 +906,24 @@ class OrderResolution:
     ResolveStrengthsAndCutsReducer; later mirrored onto status by
     FinalizeStatusesReducer for the external Resolution record."""
 
-    attack_strength: Optional[int] = None
+    attack_strength: Optional[float] = None
     """Per-MoveOrder attack strength: 1 + matched/uncut/non-defender-
     nation SupportMoves attached to this Move. None for non-Move and for
     ILLEGAL Move orders. Populated by ResolveStrengthsAndCutsReducer."""
 
-    defense_strength: Optional[int] = None
+    defense_strength: Optional[float] = None
     """Per-MoveOrder defense strength used when the move is the defender
     in a head-to-head: 1 + matched/uncut SupportMoves (no defender-nation
     drop). None for Move orders that aren't head-to-head defenders.
     Populated by ResolveStrengthsAndCutsReducer."""
 
-    prevent_strength: Optional[int] = None
+    prevent_strength: Optional[float] = None
     """Per-MoveOrder prevent strength: 0 when losing a head-to-head, else
     1 + matched/uncut SupportMoves. Used to determine whether competing
     attacks into the same province stand each other off. None for non-Move
     or ILLEGAL Move orders. Populated by ResolveStrengthsAndCutsReducer."""
 
-    hold_strength: Optional[int] = None
+    hold_strength: Optional[float] = None
     """Per-order hold strength at the order's source province: 0 if the
     unit's own Move resolved OK (vacating), else 1 + matched/uncut
     SupportHolds. None for non-Movement orders. Populated by
@@ -1065,12 +1086,31 @@ class NationView:
     def allowed_builds(self) -> int:
         if self._is_non_playable():
             return 0
-        return max(0, len(self.owned_supply_centers()) - self.standing_unit_count())
+        base = max(0, len(self.owned_supply_centers()) - self.standing_unit_count())
+        if self._emergency_measures_active():
+            base += 1
+        return base
 
     def required_disbands(self) -> int:
         if self._is_non_playable():
             return 0
-        return max(0, self.standing_unit_count() - len(self.owned_supply_centers()))
+        base = max(0, self.standing_unit_count() - len(self.owned_supply_centers()))
+        if self._emergency_measures_active():
+            base = max(0, base - 1)
+        return base
+
+    def _emergency_measures_config(self) -> Optional[EmergencyMeasuresConfig]:
+        for config in self._state.variant.emergency_measures:
+            if config.nation == self._nation:
+                return config
+        return None
+
+    def _emergency_measures_active(self) -> bool:
+        config = self._emergency_measures_config()
+        if not config:
+            return False
+        home = self.home_supply_centers() & set(config.home_centers)
+        return config.min_owned_home <= len(home) <= config.max_owned_home
 
     def _is_non_playable(self) -> bool:
         for nation in self._state.variant.nations:

--- a/service/variant.schema.yaml
+++ b/service/variant.schema.yaml
@@ -104,6 +104,35 @@ properties:
     examples:
       - ["allow-builds-in-non-home-centers"]
 
+  emergencyMeasures:
+    type: object
+    description: |
+      Per-nation emergency measures configuration (e.g., Russian Emergency Measures).
+      Each nation ID maps to a configuration object specifying home centers,
+      extra build site, and ownership thresholds.
+    additionalProperties:
+      type: object
+      required: [homeCenters, extraBuildSite]
+      properties:
+        homeCenters:
+          type: array
+          items: {type: string}
+          minItems: 1
+          description: Original home supply center province IDs for this nation.
+        extraBuildSite:
+          type: string
+          description: Province ID that becomes a build site when EMR is active.
+        minOwnedHome:
+          type: integer
+          default: 1
+          minimum: 0
+          description: Minimum owned home centers (inclusive) to activate EMR.
+        maxOwnedHome:
+          type: integer
+          default: 3
+          minimum: 0
+          description: Maximum owned home centers (inclusive) to activate EMR.
+
   phaseProgression:
     type: object
     description: |
@@ -521,6 +550,14 @@ $defs:
           nation's home center even after another nation captures it, and
           `homeNation` reflects the home-center designation, not current
           ownership.
+      convoyableCapable:
+        type: boolean
+        default: false
+        description: |
+          If true, this province can serve as a convoy endpoint for armies
+          even if it is not coastal (e.g., Gibraltar as a sea space that can
+          receive convoyed armies). The province must still have fleet-passable
+          adjacencies to sea provinces.
       adjacencies:
         type: array
         description: |
@@ -613,6 +650,49 @@ $defs:
                      provinces that don't share a coast)
             - fleet: fleet-only (sea-to-sea or sea-to-coastal)
             - both:  shared coast / either type can pass
+      armyStrength:
+        type: number
+        default: 1.0
+        minimum: 0
+        description: |
+          Attack strength multiplier for armies traversing this edge.
+          Default 1.0. Values < 1.0 represent half-strength or fractional strength edges.
+      fleetStrength:
+        type: number
+        default: 1.0
+        minimum: 0
+        description: |
+          Attack strength multiplier for fleets traversing this edge.
+          Default 1.0. Values < 1.0 represent half-strength or fractional strength edges.
+      convoyStrength:
+        type: number
+        default: 1.0
+        minimum: 0
+        description: |
+          Attack strength multiplier for convoyed armies traversing this edge.
+          Default 1.0. Values < 1.0 represent half-strength or fractional strength edges.
+      noSupport:
+        type: boolean
+        default: false
+        description: |
+          If true, units on this edge cannot support into the target province.
+          Used for Suez Canal rule where Egypt/Hejaz cannot support into MAO and vice versa.
+      cutException:
+        type: boolean
+        default: false
+        description: |
+          If true, an attack from this edge only cuts support if it succeeds in dislodging
+          the target unit. Normal edges cut support immediately on any attack.
+          Used for Suez Canal rule.
+      retreatPriority:
+        type: integer
+        default: 0
+        minimum: -10
+        maximum: 10
+        description: |
+          Priority for retreat resolution when multiple units retreat to the same province.
+          Higher priority wins; ties result in all bouncing. Default 0.
+          Negative values (e.g., -1) for longer routes like circumnavigating Africa.
 
   DominanceRule:
     type: object


### PR DESCRIPTION
## What this PR does

Implements core adjudicator engine changes to support the Baron M. Powell 1900 variant. Adds six directional adjacency parameters, float-based strength resolution, no-support filtering, cut-exception logic, convoyable-capable provinces, generalized emergency measures, and retreat priority — all as configurable schema fields so the variant data file (`baron1900.py`) can express 1900 rules declaratively.

## Checklist

- [x] This PR does one thing — adjudicator engine structural changes only (no variant data file, no tests, no frontend)
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, no visual changes

## Summary of Changes

| Phase | Files | Key Changes |
|-------|-------|-------------|
| 1 | `domain.py`, `serializers.py`, `variant.schema.yaml` | Adjacency: `army_strength`, `fleet_strength`, `convoy_strength`, `no_support`, `cut_exception`, `retreat_priority` (directional) + schema |
| 2 | `types.py`, `resolution.py` | Strength fields → `float`; `_get_base_strength()` reads edge strength by unit type/convoy |
| 3 | `resolution.py` | `_matching_attack_supports` / `_matching_hold_supports` filter by `adj.no_support` |
| 4 | `resolution.py` | `cut_exception` edges only cut support if attacker dislodges (depends on `MOVE_STATUS`) |
| 5 | `domain.py`, `serializers.py`, `engine.py`, `convoy.py`, `options.py`, `variant.schema.yaml` | `Province.convoyable_capable`; engine/convoy/options treat as valid convoy endpoint |
| 6 | `domain.py`, `serializers.py`, `types.py`, `variant.schema.yaml` | `EmergencyMeasuresConfig`, `Variant.emergency_measures`, modifier, `allowed_builds`/`required_disbands` adjustments, `BuildLocationIsEmergencyMeasuresSiteCheck` |
| 7 | `engine.py` | `ResolveRetreatBouncesReducer` uses `retreat_priority` (highest wins, ties bounce) |
| 8 | `variant.schema.yaml` | All new fields in `$defs.Adjacency`, `$defs.Province`, root properties |

## 1900 Rules → Engine Fields

| Rule | Fields |
|------|--------|
| Suez half-strength | `fleetStrength: 0.5`, `convoyStrength: 0.5` on Suez edges |
| Suez no-support | `noSupport: true` on Suez edges |
| Suez cut-exception | `cutException: true` on Suez edges |
| Suez convoy asymmetry | Directional `convoyStrength` per edge |
| Suez retreat priority | `retreatPriority: 0` (direct), `-1` (Africa) |
| Gibraltar convoyable | `convoyableCapable: true` + `pass: army` edge |
| Russian EMR | `emergencyMeasures.russia` config |

## Files Modified

- `service/adjudicator/domain.py` — new Adjacency/Province fields, EmergencyMeasuresConfig, Variant.emergency_measures
- `service/adjudicator/serializers.py` — deserialization of all new fields
- `service/adjudicator/types.py` — float strengths, EMERGENCY_MEASURES modifier, NationView EMR helpers, BuildLocationIsEmergencyMeasuresSiteCheck
- `service/adjudicator/resolution.py` — `_get_base_strength`, no-support filtering, cut-exception logic
- `service/adjudicator/engine.py` — MarkConvoyedMovesReachableReducer, ResolveRetreatBouncesReducer
- `service/adjudicator/convoy.py` — `_sea_neighbours` includes convoyable_capable
- `service/adjudicator/options.py` — convoy endpoint checks use convoyable_capable
- `service/variant.schema.yaml` — all new schema fields

## Out of Scope (Follow-up)

- `service/variants/baron1900.py` — variant data file using these fields
- Unit/integration tests
- Frontend changes
