### PR TITLE
Fix select_orders quality scorers reporting degenerate 0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,30 @@ The latest recorded baseline lives in
 `service/harness/tasks/select_orders/EVAL_RESULTS.md` — update it when you take
 a new baseline run.
 
+The `quality_strong`/`quality_avoidance` scorers only aggregate over dataset
+samples that declare `ranked_options` (a `good`/`neutral`/`bad` labelling of the
+legal moves); every other sample is `Score.unscored()` (NaN) and excluded. Those
+two scorers are the only ones that measure judgement rather than legality, so a
+new eval only bites if it carries `ranked_options`.
+
+### Harvesting eval candidates from real games
+
+`dump_phase` (in `agent`) turns a live game phase into eval raw material:
+
+```bash
+python manage.py dump_phase --game <id> --out phase_dumps
+cd packages/web
+npx vite-node scripts/render-phase.mjs ../../service/phase_dumps/<prefix>_render.json /tmp/board.png
+```
+
+It writes a board `RenderState` JSON (render it to a PNG with `render-phase.mjs`
+to eyeball what the bots did) plus one `select_orders` fixture stub per nation.
+Turn a bad decision into an eval by adding a `ranked_options` block to a stub —
+what the bot should have done under `good`, the mistake under `bad` — and
+appending it to `dataset.json`. Order *options* only exist for a game's current
+phase, so a resolved/historical phase (`--phase <id>`) is render-only. Output
+lives in the gitignored `phase_dumps/`.
+
 ---
 
 ## Development Setup

--- a/service/harness/tasks/select_orders/EVAL_RESULTS.md
+++ b/service/harness/tasks/select_orders/EVAL_RESULTS.md
@@ -5,29 +5,32 @@ a new baseline run is taken.
 
 - **Date:** 2026-07-28
 - **Model:** `anthropic/claude-haiku-4-5`
-- **Epochs:** 1 (single-epoch smoke run)
-- **Samples:** 10 dataset samples
-- **Command:** `python manage.py run_evals`
+- **Epochs:** 100
+- **Samples:** 1000 completed (10 dataset samples × 100 epochs)
+- **Command:** `inspect_ai.eval(select_orders(), epochs=100)` (the `run_evals`
+  command exposes no `--epochs` flag)
 
 | Scorer | Metric | Value | Stderr |
 |---|---|---|---|
-| legality | accuracy | 1.0000 | 0.0000 |
-| deduplication | accuracy | 1.0000 | 0.0000 |
-| coverage | accuracy | 1.0000 | 0.0000 |
-| support_coherence | accuracy | 0.9000 | 0.1000 |
-| convoy_coherence | accuracy | 1.0000 | 0.0000 |
-| quality_strong | accuracy | 0.7500 | 0.2500 |
-| quality_avoidance | accuracy | 0.5000 | 0.2887 |
+| legality | accuracy | 0.9930 | 0.0026 |
+| deduplication | accuracy | 0.9930 | 0.0026 |
+| coverage | accuracy | 0.9680 | 0.0117 |
+| support_coherence | accuracy | 0.9340 | 0.0583 |
+| convoy_coherence | accuracy | 0.9930 | 0.0026 |
+| quality_strong | accuracy | 0.7350 | 0.1439 |
+| quality_avoidance | accuracy | 0.5800 | 0.2390 |
 
-The two `quality_*` scorers now report a real signal. They previously showed a
-degenerate `0.0000 ranked_accuracy`: the custom `ranked_accuracy` metric filtered
-`NOANSWER` and compared against the string label `CORRECT`, but inspect reduces
-every score to a float before metrics run (`NOANSWER`/`INCORRECT` → 0.0,
-`CORRECT` → 1.0), so the filter and comparison never matched and the metric
-floored to 0.0. Fixed by scoring un-ranked samples with `Score.unscored()` (the
-NaN sentinel inspect excludes from metrics) and using the standard `accuracy()`
-metric, which then averages over just the ranked samples.
+The two `quality_*` scorers now report a real signal (`quality_strong` 0.74,
+`quality_avoidance` 0.58). They previously showed a degenerate `0.0000
+ranked_accuracy`: the custom `ranked_accuracy` metric filtered `NOANSWER` and
+compared against the string label `CORRECT`, but inspect reduces every score to
+a float before metrics run (`NOANSWER`/`INCORRECT` → 0.0, `CORRECT` → 1.0), so
+the filter and comparison never matched and the metric floored to 0.0. Fixed by
+scoring un-ranked samples with `Score.unscored()` (the NaN sentinel inspect
+excludes from metrics) and using the standard `accuracy()` metric, which then
+averages over just the ranked samples.
 
