### PR TITLE
Signal-arm the deadline warning and delete the sweep

### DIFF
--- a/service/phase/migrations/0017_phase_warning_job_id.py
+++ b/service/phase/migrations/0017_phase_warning_job_id.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("phase", "0016_phase_resolution_job_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="phase",
+            name="warning_job_id",
+            field=models.BigIntegerField(blank=True, editable=False, null=True),
+        ),
+        migrations.RemoveField(
+            model_name="phasestate",
+            name="deadline_warning_sent_for",
+        ),
+    ]

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -235,30 +235,13 @@ class PhaseManager(models.Manager):
 
         return members_with_extensions
 
-    def send_deadline_warnings(self):
-        WARNING_THRESHOLDS = {
-            3600: 900,
-            12 * 3600: 3600,
-            24 * 3600: 3600,
-            48 * 3600: 7200,
-            72 * 3600: 7200,
-            96 * 3600: 7200,
-            168 * 3600: 14400,
-            336 * 3600: 14400,
-        }
-
-        def get_warning_threshold(duration_seconds):
-            if not duration_seconds:
-                return 3600
-            for phase_duration, warning in sorted(WARNING_THRESHOLDS.items()):
-                if duration_seconds <= phase_duration:
-                    return warning
-            return 14400
-
-        with tracer.start_as_current_span("phase.manager.send_deadline_warnings") as span:
+    def send_deadline_warning(self, phase_id):
+        with tracer.start_as_current_span("phase.manager.send_deadline_warning") as span:
+            span.set_attribute("phase.id", phase_id)
             now = timezone.now()
 
-            active_phases = self.filter(
+            phase = self.filter(
+                pk=phase_id,
                 status=PhaseStatus.ACTIVE,
                 game__sandbox=False,
                 game__paused_at__isnull=True,
@@ -271,77 +254,69 @@ class PhaseManager(models.Manager):
                 'phase_states__orders',
                 Prefetch('units', queryset=Unit.objects.select_related('nation'), to_attr='prefetched_units'),
                 Prefetch('supply_centers', queryset=SupplyCenter.objects.select_related('nation'), to_attr='prefetched_supply_centers'),
-            )
+            ).first()
 
+            if phase is None:
+                logger.info(f"Phase {phase_id} not eligible for deadline warning; skipping")
+                return {"notifications_sent": 0}
+
+            time_until_deadline = (phase.scheduled_resolution - now).total_seconds()
+            if time_until_deadline <= 0:
+                logger.info(f"Phase {phase_id} deadline already passed; skipping warning")
+                return {"notifications_sent": 0}
+
+            is_fixed_time = phase.game.deadline_mode == DeadlineMode.FIXED_TIME
+            time_left = format_time_remaining(time_until_deadline)
+
+            units_by_nation = {}
+            dislodged_units_by_nation = {}
+            for unit in phase.prefetched_units:
+                units_by_nation[unit.nation_id] = units_by_nation.get(unit.nation_id, 0) + 1
+                if unit.dislodged:
+                    dislodged_units_by_nation[unit.nation_id] = dislodged_units_by_nation.get(unit.nation_id, 0) + 1
+
+            sc_by_nation = {}
+            for sc in phase.prefetched_supply_centers:
+                sc_by_nation[sc.nation_id] = sc_by_nation.get(sc.nation_id, 0) + 1
+
+            is_adjustment = phase.type == PhaseType.ADJUSTMENT
             notifications_sent = 0
 
-            for phase in active_phases:
-                duration_seconds = phase.game.get_effective_phase_duration_seconds(phase.type)
-                warning_threshold = get_warning_threshold(duration_seconds)
-                time_until_deadline = (phase.scheduled_resolution - now).total_seconds()
-
-                if time_until_deadline <= 0 or time_until_deadline > warning_threshold:
+            for ps in phase.phase_states.all():
+                if not ps.has_possible_orders:
                     continue
 
