### PR TITLE
Record select_orders eval baseline and document running evals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,31 @@ inference. Persona/roster → bot_profile. If you want to eval something in
 agent, a reasoning decision has leaked out of harness. If you want a plain
 deterministic assertion in harness, that logic belongs in agent.
 
+### Running the harness evals
+
+The `select_orders` evals run against the real model via a management command
+(`service/`):
+
+```bash
+python manage.py run_evals              # full dataset, model/key from settings
+python manage.py run_evals --limit 1    # quick smoke run
+python manage.py run_evals --model anthropic/claude-...   # override model
+```
+
+It needs `BOT_ANTHROPIC_API_KEY` set (model defaults to `BOT_LLM_MODEL`); it
+prints a skip line and exits if the key is missing. Each eval hits the LLM
+provider, so it costs real tokens.
+
+**Permission policy:** running a single epoch (the default — one pass over the
+dataset) is fine without asking. Do **not** run multiple epochs (each sample
+repeated N times) unless the user explicitly asks — that multiplies model calls
+and cost. When asked for multiple epochs, invoke `inspect_ai.eval(...)` with
+`epochs=N` directly (the command exposes no `--epochs` flag).
+
+The latest recorded baseline lives in
+`service/harness/tasks/select_orders/EVAL_RESULTS.md` — update it when you take
+a new baseline run.
+
 ---
 
 ## Development Setup

--- a/service/harness/tasks/select_orders/EVAL_RESULTS.md
+++ b/service/harness/tasks/select_orders/EVAL_RESULTS.md
@@ -1,0 +1,25 @@
+# select_orders eval results
+
+Latest recorded run of the `select_orders` harness evals. Update this file when
+a new baseline run is taken.
+
+- **Date:** 2026-07-28
+- **Model:** `anthropic/claude-haiku-4-5`
+- **Epochs:** 100
+- **Samples:** 1000 completed (10 dataset samples × 100 epochs)
+- **Command:** `python manage.py run_evals` (epochs=100 supplied ad hoc)
+
+| Scorer | Metric | Value | Stderr |
+|---|---|---|---|
+| legality | accuracy | 0.9920 | 0.0036 |
+| deduplication | accuracy | 0.9920 | 0.0036 |
+| coverage | accuracy | 0.9770 | 0.0101 |
+| support_coherence | accuracy | 0.9360 | 0.0542 |
+| convoy_coherence | accuracy | 0.9920 | 0.0036 |
+| quality_strong | ranked_accuracy | 0.0000 | 0.1315 |
+| quality_avoidance | ranked_accuracy | 0.0000 | 0.1304 |
+
+The legality and coherence scorers are strong (0.94–0.99). The two `quality_*`
+scorers report 0.0000 ranked_accuracy — investigate before treating this as a
+true quality signal (the ranked scorers may be degenerating rather than
+reflecting genuinely poor ordering).


### PR DESCRIPTION
## What this PR does

Captures the current `select_orders` eval outcome as a checked-in record and documents how to run the harness evals in future sessions. Adds `service/harness/tasks/select_orders/EVAL_RESULTS.md` with the latest run (epochs=100, `claude-haiku-4-5`, 1000 completed samples), and adds a "Running the harness evals" subsection to `CLAUDE.md` covering the `run_evals` command, its API-key requirement, and a permission policy: a single epoch (the default) may be run without asking, but multiple epochs need an explicit user request since they multiply model calls and cost.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, docs/record-only change
- [ ] Tests cover the change — n/a, no code changed; adds a markdown record and CLAUDE.md guidance only
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bEAnnWs5kprtz5s4Gb9ny

---
_Generated by [Claude Code](https://claude.ai/code/session_016bEAnnWs5kprtz5s4Gb9ny)_