-This is a single-epoch smoke run — only 4 of the 10 samples carry
-`ranked_options`, so the `quality_*` values are low-N and noisy. Take a
-multi-epoch run for a stable baseline.
+Only 4 of the 10 dataset samples carry `ranked_options`, so the `quality_*`
+stderr stays high (fixture-level variance dominates): the model reliably finds
+the strong order in some positions and reliably misses it in others. Adding more
+ranked fixtures — e.g. via the `dump_phase` harvesting loop — will tighten these.

--- a/service/harness/tasks/select_orders/EVAL_RESULTS.md
+++ b/service/harness/tasks/select_orders/EVAL_RESULTS.md
@@ -5,21 +5,29 @@ a new baseline run is taken.
 
 - **Date:** 2026-07-28
 - **Model:** `anthropic/claude-haiku-4-5`
-- **Epochs:** 100
-- **Samples:** 1000 completed (10 dataset samples × 100 epochs)
-- **Command:** `python manage.py run_evals` (epochs=100 supplied ad hoc)
+- **Epochs:** 1 (single-epoch smoke run)
+- **Samples:** 10 dataset samples
+- **Command:** `python manage.py run_evals`
 
 | Scorer | Metric | Value | Stderr |
 |---|---|---|---|
-| legality | accuracy | 0.9920 | 0.0036 |
-| deduplication | accuracy | 0.9920 | 0.0036 |
-| coverage | accuracy | 0.9770 | 0.0101 |
-| support_coherence | accuracy | 0.9360 | 0.0542 |
-| convoy_coherence | accuracy | 0.9920 | 0.0036 |
-| quality_strong | ranked_accuracy | 0.0000 | 0.1315 |
-| quality_avoidance | ranked_accuracy | 0.0000 | 0.1304 |
+| legality | accuracy | 1.0000 | 0.0000 |
+| deduplication | accuracy | 1.0000 | 0.0000 |
+| coverage | accuracy | 1.0000 | 0.0000 |
+| support_coherence | accuracy | 0.9000 | 0.1000 |
+| convoy_coherence | accuracy | 1.0000 | 0.0000 |
+| quality_strong | accuracy | 0.7500 | 0.2500 |
+| quality_avoidance | accuracy | 0.5000 | 0.2887 |
 
-The legality and coherence scorers are strong (0.94–0.99). The two `quality_*`
-scorers report 0.0000 ranked_accuracy — investigate before treating this as a
-true quality signal (the ranked scorers may be degenerating rather than
-reflecting genuinely poor ordering).
+The two `quality_*` scorers now report a real signal. They previously showed a
+degenerate `0.0000 ranked_accuracy`: the custom `ranked_accuracy` metric filtered
+`NOANSWER` and compared against the string label `CORRECT`, but inspect reduces
+every score to a float before metrics run (`NOANSWER`/`INCORRECT` → 0.0,
+`CORRECT` → 1.0), so the filter and comparison never matched and the metric
+floored to 0.0. Fixed by scoring un-ranked samples with `Score.unscored()` (the
+NaN sentinel inspect excludes from metrics) and using the standard `accuracy()`
+metric, which then averages over just the ranked samples.
+
+This is a single-epoch smoke run — only 4 of the 10 samples carry
+`ranked_options`, so the `quality_*` values are low-N and noisy. Take a
+multi-epoch run for a stable baseline.

--- a/service/harness/tasks/select_orders/scorers/quality.py
+++ b/service/harness/tasks/select_orders/scorers/quality.py
@@ -1,18 +1,7 @@
-from inspect_ai.scorer import CORRECT, INCORRECT, NOANSWER, Metric, SampleScore, Score, Target, metric, scorer, stderr
+from inspect_ai.scorer import CORRECT, INCORRECT, Score, Target, accuracy, scorer, stderr
 
 from harness.tasks.select_orders.options import describe_option, same_option
 from harness.tasks.select_orders.scorers._resolve import resolve_orders