-                is_fixed_time = phase.game.deadline_mode == DeadlineMode.FIXED_TIME
-                time_left = format_time_remaining(time_until_deadline)
+                nation_id = ps.member.nation_id
+                unit_count = units_by_nation.get(nation_id, 0)
 
-                units_by_nation = {}
-                dislodged_units_by_nation = {}
-                for unit in phase.prefetched_units:
-                    units_by_nation[unit.nation_id] = units_by_nation.get(unit.nation_id, 0) + 1
-                    if unit.dislodged:
-                        dislodged_units_by_nation[unit.nation_id] = dislodged_units_by_nation.get(unit.nation_id, 0) + 1
+                if is_adjustment:
+                    sc_count = sc_by_nation.get(nation_id, 0)
+                    total_units = abs(sc_count - unit_count)
+                elif phase.type == PhaseType.RETREAT:
+                    total_units = dislodged_units_by_nation.get(nation_id, 0)
+                else:
+                    total_units = unit_count
 
-                sc_by_nation = {}
-                for sc in phase.prefetched_supply_centers:
-                    sc_by_nation[sc.nation_id] = sc_by_nation.get(sc.nation_id, 0) + 1
+                if total_units == 0:
+                    continue
 
-                is_adjustment = phase.type == PhaseType.ADJUSTMENT
-                warned_states = []
+                body = build_notification_body(
+                    ps.orders_confirmed, is_fixed_time, len(ps.orders.all()), total_units, time_left,
+                    ps.member.nmr_extensions_remaining,
+                    is_adjustment=is_adjustment,
+                )
+                if body is None:
+                    continue
 
-                for ps in phase.phase_states.all():
-                    if not ps.has_possible_orders:
-                        continue
-                    if ps.deadline_warning_sent_for == phase.scheduled_resolution:
-                        continue
+                if ps.member.user_id is None:
+                    continue
 
-                    nation_id = ps.member.nation_id
-                    unit_count = units_by_nation.get(nation_id, 0)
-
-                    if is_adjustment:
-                        sc_count = sc_by_nation.get(nation_id, 0)
-                        total_units = abs(sc_count - unit_count)
-                    elif phase.type == PhaseType.RETREAT:
-                        total_units = dislodged_units_by_nation.get(nation_id, 0)
-                    else:
-                        total_units = unit_count
-
-                    if total_units == 0:
-                        continue
-
-                    body = build_notification_body(
-                        ps.orders_confirmed, is_fixed_time, len(ps.orders.all()), total_units, time_left,
-                        ps.member.nmr_extensions_remaining,
-                        is_adjustment=is_adjustment,
-                    )
-                    if body is None:
-                        continue
-
-                    if ps.member.user_id is None:
-                        continue
-
-                    emit("deadline_warning", game=phase.game, recipients=[ps.member.user_id], body=body)
-                    ps.deadline_warning_sent_for = phase.scheduled_resolution
-                    warned_states.append(ps)
-                    notifications_sent += 1
-                    logger.info(f"Sent deadline warning to user {ps.member.user_id} for game {phase.game.name}")
-
-                if warned_states:
-                    PhaseState.objects.bulk_update(warned_states, ["deadline_warning_sent_for"])
+                emit("deadline_warning", game=phase.game, recipients=[ps.member.user_id], body=body)
+                notifications_sent += 1
+                logger.info(f"Sent deadline warning to user {ps.member.user_id} for game {phase.game.name}")
 
             span.set_attribute("notifications.sent", notifications_sent)
-            logger.info(f"Sent {notifications_sent} deadline warning notification(s)")
+            logger.info(f"Sent {notifications_sent} deadline warning notification(s) for phase {phase_id}")
 
             return {"notifications_sent": notifications_sent}
 
@@ -856,6 +831,7 @@ class Phase(BaseModel):
     type = models.CharField(max_length=10)
     scheduled_resolution = models.DateTimeField(null=True, blank=True)
     resolution_job_id = models.BigIntegerField(null=True, blank=True, editable=False)
+    warning_job_id = models.BigIntegerField(null=True, blank=True, editable=False)
     options = models.JSONField(default=dict)
 
     class Meta:
