### PR TITLE
Run gunicorn with multiple workers and threads in production

### DIFF
--- a/service/entrypoint.sh
+++ b/service/entrypoint.sh
@@ -58,4 +58,8 @@ print("Superuser created successfully")
 EOF
 
 echo "Starting Gunicorn..."
-exec gunicorn project.wsgi:application --bind 0.0.0.0:8000
+exec gunicorn project.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers "${GUNICORN_WORKERS:-2}" \
+    --threads "${GUNICORN_THREADS:-4}" \
+    --timeout "${GUNICORN_TIMEOUT:-60}"


### PR DESCRIPTION
## What this PR does

Production runs gunicorn with no `--workers`/`--threads` flags (`service/entrypoint.sh`), so it defaults to a **single sync worker that processes one request at a time**. This PR runs 2 workers × 4 threads by default, tunable via `GUNICORN_WORKERS`, `GUNICORN_THREADS`, and `GUNICORN_TIMEOUT`.

### Why

Investigating slow endpoints in Honeycomb (`diplicity-service`, last 7 days) showed the latency is **wait time, not query or serialization time**:

- `GET games/` — P50 483ms, P95 1065ms, max 2824ms
- `GET games/<id>/channels/` — P50 105ms but P99 303ms, max 966ms
- Several other game endpoints have P95/P99 well above the ~200ms target

Opening the slowest traces: the slowest channels request (966ms) does **3 SQL queries totalling ~11ms**, and the first query doesn't start until ~902ms into the request. The slowest `games/` request (2824ms) runs all its serializer spans in the last ~21ms. The DB and app code are fast — the time is spent queueing.

A single sync worker can only handle one request at a time, so the ~5–6 API calls each game screen fires in parallel stack up behind each other. Setting `--threads > 1` selects the `gthread` worker class, which is well suited to Django's I/O-bound (DB-waiting) request profile.

This is the first of two changes from the investigation; a follow-up will address per-request DB connection handling (no `conn_max_age`/pooling on the `DATABASE_CONNECTION_STRING` settings branch).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change — n/a, this is a process-launch config change in `entrypoint.sh` (not unit-testable); validated with `sh -n`
- [x] Screenshots embedded in the PR description for any visual changes — n/a, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K3KJZVyZowo9XnqGdbiGg

---
_Generated by [Claude Code](https://claude.ai/code/session_019K3KJZVyZowo9XnqGdbiGg)_