-
-
-@metric
-def ranked_accuracy() -> Metric:
-    def compute(scores: list[SampleScore]) -> float:
-        ranked = [s for s in scores if s.score.value != NOANSWER]
-        if not ranked:
-            return 0.0
-        return sum(1.0 for s in ranked if s.score.value == CORRECT) / len(ranked)
-
-    return compute
 
 
 def _ranked(state, key: str) -> list | None:
@@ -22,12 +11,12 @@ def _ranked(state, key: str) -> list | None:
     return ranked_options.get(key) or None
 
 
-@scorer(metrics=[ranked_accuracy(), stderr()])
+@scorer(metrics=[accuracy(), stderr()])
 def quality_strong():
     async def score(state, target: Target) -> Score:
         good = _ranked(state, "good")
         if good is None:
-            return Score(value=NOANSWER, explanation="fixture declares no strong orders")
+            return Score.unscored(explanation="fixture declares no strong orders")
 
         orders, context, failure = resolve_orders(state)
         if failure is not None:
@@ -47,12 +36,12 @@ def quality_strong():
     return score
 
 
-@scorer(metrics=[ranked_accuracy(), stderr()])
+@scorer(metrics=[accuracy(), stderr()])
 def quality_avoidance():
     async def score(state, target: Target) -> Score:
         bad = _ranked(state, "bad")
         if bad is None:
-            return Score(value=NOANSWER, explanation="fixture declares no weak orders")
+            return Score.unscored(explanation="fixture declares no weak orders")
 
         orders, context, failure = resolve_orders(state)
         if failure is not None:

--- a/service/harness/tests.py
+++ b/service/harness/tests.py
@@ -1,11 +1,17 @@
 import json
+import math
 
 import pytest
+from inspect_ai import Task
+from inspect_ai import eval as inspect_eval
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.model import ModelOutput, get_model
 from inspect_ai.scorer import CORRECT, INCORRECT, Target
+from inspect_ai.solver import generate
 
 from common.constants import OrderType
 
-from harness.adapter import data_to_fixture, fixture_to_data
+from harness.adapter import data_to_fixture, fixture_to_context, fixture_to_data
 from harness.exceptions import ContextError, FixtureError, ParsingError
 from harness.tasks.reply.parser import parse_completion as parse_reply
 from harness.tasks.reply.user_prompt import user_prompt as reply_user_prompt
@@ -15,6 +21,8 @@ from harness.tasks.select_orders.scorers import (
     coverage,
     deduplication,
     legality,
+    quality_avoidance,
+    quality_strong,
     support_coherence,
 )
 
@@ -341,3 +349,80 @@ class TestDataToFixture:
             member["is_current_user"] = False
         with pytest.raises(FixtureError):
             data_to_fixture(data, fixture_id="harvested_case")