@@ -975,7 +951,6 @@ class PhaseState(BaseModel):
     orders_confirmed = models.BooleanField(default=False)
     eliminated = models.BooleanField(default=False)
     has_possible_orders = models.BooleanField(default=False)
-    deadline_warning_sent_for = models.DateTimeField(null=True, blank=True)
     orders_outcome = models.CharField(
         max_length=8, choices=OrdersOutcome, null=True, blank=True, default=None
     )

--- a/service/phase/signals.py
+++ b/service/phase/signals.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
@@ -7,7 +8,8 @@ from procrastinate.contrib.django import app as procrastinate_app
 
 from common.constants import PhaseStatus
 from phase.models import Phase
-from phase.tasks import resolve_phase
+from phase.tasks import resolve_phase, send_deadline_warning
+from phase.utils import deadline_warning_offset
 
 logger = logging.getLogger(__name__)
 
@@ -20,17 +22,20 @@ def cache_phase_pre_save_state(sender, instance, **kwargs):
     if instance.pk:
         row = (
             Phase.objects.filter(pk=instance.pk)
-            .values_list("scheduled_resolution", "status", "resolution_job_id")
+            .values_list("scheduled_resolution", "status", "resolution_job_id", "warning_job_id")
             .first()
         )
-        _phase_pre_save_state[instance.pk] = row or (None, None, None)
+        _phase_pre_save_state[instance.pk] = row or (None, None, None, None)
 
 
 @receiver(post_save, sender=Phase)
