### PR TITLE
Show offline-specific UI instead of generic crash screen when disconnected

### DIFF
--- a/packages/web/android/app/capacitor.build.gradle
+++ b/packages/web/android/app/capacitor.build.gradle
@@ -11,6 +11,7 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-firebase-messaging')
     implementation project(':capacitor-app')
+    implementation project(':capacitor-network')
     implementation project(':capacitor-splash-screen')
     implementation project(':capgo-capacitor-social-login')
 

--- a/packages/web/android/capacitor.settings.gradle
+++ b/packages/web/android/capacitor.settings.gradle
@@ -8,6 +8,9 @@ project(':capacitor-firebase-messaging').projectDir = new File('../node_modules/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-network'
+project(':capacitor-network').projectDir = new File('../node_modules/@capacitor/network/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 

--- a/packages/web/ios/App/CapApp-SPM/Package.swift
+++ b/packages/web/ios/App/CapApp-SPM/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.1.0"),
         .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/@capacitor-firebase/messaging"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorNetwork", path: "../../../node_modules/@capacitor/network"),
         .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
         .package(name: "CapgoCapacitorSocialLogin", path: "../../../node_modules/@capgo/capacitor-social-login")
     ],
@@ -25,6 +26,7 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorFirebaseMessaging", package: "CapacitorFirebaseMessaging"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorNetwork", package: "CapacitorNetwork"),
                 .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
                 .product(name: "CapgoCapacitorSocialLogin", package: "CapgoCapacitorSocialLogin")
             ]

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/app": "^8.0.1",
         "@capacitor/core": "^8.1.0",
         "@capacitor/ios": "^8.1.0",
+        "@capacitor/network": "^8.0.1",
         "@capacitor/splash-screen": "^8.0.1",
         "@capgo/capacitor-social-login": "^8.3.6",
         "@fontsource/roboto": "^5.1.0",
@@ -500,6 +501,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.1.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/splash-screen": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.6",
+  "version": "1.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,6 +28,7 @@
     "@capacitor/app": "^8.0.1",
     "@capacitor/core": "^8.1.0",
     "@capacitor/ios": "^8.1.0",
+    "@capacitor/network": "^8.0.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capgo/capacitor-social-login": "^8.3.6",
     "@fontsource/roboto": "^5.1.0",

--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -24,6 +24,7 @@ import { useIsMobile } from "./hooks/use-mobile";
 import { getVariantsListQueryOptions } from "./api/generated/endpoints";
 import * as Sentry from "@sentry/react";
 import { deepLinkStorage, useDeepLink } from "./deepLink";