+
+
+def _quality_fixture(fixture_id="quality", ranked=True):
+    fixture = {
+        "id": fixture_id,
+        "variant": "classical",
+        "nation": "England",
+        "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+        "units": [{"type": "Army", "nation": "England", "province": "lon"}],
+        "supply_centers": [{"nation": "England", "province": "lon"}],
+        "order_options": [
+            {"source": "lon", "order_type": "Hold", "target": "lon"},
+            {"source": "lon", "order_type": "Move", "target": "eng"},
+        ],
+    }
+    if ranked:
+        fixture["ranked_options"] = {
+            "good": [{"source": "lon", "order_type": "Hold", "target": "lon"}],
+            "neutral": [],
+            "bad": [{"source": "lon", "order_type": "Move", "target": "eng"}],
+        }
+    return fixture
+
+
+class TestQualityScorers:
+
+    def _state(self, fixture, choices):
+        state = _FakeState(_completion(choices), fixture_to_context(fixture))
+        state.metadata["ranked_options"] = fixture.get("ranked_options")
+        return state
+
+    def test_selecting_good_order_is_strong_correct(self):
+        assert _run(quality_strong, self._state(_quality_fixture(), [("lon", 0)])).value == CORRECT
+
+    def test_missing_good_order_is_strong_incorrect(self):
+        assert _run(quality_strong, self._state(_quality_fixture(), [("lon", 1)])).value == INCORRECT
+
+    def test_selecting_bad_order_is_avoidance_incorrect(self):
+        assert _run(quality_avoidance, self._state(_quality_fixture(), [("lon", 1)])).value == INCORRECT
+
+    def test_avoiding_bad_order_is_avoidance_correct(self):
+        assert _run(quality_avoidance, self._state(_quality_fixture(), [("lon", 0)])).value == CORRECT
+
+    def test_fixture_without_ranked_options_is_unscored(self):
+        state = self._state(_quality_fixture(ranked=False), [("lon", 0)])
+        for scorer_factory in (quality_strong, quality_avoidance):
+            value = _run(scorer_factory, state).value
+            assert isinstance(value, float) and math.isnan(value)
+
+
+class TestQualityMetricAggregation:
+
+    def _sample(self, fixture):
+        return Sample(
+            id=fixture["id"],
+            input="ignored",
+            metadata={"context": fixture_to_context(fixture), "ranked_options": fixture.get("ranked_options")},
+        )
+
+    def test_accuracy_covers_ranked_samples_and_skips_the_rest(self, tmp_path):
+        good_pick = _completion([("lon", 0)])
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=lambda *args, **kwargs: ModelOutput.from_content("mockllm/model", good_pick),
+        )
+        dataset = MemoryDataset(
+            [
+                self._sample(_quality_fixture("ranked", ranked=True)),
+                self._sample(_quality_fixture("unranked", ranked=False)),
+            ]
+        )
+        task = Task(dataset=dataset, solver=generate(), scorer=[quality_strong(), quality_avoidance()])
+        log = inspect_eval(task, model=model, display="none", log_dir=str(tmp_path))[0]
+
+        metrics = {score.name: score.metrics["accuracy"].value for score in log.results.scores}
+        assert metrics["quality_strong"] == 1.0
+        assert metrics["quality_avoidance"] == 1.0


### PR DESCRIPTION
## What this PR does

The `quality_strong` / `quality_avoidance` scorers — the only two that measure order-selection *judgement* rather than legality — always reported `0.0000`, so the eval was blind to whether a bot picked a good or bad move.

**Root cause:** the custom `ranked_accuracy` metric filtered `NOANSWER` and compared score values against the `CORRECT` string label. But inspect **reduces every score to a float before metrics run** (`value_to_float`: `NOANSWER`/`INCORRECT` → `0.0`, `CORRECT` → `1.0`), even at `epochs=1`. So `s.score.value != NOANSWER` was always true (a float is never `'N'`) and `s.score.value == CORRECT` was always false (a float is never `'C'`) → the metric floored to `0.0` regardless of the model's actual picks. The per-sample scores were correct all along (verified in the inspect log); only the aggregation was broken.

**Fix:**
- Score samples without `ranked_options` via `Score.unscored()` — the NaN sentinel inspect documents as excluded from metrics and reducers — instead of `Score(value=NOANSWER)`.
- Use the standard `accuracy()` metric, which then averages over just the ranked samples.

**New 100-epoch baseline** (1000 samples) recorded in `EVAL_RESULTS.md`, replacing the degenerate quality rows: `quality_strong 0.735`, `quality_avoidance 0.580` — a real signal. Their stderr stays wide because only 4 of the 10 dataset samples carry `ranked_options`; adding more (via the `dump_phase` harvesting loop) will tighten them.

Also documents the now-working harvest → label → measure eval loop (`dump_phase` → `render-phase.mjs` → add `ranked_options` → `dataset.json`) in CLAUDE.md.

## Checklist

- [x] This PR does one thing — the scorer fix, its tests, the refreshed baseline, and the loop guidance the fix completes
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — unit tests for both scorers (good→correct, bad→incorrect, avoided→correct, no-`ranked_options`→unscored) plus an end-to-end `mockllm` test that exercises the reduce-then-metric pipeline the bug lived in and asserts a non-zero aggregate
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a: no web-app UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWJcaV8KbfeKMSxa8VYtCb