-def arm_deadline_resolution(sender, instance, created, **kwargs):
-    old_scheduled_resolution, old_status, old_job_id = _phase_pre_save_state.pop(
-        instance.pk, (None, None, None)
-    )
+def arm_deadline_jobs(sender, instance, created, **kwargs):
+    (
+        old_scheduled_resolution,
+        old_status,
+        old_resolution_job_id,
+        old_warning_job_id,
+    ) = _phase_pre_save_state.pop(instance.pk, (None, None, None, None))
 
     scheduled_resolution = instance.scheduled_resolution
     unchanged = (
@@ -41,25 +46,62 @@ def arm_deadline_resolution(sender, instance, created, **kwargs):
     if unchanged:
         return
 
-    if old_job_id is not None:
-        procrastinate_app.job_manager.cancel_job_by_id(old_job_id)
-
-    new_job_id = None
     can_arm = (
         instance.status == PhaseStatus.ACTIVE
         and scheduled_resolution is not None
         and scheduled_resolution > timezone.now()
     )
-    if can_arm:
-        new_job_id = resolve_phase.configure(
-            schedule_at=scheduled_resolution,
-            lock=f"resolve-game-{instance.game_id}",
-        ).defer(phase_id=instance.pk)
 
-        logger.info(
-            f"Armed deadline resolution for phase {instance.pk} (game {instance.game_id}) "
-            f"at {scheduled_resolution} (job {new_job_id})"
-        )
+    updates = {}
 
-    if new_job_id != old_job_id:
-        Phase.objects.filter(pk=instance.pk).update(resolution_job_id=new_job_id)
+    new_resolution_job_id = arm_deadline_resolution(instance, scheduled_resolution, can_arm, old_resolution_job_id)
+    if new_resolution_job_id != old_resolution_job_id:
+        updates["resolution_job_id"] = new_resolution_job_id
+
+    new_warning_job_id = arm_deadline_warning(instance, scheduled_resolution, can_arm, old_warning_job_id)
+    if new_warning_job_id != old_warning_job_id:
+        updates["warning_job_id"] = new_warning_job_id
+
+    if updates:
+        Phase.objects.filter(pk=instance.pk).update(**updates)
+
+
+def arm_deadline_resolution(instance, scheduled_resolution, can_arm, old_job_id):
+    if old_job_id is not None:
+        procrastinate_app.job_manager.cancel_job_by_id(old_job_id)
+
+    if not can_arm:
+        return None
+
+    new_job_id = resolve_phase.configure(
+        schedule_at=scheduled_resolution,
+        lock=f"resolve-game-{instance.game_id}",
+    ).defer(phase_id=instance.pk)
+
+    logger.info(
+        f"Armed deadline resolution for phase {instance.pk} (game {instance.game_id}) "
+        f"at {scheduled_resolution} (job {new_job_id})"
+    )
+    return new_job_id
+
+
+def arm_deadline_warning(instance, scheduled_resolution, can_arm, old_job_id):
+    if old_job_id is not None:
+        procrastinate_app.job_manager.cancel_job_by_id(old_job_id)
+
+    if not can_arm:
+        return None
+
+    duration_seconds = instance.game.get_effective_phase_duration_seconds(instance.type)
+    warning_at = scheduled_resolution - timedelta(seconds=deadline_warning_offset(duration_seconds))
+
+    new_job_id = send_deadline_warning.configure(
+        schedule_at=warning_at,
+        lock=f"warn-game-{instance.game_id}",
+    ).defer(phase_id=instance.pk)
+
+    logger.info(
+        f"Armed deadline warning for phase {instance.pk} (game {instance.game_id}) "
+        f"at {warning_at} (job {new_job_id})"
+    )
+    return new_job_id

--- a/service/phase/tasks.py
+++ b/service/phase/tasks.py
@@ -13,15 +13,14 @@ def resolve_phase(phase_id: int):
     Phase.objects.resolve_if_due(phase_id)
 
 
+@app.task(name="phase.send_deadline_warning", retry=3)
+def send_deadline_warning(phase_id: int):
+    logger.info(f"Running send_deadline_warning task for phase {phase_id}")
+    Phase.objects.send_deadline_warning(phase_id)
+
+
 @app.periodic(cron="* * * * *")
 @app.task(name="phase.sweep_due_phases")
 def sweep_due_phases(timestamp: int):
     logger.info(f"Running sweep_due_phases task (scheduled for {timestamp})")
     Phase.objects.sweep_due_phases()
-
-
-@app.periodic(cron="* * * * *")
-@app.task(name="phase.send_deadline_warnings")
-def send_deadline_warnings(timestamp: int):
-    logger.info(f"Running send_deadline_warnings task (scheduled for {timestamp})")
-    Phase.objects.send_deadline_warnings()

--- a/service/phase/test_background_resolution.py
+++ b/service/phase/test_background_resolution.py
@@ -11,6 +11,7 @@ from common.constants import DeadlineMode, PhaseFrequency, PhaseStatus
 from game.models import Game
 from phase.models import Phase
 from phase.serializers import PhaseStateSerializer
+from phase.utils import deadline_warning_offset
 
 
 def _resolve_jobs(connector):
@@ -19,6 +20,10 @@ def _resolve_jobs(connector):
 
 def _immediate_resolve_jobs(connector):
     return [j for j in _resolve_jobs(connector) if j["scheduled_at"] is None]
+
+
+def _warning_jobs(connector):
+    return [j for j in connector.jobs.values() if j["task_name"] == "phase.send_deadline_warning"]
 
 
 class TestConfirmTrigger:
@@ -264,6 +269,102 @@ class TestDeadlineTimerArming:
 
         phase.refresh_from_db()
         assert phase.resolution_job_id is None
+
+
+class TestDeadlineWarningArming:
+
+    @pytest.mark.django_db
+    def test_active_future_deadline_arms_warning(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        future = timezone.now() + timedelta(hours=24)
+        phase = phase_factory(
+            scheduled_resolution=future,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+
+        offset = deadline_warning_offset(
+            phase.game.get_effective_phase_duration_seconds(phase.type)
+        )
+        jobs = _warning_jobs(in_memory_procrastinate)
+        assert len(jobs) == 1
+        assert jobs[0]["args"] == {"phase_id": phase.id}
+        assert jobs[0]["lock"] == f"warn-game-{phase.game_id}"
+        assert jobs[0]["scheduled_at"] == future - timedelta(seconds=offset)
+
+    @pytest.mark.django_db
+    def test_pending_phase_does_not_arm_warning(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        phase_factory(
+            scheduled_resolution=timezone.now() + timedelta(hours=24),
+            status=PhaseStatus.PENDING,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+
+        assert _warning_jobs(in_memory_procrastinate) == []
+
+    @pytest.mark.django_db
+    def test_deadline_change_rearms_warning(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        future = timezone.now() + timedelta(hours=24)
+        phase = phase_factory(
+            scheduled_resolution=future,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+
+        phase.scheduled_resolution = future + timedelta(hours=2)
+        phase.save()
+
+        assert len(_warning_jobs(in_memory_procrastinate)) == 2
+
+    @pytest.mark.django_db
+    def test_deadline_change_cancels_previous_warning_job(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        future = timezone.now() + timedelta(hours=24)
+        phase = phase_factory(
+            scheduled_resolution=future,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+        phase.refresh_from_db()
+        old_job_id = phase.warning_job_id
+
+        phase.scheduled_resolution = future + timedelta(hours=2)
+        phase.save()
+
+        assert in_memory_procrastinate.jobs[old_job_id]["status"] == "cancelled"
+
+    @pytest.mark.django_db
+    def test_phase_completion_cancels_warning_job(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        future = timezone.now() + timedelta(hours=24)
+        phase = phase_factory(
+            scheduled_resolution=future,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+        phase.refresh_from_db()
+        old_job_id = phase.warning_job_id
+        assert old_job_id is not None
+
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        assert in_memory_procrastinate.jobs[old_job_id]["status"] == "cancelled"
+        phase.refresh_from_db()
+        assert phase.warning_job_id is None
 
 
 class TestSweepCanary:

--- a/service/phase/test_deadline_reminders.py
+++ b/service/phase/test_deadline_reminders.py
@@ -4,58 +4,12 @@ from unittest.mock import patch
 import pytest
 from django.utils import timezone
 
-from common.constants import DeadlineMode, GameStatus, UnitType
+from common.constants import DeadlineMode, GameStatus, PhaseStatus, UnitType
+from game.models import Game
 from phase.models import Phase
 
 
-class TestDeadlineReminderGuard:
-
-    @pytest.mark.django_db
-    def test_sends_one_reminder_per_deadline(
-        self, phase_factory, classical_england_nation, classical_edinburgh_province
-    ):
-        phase = phase_factory(
-            scheduled_resolution=timezone.now() + timedelta(minutes=30),
-            phase_states_config=[
-                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
-            ],
-        )
-        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
-
-        with patch("phase.models.emit") as mock_emit:
-            first = Phase.objects.send_deadline_warnings()
-            second = Phase.objects.send_deadline_warnings()
-
-        assert first["notifications_sent"] == 1
-        assert second["notifications_sent"] == 0
-        mock_emit.assert_called_once()
-
-        phase_state = phase.phase_states.first()
-        phase_state.refresh_from_db()
-        assert phase_state.deadline_warning_sent_for == phase.scheduled_resolution
-
-    @pytest.mark.django_db
-    def test_fresh_reminder_after_deadline_moves(
-        self, phase_factory, classical_england_nation, classical_edinburgh_province
-    ):
-        phase = phase_factory(
-            scheduled_resolution=timezone.now() + timedelta(minutes=30),
-            phase_states_config=[
-                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
-            ],
-        )
-        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
-
-        with patch("phase.models.emit") as mock_emit:
-            Phase.objects.send_deadline_warnings()
-
-            phase.scheduled_resolution = phase.scheduled_resolution + timedelta(minutes=10)
-            phase.save()
-
-            third = Phase.objects.send_deadline_warnings()
-
-        assert third["notifications_sent"] == 1
-        assert mock_emit.call_count == 2
+class TestDeadlineWarningRecipients:
 
     @pytest.mark.django_db
     def test_confirmed_player_not_reminded(
@@ -83,7 +37,7 @@ class TestDeadlineReminderGuard:
         phase.units.create(type=UnitType.ARMY, nation=classical_france_nation, province=classical_paris_province)
 
         with patch("phase.models.emit") as mock_emit:
-            result = Phase.objects.send_deadline_warnings()
+            result = Phase.objects.send_deadline_warning(phase.id)
 
         assert result["notifications_sent"] == 1
         mock_emit.assert_called_once()
@@ -91,7 +45,7 @@ class TestDeadlineReminderGuard:
 
     @pytest.mark.django_db
     def test_eliminated_player_not_reminded(self, phase_factory, classical_england_nation):
-        phase_factory(
+        phase = phase_factory(
             scheduled_resolution=timezone.now() + timedelta(minutes=30),
             phase_states_config=[
                 {"nation": classical_england_nation, "has_possible_orders": False, "orders_confirmed": False},
@@ -99,7 +53,7 @@ class TestDeadlineReminderGuard:
         )
 
         with patch("phase.models.emit") as mock_emit:
-            result = Phase.objects.send_deadline_warnings()
+            result = Phase.objects.send_deadline_warning(phase.id)
 
         assert result["notifications_sent"] == 0
         mock_emit.assert_not_called()
@@ -108,8 +62,6 @@ class TestDeadlineReminderGuard:
     def test_fixed_time_game_reminds_players_with_orders(
         self, phase_factory, classical_variant, classical_england_nation, classical_edinburgh_province
     ):
-        from game.models import Game
-
         game = Game.objects.create(
             variant=classical_variant,
             name="Fixed Time Game",
@@ -126,7 +78,48 @@ class TestDeadlineReminderGuard:
         phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
 
         with patch("phase.models.emit") as mock_emit:
-            result = Phase.objects.send_deadline_warnings()
+            result = Phase.objects.send_deadline_warning(phase.id)
 
         assert result["notifications_sent"] == 1
         mock_emit.assert_called_once()
+
+    @pytest.mark.django_db
+    def test_completed_phase_is_skipped(self, phase_factory, classical_england_nation, classical_edinburgh_province):
+        phase = phase_factory(
+            scheduled_resolution=timezone.now() + timedelta(minutes=30),
+            status=PhaseStatus.COMPLETED,
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
+
+        with patch("phase.models.emit") as mock_emit:
+            result = Phase.objects.send_deadline_warning(phase.id)
+
+        assert result["notifications_sent"] == 0
+        mock_emit.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_passed_deadline_is_skipped(self, phase_factory, classical_england_nation, classical_edinburgh_province):
+        phase = phase_factory(
+            scheduled_resolution=timezone.now() - timedelta(minutes=1),
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+        phase.units.create(type=UnitType.ARMY, nation=classical_england_nation, province=classical_edinburgh_province)
+
+        with patch("phase.models.emit") as mock_emit:
+            result = Phase.objects.send_deadline_warning(phase.id)
+
+        assert result["notifications_sent"] == 0
+        mock_emit.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_missing_phase_is_skipped(self):
+        with patch("phase.models.emit") as mock_emit:
+            result = Phase.objects.send_deadline_warning(999999)
+
+        assert result["notifications_sent"] == 0
+        mock_emit.assert_not_called()

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -1193,7 +1193,7 @@ class TestCreateFromAdjudicationDataPerformance:
 
         query_count = len(connection.queries)
 
-        assert query_count == 21
+        assert query_count == 22
 
     @pytest.mark.django_db
     def test_create_from_adjudication_data_query_count_with_full_game(
@@ -4559,7 +4559,7 @@ class TestSendDeadlineWarnings:
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
         germany_ps.orders.create(source=italy_vs_germany_kiel_province, order_type=OrderType.HOLD)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         assert mock_send_notification_to_users.call_count == 2
         body = mock_send_notification_to_users.call_args_list[0].kwargs["body"]
@@ -4582,7 +4582,7 @@ class TestSendDeadlineWarnings:
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
         germany_ps.orders.create(source=italy_vs_germany_kiel_province, order_type=OrderType.HOLD)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_not_called()
 
@@ -4602,7 +4602,7 @@ class TestSendDeadlineWarnings:
         italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True)
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -4622,7 +4622,7 @@ class TestSendDeadlineWarnings:
         add_italy_germany_units(phase)
         phase.phase_states.create(member=italy, has_possible_orders=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -4641,7 +4641,7 @@ class TestSendDeadlineWarnings:
         add_italy_germany_units(phase)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_not_called()
 
@@ -4659,7 +4659,7 @@ class TestSendDeadlineWarnings:
         italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -4683,7 +4683,7 @@ class TestSendDeadlineWarnings:
         italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
         italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -4703,106 +4703,12 @@ class TestSendDeadlineWarnings:
         add_italy_germany_units(phase)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
         assert "no orders given" in call_kwargs["body"]
         assert "stop waiting for you" in call_kwargs["body"]
-
-    @pytest.mark.django_db
-    def test_second_call_does_not_resend(
-        self,
-        deadline_warning_game_factory,
-        add_italy_germany_units,
-        mock_send_notification_to_users,
-    ):
-        now = timezone.now()
-        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.DURATION, now + timedelta(minutes=10))
-        add_italy_germany_units(phase)
-        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
-
-        Phase.objects.send_deadline_warnings()
-        Phase.objects.send_deadline_warnings()
-
-        assert mock_send_notification_to_users.call_count == 1
-
-    @pytest.mark.django_db
-    def test_marker_set_to_scheduled_resolution_after_send(
-        self,
-        deadline_warning_game_factory,
-        add_italy_germany_units,
-        mock_send_notification_to_users,
-    ):
-        now = timezone.now()
-        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.DURATION, now + timedelta(minutes=10))
-        add_italy_germany_units(phase)
-        ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
-
-        Phase.objects.send_deadline_warnings()
-
-        ps.refresh_from_db()
-        assert ps.deadline_warning_sent_for == phase.scheduled_resolution
-
-    @pytest.mark.django_db
-    def test_deadline_extension_sends_fresh_warning(
-        self,
-        deadline_warning_game_factory,
-        add_italy_germany_units,
-        mock_send_notification_to_users,
-    ):
-        now = timezone.now()
-        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.DURATION, now + timedelta(hours=1))
-        game.movement_phase_duration = "48 hours"
-        game.save()
-        add_italy_germany_units(phase)
-        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
-
-        Phase.objects.send_deadline_warnings()
-        assert mock_send_notification_to_users.call_count == 1
-
-        game.status = GameStatus.ACTIVE
-        game.save()
-        game.extend_deadline("1 hour")
-
-        Phase.objects.send_deadline_warnings()
-        assert mock_send_notification_to_users.call_count == 2
-
-    @pytest.mark.django_db
-    def test_deadline_move_after_nmr_extension_sends_fresh_warning(
-        self,
-        deadline_warning_game_factory,
-        add_italy_germany_units,
-        mock_send_notification_to_users,
-    ):
-        now = timezone.now()
-        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.DURATION, now + timedelta(hours=1))
-        game.movement_phase_duration = "48 hours"
-        game.save()
-        add_italy_germany_units(phase)
-        italy.nmr_extensions_remaining = 1
-        italy.save()
-        ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
-
-        def _deadline_warning_count():
-            return len([
-                c for c in mock_send_notification_to_users.call_args_list
-                if c.kwargs.get("notification_type") == "deadline_warning"
-            ])
-
-        Phase.objects.send_deadline_warnings()
-        assert _deadline_warning_count() == 1
-        ps.refresh_from_db()
-        assert ps.deadline_warning_sent_for == phase.scheduled_resolution
-
-        Phase.objects._check_and_apply_nmr_extensions(phase)
-
-        phase.refresh_from_db()
-        phase.scheduled_resolution = now + timedelta(minutes=30)
-        phase.save()
-
-        Phase.objects.send_deadline_warnings()
-        assert _deadline_warning_count() == 2
 
     @pytest.mark.django_db
     def test_fixed_time_no_orders_with_extensions_shows_extension_message(
@@ -4819,7 +4725,7 @@ class TestSendDeadlineWarnings:
         phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
         assert "deadline will extend" in call_kwargs["body"]
@@ -4838,7 +4744,7 @@ class TestSendDeadlineWarnings:
         phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
         assert "stop waiting for you" in call_kwargs["body"]
@@ -4858,7 +4764,7 @@ class TestSendDeadlineWarnings:
         phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
         assert "deadline will extend" in call_kwargs["body"]
@@ -4877,7 +4783,7 @@ class TestSendDeadlineWarnings:
         phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
         assert "stop waiting for you" in call_kwargs["body"]
@@ -4892,7 +4798,7 @@ class TestSendDeadlineWarnings:
         game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
         phase.phase_states.create(member=italy, has_possible_orders=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_not_called()
 
@@ -4928,7 +4834,7 @@ class TestSendDeadlineWarnings:
         phase.supply_centers.create(province=italy_vs_germany_venice_province, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_not_called()
 
@@ -4974,7 +4880,7 @@ class TestSendDeadlineWarnings:
             source=dislodged_unit.province, order_type=OrderType.MOVE, target=italy_vs_germany_rome_province
         )
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -5017,7 +4923,7 @@ class TestSendDeadlineWarnings:
         phase.supply_centers.create(province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs
@@ -5062,7 +4968,7 @@ class TestSendDeadlineWarnings:
         phase.supply_centers.create(province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation)
         phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=False)
 
-        Phase.objects.send_deadline_warnings()
+        Phase.objects.send_deadline_warning(phase.id)
 
         mock_send_notification_to_users.assert_called_once()
         call_kwargs = mock_send_notification_to_users.call_args.kwargs

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -16,6 +16,27 @@ def format_time_remaining(seconds):
     return "less than a minute"
 
 
+WARNING_THRESHOLDS = {
+    3600: 900,
+    12 * 3600: 3600,
+    24 * 3600: 3600,
+    48 * 3600: 7200,
+    72 * 3600: 7200,
+    96 * 3600: 7200,
+    168 * 3600: 14400,
+    336 * 3600: 14400,
+}
+
+
+def deadline_warning_offset(duration_seconds):
+    if not duration_seconds:
+        return 3600
+    for phase_duration, warning in sorted(WARNING_THRESHOLDS.items()):
+        if duration_seconds <= phase_duration:
+            return warning
+    return 14400
+
+
 def format_deadline(dt, tz_name=None):
     if tz_name:
         try:


### PR DESCRIPTION
## What this PR does

Closes #1073. Replaces the every-minute `phase.send_deadline_warnings` cron sweep with a per-phase job armed at `scheduled_resolution - threshold`, re-armed when the deadline or status changes and evaluated at fire time — mirroring the existing phase-resolution arming.

Because recipients are evaluated when the job fires (not when it's armed), confirm / unconfirm / extension all "just work" with no per-player cancellation, which lets the old per-player `deadline_warning_sent_for` dedup marker go away entirely.

Changes:
- Add `Phase.warning_job_id` (migration `0017`) and drop the now-unused `PhaseState.deadline_warning_sent_for` field.
- Move the warning-threshold table out of the sweep into `phase.utils.deadline_warning_offset`, which the arm computation owns.
- Add `arm_deadline_warning` alongside `arm_deadline_resolution`, both dispatched from a single `arm_deadline_jobs` post_save receiver that cancels and re-arms each job on change.
- Add the `phase.send_deadline_warning(phase_id)` task + manager method, which evaluates recipients at fire time (`has_possible_orders`, not confirmed, active) and emits `deadline_warning`.
- Delete the periodic sweep task and the `send_deadline_warnings` manager method. The resolution canary sweep (`sweep_due_phases`) is untouched.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — N/A, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018trT4XjJMoto7uxYkafSBp)_