+import { isNetworkError } from "./utils/network";
 
 const RouteFallback: React.FC = () => (
   <div className="flex-1 flex items-center justify-center">
@@ -35,7 +36,7 @@ const RootErrorBoundary: React.FC = () => {
   const error = useRouteError() as Error;
 
   React.useEffect(() => {
-    if (error) {
+    if (error && !isNetworkError(error)) {
       Sentry.captureException(error);
     }
   }, [error]);

--- a/packages/web/src/components/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary.tsx
@@ -3,13 +3,21 @@ import * as Sentry from "@sentry/react";
 import { DiplicityLogo } from "./DiplicityLogo";
 import { Button } from "@/components/ui/button";
 import { SafeAreaView } from "@/components/SafeAreaView";
+import { OfflineNotice } from "./OfflineNotice";
 import { isStaleChunkError, reloadForStaleChunk } from "@/utils/staleChunk";
+import { isNetworkError } from "@/utils/network";
+
+const reloadApp = () => window.location.reload();
 
 interface ErrorFallbackUIProps {
   error: Error;
 }
 
 export const ErrorFallbackUI: React.FC<ErrorFallbackUIProps> = ({ error }) => {
+  if (isNetworkError(error)) {
+    return <OfflineNotice fullScreen onRetry={reloadApp} />;
+  }
+
   return (
     <div className="max-w-sm mx-auto">
       <SafeAreaView className="flex flex-col items-center justify-center min-h-screen text-center gap-6">

--- a/packages/web/src/components/GameDetailLayout.tsx
+++ b/packages/web/src/components/GameDetailLayout.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Navigation } from "@/components/Navigation";
 import { GameMap } from "@/components/GameMap";
 import { SafeAreaView } from "@/components/SafeAreaView";
+import { OfflineBanner } from "@/components/OfflineBanner";
 import { useGameRetrieve } from "@/api/generated/endpoints";
 
 const navigationItems = [
@@ -119,6 +120,7 @@ const GameDetailLayout: React.FC<GameDetailLayoutProps> = ({
           className
         )}
       >
+        <OfflineBanner />
         <div className="flex items-stretch flex-1 min-h-0 w-full">
           {/* Left Sidebar - Icons only */}
           <Sidebar collapsible="none" className="hidden md:flex w-14">

--- a/packages/web/src/components/HomeLayout.tsx
+++ b/packages/web/src/components/HomeLayout.tsx
@@ -17,6 +17,7 @@ import { DiplicityLogo } from "@/components/DiplicityLogo";
 import { Navigation } from "@/components/Navigation";
 import { SidebarUserArea } from "@/components/SidebarUserArea";
 import { SafeAreaView } from "@/components/SafeAreaView";
+import { OfflineBanner } from "@/components/OfflineBanner";
 import { Home, Search, PlusCircle, MessageCircle, CircleHelp } from "lucide-react";
 
 const navigationItems = [
@@ -74,6 +75,7 @@ const HomeLayout: React.FC<HomeLayoutProps> = ({ children, className }) => {
           className
         )}
       >
+        <OfflineBanner />
         <div className="flex items-stretch flex-1 min-h-0 w-full">
           {/* Left Sidebar - ShadCN Sidebar with collapsible functionality */}
           <Sidebar collapsible="icon">

--- a/packages/web/src/components/OfflineBanner.test.tsx
+++ b/packages/web/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OfflineBanner } from "./OfflineBanner";
+
+const mockUseNetworkStatus = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useNetworkStatus: () => mockUseNetworkStatus(),
+}));
+
+describe("OfflineBanner", () => {
+  beforeEach(() => {
+    mockUseNetworkStatus.mockReset();
+  });
+
+  it("shows the offline message when offline", () => {
+    mockUseNetworkStatus.mockReturnValue(false);
+    render(<OfflineBanner />);
+    expect(screen.getByText("No internet connection")).toBeInTheDocument();
+  });
+
+  it("renders nothing when online", () => {
+    mockUseNetworkStatus.mockReturnValue(true);
+    const { container } = render(<OfflineBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/components/OfflineBanner.tsx
+++ b/packages/web/src/components/OfflineBanner.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { WifiOff } from "lucide-react";
+import { useNetworkStatus } from "@/hooks";
+
+const OfflineBanner: React.FC = () => {
+  const online = useNetworkStatus();
+
+  if (online) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-2 border-b bg-muted px-4 py-2 text-sm text-muted-foreground">
+      <WifiOff className="size-4" />
+      No internet connection
+    </div>
+  );
+};
+
+export { OfflineBanner };

--- a/packages/web/src/components/OfflineNotice.test.tsx
+++ b/packages/web/src/components/OfflineNotice.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OfflineNotice } from "./OfflineNotice";
+
+const mockUseNetworkStatus = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useNetworkStatus: () => mockUseNetworkStatus(),
+}));
+
+describe("OfflineNotice", () => {
+  beforeEach(() => {
+    mockUseNetworkStatus.mockReset();
+    mockUseNetworkStatus.mockReturnValue(false);
+  });
+
+  it("retries when the user taps Try Again", async () => {
+    const onRetry = vi.fn();
+    render(<OfflineNotice onRetry={onRetry} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries automatically when the connection returns", () => {
+    const onRetry = vi.fn();
+    const { rerender } = render(<OfflineNotice onRetry={onRetry} />);
+    expect(onRetry).not.toHaveBeenCalled();
+
+    mockUseNetworkStatus.mockReturnValue(true);
+    rerender(<OfflineNotice onRetry={onRetry} />);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when it mounts already online", () => {
+    mockUseNetworkStatus.mockReturnValue(true);
+    const onRetry = vi.fn();
+    render(<OfflineNotice onRetry={onRetry} />);
+
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("renders the full-screen variant heading", () => {
+    render(<OfflineNotice onRetry={vi.fn()} fullScreen />);
+    expect(
+      screen.getByRole("heading", { name: "No internet connection" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/OfflineNotice.tsx
+++ b/packages/web/src/components/OfflineNotice.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { WifiOff } from "lucide-react";
+import { DiplicityLogo } from "./DiplicityLogo";
+import { Button } from "@/components/ui/button";
+import { SafeAreaView } from "@/components/SafeAreaView";
+import { Notice } from "@/components/Notice";
+import { useNetworkStatus } from "@/hooks";
+
+interface OfflineNoticeProps {
+  onRetry: () => void;
+  fullScreen?: boolean;
+}
+
+const OfflineNotice: React.FC<OfflineNoticeProps> = ({ onRetry, fullScreen }) => {
+  const online = useNetworkStatus();
+  const wasOffline = React.useRef(!online);
+
+  React.useEffect(() => {
+    if (online && wasOffline.current) {
+      onRetry();
+    }
+    wasOffline.current = !online;
+  }, [online, onRetry]);
+
+  if (fullScreen) {
+    return (
+      <div className="max-w-sm mx-auto">
+        <SafeAreaView className="flex flex-col items-center justify-center min-h-screen text-center gap-6">
+          <DiplicityLogo />
+          <h1 className="text-2xl font-bold">No internet connection</h1>
+          <p className="text-muted-foreground">
+            Diplicity needs a connection to load. Check your connection and try
+            again.
+          </p>
+          <Button variant="outline" onClick={onRetry}>
+            Try Again
+          </Button>
+        </SafeAreaView>
+      </div>
+    );
+  }
+
+  return (
+    <Notice
+      icon={WifiOff}
+      title="No internet connection"
+      message="Check your connection and try again."
+      actions={<Button onClick={onRetry}>Try Again</Button>}
+    />
+  );
+};
+
+export { OfflineNotice };

--- a/packages/web/src/components/QueryErrorBoundary.tsx
+++ b/packages/web/src/components/QueryErrorBoundary.tsx
@@ -3,6 +3,8 @@ import { useQueryErrorResetBoundary } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react";
 import { Button } from "@/components/ui/button";
 import { Notice } from "@/components/Notice";
+import { OfflineNotice } from "@/components/OfflineNotice";
+import { isNetworkError } from "@/utils/network";
 import { AlertCircle } from "lucide-react";
 
 interface QueryErrorFallbackProps {
@@ -14,6 +16,14 @@ const QueryErrorFallback: React.FC<QueryErrorFallbackProps> = ({
   error,
   onReset,
 }) => {
+  if (isNetworkError(error)) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8">
+        <OfflineNotice onRetry={onReset} />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center justify-center p-8">
       <Notice
@@ -55,7 +65,9 @@ class ErrorBoundaryClass extends Component<
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryClassState {
-    Sentry.captureException(error);
+    if (!isNetworkError(error)) {
+      Sentry.captureException(error);
+    }
     return { hasError: true, error };
   }
 

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useDraft } from "./useDraft";
+export { useNetworkStatus } from "./useNetworkStatus";
 export { useRequiredParams } from "./useRequiredParams";

--- a/packages/web/src/hooks/useNetworkStatus.ts
+++ b/packages/web/src/hooks/useNetworkStatus.ts
@@ -12,7 +12,7 @@ export const useNetworkStatus = (): boolean => {
     });
 
     const handle = Network.addListener("networkStatusChange", (status) => {
-      setOnline(status.connected);
+      if (active) setOnline(status.connected);
     });
 
     return () => {

--- a/packages/web/src/hooks/useNetworkStatus.ts
+++ b/packages/web/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { Network } from "@capacitor/network";
+
+export const useNetworkStatus = (): boolean => {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    Network.getStatus().then((status) => {
+      if (active) setOnline(status.connected);
+    });
+
+    const handle = Network.addListener("networkStatusChange", (status) => {
+      setOnline(status.connected);
+    });
+
+    return () => {
+      active = false;
+      handle.then((listener) => listener.remove());
+    };
+  }, []);
+
+  return online;
+};

--- a/packages/web/src/utils/network.test.ts
+++ b/packages/web/src/utils/network.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { AxiosError } from "axios";
+import { isNetworkError } from "./network";
+
+describe("isNetworkError", () => {
+  it("returns true for an axios network error", () => {
+    expect(
+      isNetworkError(new AxiosError("Network Error", AxiosError.ERR_NETWORK))
+    ).toBe(true);
+  });
+
+  it("returns false for an axios error with a response code", () => {
+    expect(
+      isNetworkError(new AxiosError("Not Found", AxiosError.ERR_BAD_REQUEST))
+    ).toBe(false);
+  });
+
+  it("returns false for a non-axios error", () => {
+    expect(isNetworkError(new Error("Network Error"))).toBe(false);
+  });
+
+  it("returns false for a non-error value", () => {
+    expect(isNetworkError("offline")).toBe(false);
+  });
+});

--- a/packages/web/src/utils/network.ts
+++ b/packages/web/src/utils/network.ts
@@ -1,0 +1,4 @@
+import { AxiosError } from "axios";
+
+export const isNetworkError = (error: unknown): boolean =>
+  error instanceof AxiosError && error.code === AxiosError.ERR_NETWORK;


### PR DESCRIPTION
## What this PR does

When the app can't reach the API while offline (reproduced on the iOS Capacitor build in airplane mode), every failure surfaced the generic full-screen "Something went wrong / We've been notified of the issue" crash screen. That message is untrue for a connectivity problem — nothing is reported and there's nothing for the team to fix — and it offered no real way out (the "Go Home" button reloaded the same network-dependent route, re-erroring).

This detects connectivity failures (axios `ERR_NETWORK`) and the live connection status, and shows honest, recoverable offline UI instead:

- **Full-screen offline notice** replaces the crash screen when the app can't load at all (the root route loader failing on `GET /variants/` is what produced the reported screenshot), with a **Try Again** action.
- **Inline offline notice** in `QueryErrorBoundary` for per-screen load failures, keeping the screen header/chrome visible.
- **Persistent "No internet connection" banner** in the authenticated app shell (`HomeLayout`, `GameDetailLayout`) while offline — the indicator for a mid-session drop where cached content is still on screen.
- **Auto-retry when the connection returns** (reload for the full-screen case, query reset for the inline case).
- **Connectivity failures are no longer reported to Sentry** (`RootErrorBoundary` and `QueryErrorBoundary`), removing noise from an expected condition.

We deliberately do **not** add offline mode (caching, queued mutations) — the game state is server-authoritative. This only improves the messaging and recovery.

Connection status is read through `@capacitor/network` rather than `navigator.onLine`, which is unreliable inside the iOS WKWebView. The plugin has a web implementation too, so the banner works on the web build as well. The native plugin manifests (`Package.swift`, Android gradle files) were regenerated by `npx cap sync`.

Also **bumps the version to 1.5.7** (`package.json`) so a new iOS build can be cut to TestFlight for on-device testing — Fastlane sources `MARKETING_VERSION` from that field.

### Key files

- `src/hooks/useNetworkStatus.ts` — live connection status via `@capacitor/network`
- `src/utils/network.ts` — `isNetworkError` (axios `ERR_NETWORK`)
- `src/components/OfflineNotice.tsx` — shared offline UI (full-screen + inline), auto-retry on reconnect
- `src/components/OfflineBanner.tsx` — persistent shell banner
- `ErrorBoundary.tsx`, `QueryErrorBoundary.tsx`, `Router.tsx` — branch to offline UI, skip Sentry

## Screenshots

_Mobile (390×844), captured against `dev:mocks` with connectivity failures simulated. To be dragged into this description:_

1. **Full-screen offline** — replaces the reported "Something went wrong" screen.
2. **Inline offline** — a screen whose content query fails while offline (header + nav preserved).
3. **Persistent banner** — "No internet connection" over already-loaded content (My Games, and in-game).

## Checklist

- [x] This PR does one thing — offline-messaging UX, plus the version bump needed to ship it for device testing
- [x] Self-reviewed the diff (the `/review-pr` skill shells out to `gh`, which isn't configured in this remote environment, so the review was run independently rather than via that command)
- [x] Tests cover the change (`network.test.ts`, `OfflineNotice.test.tsx`, `OfflineBanner.test.tsx`; full suite 539 passing)
- [ ] Screenshots embedded — captured and delivered; need to be attached to this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ES4CXZscBKfJtHiVszyRpZ