### PR TITLE
Add S1901M opening-order sampler and blunder ledger

### DIFF
--- a/service/harness/management/commands/sample_openings.py
+++ b/service/harness/management/commands/sample_openings.py
@@ -13,7 +13,7 @@ from harness.adapter import fixture_to_context
 from harness.exceptions import ParsingError
 from harness.tasks.select_orders import parse_completion, system_prompt, user_prompt
 from harness.tasks.select_orders.options import describe_option
-from harness.tasks.select_orders.scorers.coherence import dangling
+from harness.tasks.select_orders.scorers.coherence import MOVEMENT_TYPES, dangling
 
 OPENINGS_DIR = Path(__file__).resolve().parents[2] / "tasks" / "select_orders" / "openings" / "s1901m"
 
@@ -30,6 +30,10 @@ def _order_str(order, context, unit_types):
 def _flags(orders):
     sources = {order["source"] for order in orders}
     flags = [f"hold:{order['source']}" for order in orders if order["order_type"] == "Hold"]
+    move_targets = Counter(
+        order["target"] for order in orders if order["order_type"] in MOVEMENT_TYPES and order["target"]
+    )
+    flags += [f"self_bounce:{dest}" for dest, count in move_targets.items() if count >= 2]
     for order_type, own_label, foreign_label in (
         ("Support", "dangling_support", "support_foreign"),
         ("Convoy", "dangling_convoy", "convoy_foreign"),

--- a/service/harness/management/commands/sample_openings.py
+++ b/service/harness/management/commands/sample_openings.py
@@ -1,0 +1,139 @@
+import asyncio
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+
+from harness.adapter import fixture_to_context
+from harness.exceptions import ParsingError
+from harness.tasks.select_orders import parse_completion, system_prompt, user_prompt
+from harness.tasks.select_orders.options import describe_option
+from harness.tasks.select_orders.scorers.coherence import dangling
+
+OPENINGS_DIR = Path(__file__).resolve().parents[2] / "tasks" / "select_orders" / "openings" / "s1901m"
+
+
+def _unit_types(context):
+    return {unit["province"]: ("A" if unit["type"] == "Army" else "F") for unit in context["units"]}
+
+
+def _order_str(order, context, unit_types):
+    prefix = unit_types.get(order["source"], "?")
+    return f"{prefix} {order['source']} {describe_option(order, context)}"
+
+
+def _flags(orders):
+    flags = [f"hold:{order['source']}" for order in orders if order["order_type"] == "Hold"]
+    flags += [f"dangling_support:{aux}" for aux, _target, _actual in dangling(orders, "Support")]
+    flags += [f"dangling_convoy:{aux}" for aux, _target, _actual in dangling(orders, "Convoy")]
+    return flags
+
+
+def ledger_for_nation(context, completions):
+    unit_types = _unit_types(context)
+    joint = Counter()
+    representative = {}
+    marginals = {}
+    unparseable = 0
+
+    for completion in completions:
+        try:
+            orders = parse_completion(completion, context)
+        except ParsingError:
+            unparseable += 1
+            continue
+        key = tuple(sorted(_order_str(order, context, unit_types) for order in orders))
+        joint[key] += 1
+        representative.setdefault(key, orders)
+        for order in orders:
+            marginals.setdefault(order["source"], Counter())[_order_str(order, context, unit_types)] += 1
+
+    scored = sum(joint.values())
+    order_sets = [
+        {
+            "count": count,
+            "share": round(count / scored, 3) if scored else 0.0,
+            "orders": list(key),
+            "flags": _flags(representative[key]),
+        }
+        for key, count in joint.most_common()
+    ]
+    unit_marginals = {
+        source: [
+            {"order": order, "count": count, "share": round(count / scored, 3) if scored else 0.0}
+            for order, count in counts.most_common()
+        ]
+        for source, counts in marginals.items()
+    }
+    return {
+        "samples": len(completions),
+        "unparseable": unparseable,
+        "order_sets": order_sets,
+        "unit_marginals": unit_marginals,
+    }
+
+
+class Command(BaseCommand):
+    help = (
+        "Sample select_orders many times per nation on the fixed classical S1901M opening "
+        "and write a ledger of the order distributions (with mechanical-blunder flags)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--samples", type=int, default=50, help="samples per nation")
+        parser.add_argument("--model", default=f"anthropic/{settings.BOT_LLM_MODEL}")
+        parser.add_argument("--concurrency", type=int, default=8)
+        parser.add_argument("--out", default="phase_dumps/opening_ledger.json")
+
+    def handle(self, *args, **options):
+        if not settings.BOT_ANTHROPIC_API_KEY:
+            self.stdout.write("skip: BOT_ANTHROPIC_API_KEY is not set")
+            return
+        os.environ.setdefault("ANTHROPIC_API_KEY", settings.BOT_ANTHROPIC_API_KEY)
+
+        fixtures = sorted(OPENINGS_DIR.glob("*.json"))
+        if not fixtures:
+            self.stderr.write(f"no opening fixtures in {OPENINGS_DIR}")
+            return
+
+        model = get_model(options["model"])
+        nations = {}
+        for path in fixtures:
+            fixture = json.loads(path.read_text())
+            context = fixture_to_context(fixture)
+            completions = asyncio.run(
+                self._sample(model, context, options["samples"], options["concurrency"])
+            )
+            nations[fixture["nation"]] = ledger_for_nation(context, completions)
+            self.stdout.write(f"sampled {fixture['nation']}: {len(completions)} completion(s)")
+
+        ledger = {
+            "meta": {
+                "position": "classical Spring 1901 Movement",
+                "model": options["model"],
+                "samples_per_nation": options["samples"],
+                "persona": None,
+            },
+            "nations": nations,
+        }
+        out = Path(options["out"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(ledger, indent=2) + "\n")
+        self.stdout.write(f"wrote {out}")
+
+    async def _sample(self, model, context, samples, concurrency):
+        system = system_prompt(context)
+        user = user_prompt(context)
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def one():
+            async with semaphore:
+                output = await model.generate([ChatMessageSystem(content=system), ChatMessageUser(content=user)])
+                return output.completion
+
+        return await asyncio.gather(*[one() for _ in range(samples)])

--- a/service/harness/management/commands/sample_openings.py
+++ b/service/harness/management/commands/sample_openings.py
@@ -28,9 +28,15 @@ def _order_str(order, context, unit_types):
 
 
 def _flags(orders):
+    sources = {order["source"] for order in orders}
     flags = [f"hold:{order['source']}" for order in orders if order["order_type"] == "Hold"]
-    flags += [f"dangling_support:{aux}" for aux, _target, _actual in dangling(orders, "Support")]
-    flags += [f"dangling_convoy:{aux}" for aux, _target, _actual in dangling(orders, "Convoy")]
+    for order_type, own_label, foreign_label in (
+        ("Support", "dangling_support", "support_foreign"),
+        ("Convoy", "dangling_convoy", "convoy_foreign"),
+    ):
+        for aux, _target, _actual in dangling(orders, order_type):
+            label = own_label if aux in sources else foreign_label
+            flags.append(f"{label}:{aux}")
     return flags
 
 

--- a/service/harness/tasks/select_orders/openings/s1901m/austria.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/austria.json
@@ -1,0 +1,400 @@
+{
+  "id": "s1901m_austria",
+  "variant": "classical",
+  "nation": "Austria",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "bud",
+      "order_type": "Hold"
+    },
+    {
+      "source": "bud",
+      "order_type": "Move",
+      "target": "gal"
+    },
+    {
+      "source": "bud",
+      "order_type": "Move",
+      "target": "rum"
+    },
+    {
+      "source": "bud",
+      "order_type": "Move",
+      "target": "ser"
+    },
+    {
+      "source": "bud",
+      "order_type": "Move",
+      "target": "tri"
+    },
+    {
+      "source": "bud",
+      "order_type": "Move",
+      "target": "vie"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "rum",
+      "aux": "sev"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "tri"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "ven"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "vie"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "vie"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "vie",
+      "aux": "vie"
+    },
+    {
+      "source": "bud",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "war"
+    },
+    {
+      "source": "tri",
+      "order_type": "Hold"
+    },
+    {
+      "source": "tri",
+      "order_type": "Move",
+      "target": "adr"
+    },
+    {
+      "source": "tri",
+      "order_type": "Move",
+      "target": "alb"
+    },
+    {
+      "source": "tri",
+      "order_type": "Move",
+      "target": "ven"
+    },
+    {
+      "source": "tri",
+      "order_type": "Support",
+      "target": "ven",
+      "aux": "rom"
+    },
+    {
+      "source": "tri",
+      "order_type": "Support",
+      "target": "ven",
+      "aux": "ven"
+    },
+    {
+      "source": "vie",
+      "order_type": "Hold"
+    },
+    {
+      "source": "vie",
+      "order_type": "Move",
+      "target": "boh"
+    },
+    {
+      "source": "vie",
+      "order_type": "Move",
+      "target": "bud"
+    },
+    {
+      "source": "vie",
+      "order_type": "Move",
+      "target": "gal"
+    },
+    {
+      "source": "vie",
+      "order_type": "Move",
+      "target": "tri"
+    },
+    {
+      "source": "vie",
+      "order_type": "Move",
+      "target": "tyr"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "bud",
+      "aux": "bud"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "bud"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "bud"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "boh",
+      "aux": "mun"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "mun"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "tri"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "ven"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "ven"
+    },
+    {
+      "source": "vie",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "war"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), Austria. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/england.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/england.json
@@ -1,0 +1,371 @@
+{
+  "id": "s1901m_england",
+  "variant": "classical",
+  "nation": "England",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "edi",
+      "order_type": "Hold"
+    },
+    {
+      "source": "edi",
+      "order_type": "Move",
+      "target": "cly"
+    },
+    {
+      "source": "edi",
+      "order_type": "Move",
+      "target": "nrg"
+    },
+    {
+      "source": "edi",
+      "order_type": "Move",
+      "target": "nth"
+    },
+    {
+      "source": "edi",
+      "order_type": "Move",
+      "target": "yor"
+    },
+    {
+      "source": "edi",
+      "order_type": "Support",
+      "target": "nth",
+      "aux": "lon"
+    },
+    {
+      "source": "edi",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "lon"
+    },
+    {
+      "source": "edi",
+      "order_type": "Support",
+      "target": "cly",
+      "aux": "lvp"
+    },
+    {
+      "source": "edi",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "lvp"
+    },
+    {
+      "source": "lon",
+      "order_type": "Hold"
+    },
+    {
+      "source": "lon",
+      "order_type": "Move",
+      "target": "eng"
+    },
+    {
+      "source": "lon",
+      "order_type": "Move",
+      "target": "nth"
+    },
+    {
+      "source": "lon",
+      "order_type": "Move",
+      "target": "wal"
+    },
+    {
+      "source": "lon",
+      "order_type": "Move",
+      "target": "yor"
+    },
+    {
+      "source": "lon",
+      "order_type": "Support",
+      "target": "eng",
+      "aux": "bre"
+    },
+    {
+      "source": "lon",
+      "order_type": "Support",
+      "target": "nth",
+      "aux": "edi"
+    },
+    {
+      "source": "lon",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "edi"
+    },
+    {
+      "source": "lon",
+      "order_type": "Support",
+      "target": "wal",
+      "aux": "lvp"
+    },
+    {
+      "source": "lon",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "lvp"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Hold"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Move",
+      "target": "cly"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Move",
+      "target": "edi"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Move",
+      "target": "wal"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Move",
+      "target": "yor"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Support",
+      "target": "cly",
+      "aux": "edi"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Support",
+      "target": "edi",
+      "aux": "edi"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "edi"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Support",
+      "target": "wal",
+      "aux": "lon"
+    },
+    {
+      "source": "lvp",
+      "order_type": "Support",
+      "target": "yor",
+      "aux": "lon"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), England. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/france.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/france.json
@@ -1,0 +1,377 @@
+{
+  "id": "s1901m_france",
+  "variant": "classical",
+  "nation": "France",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "bre",
+      "order_type": "Hold"
+    },
+    {
+      "source": "bre",
+      "order_type": "Move",
+      "target": "eng"
+    },
+    {
+      "source": "bre",
+      "order_type": "Move",
+      "target": "gas"
+    },
+    {
+      "source": "bre",
+      "order_type": "Move",
+      "target": "mid"
+    },
+    {
+      "source": "bre",
+      "order_type": "Move",
+      "target": "pic"
+    },
+    {
+      "source": "bre",
+      "order_type": "Support",
+      "target": "eng",
+      "aux": "lon"
+    },
+    {
+      "source": "bre",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "mar"
+    },
+    {
+      "source": "bre",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "par"
+    },
+    {
+      "source": "bre",
+      "order_type": "Support",
+      "target": "pic",
+      "aux": "par"
+    },
+    {
+      "source": "mar",
+      "order_type": "Hold"
+    },
+    {
+      "source": "mar",
+      "order_type": "Move",
+      "target": "bur"
+    },
+    {
+      "source": "mar",
+      "order_type": "Move",
+      "target": "gas"
+    },
+    {
+      "source": "mar",
+      "order_type": "Move",
+      "target": "pie"
+    },
+    {
+      "source": "mar",
+      "order_type": "Move",
+      "target": "spa"
+    },
+    {
+      "source": "mar",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "bre"
+    },
+    {
+      "source": "mar",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "mun"
+    },
+    {
+      "source": "mar",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "par"
+    },
+    {
+      "source": "mar",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "par"
+    },
+    {
+      "source": "mar",
+      "order_type": "Support",
+      "target": "pie",
+      "aux": "ven"
+    },
+    {
+      "source": "par",
+      "order_type": "Hold"
+    },
+    {
+      "source": "par",
+      "order_type": "Move",
+      "target": "bre"
+    },
+    {
+      "source": "par",
+      "order_type": "Move",
+      "target": "bur"
+    },
+    {
+      "source": "par",
+      "order_type": "Move",
+      "target": "gas"
+    },
+    {
+      "source": "par",
+      "order_type": "Move",
+      "target": "pic"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "bre",
+      "aux": "bre"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "bre"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "pic",
+      "aux": "bre"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "mar"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "gas",
+      "aux": "mar"
+    },
+    {
+      "source": "par",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "mun"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), France. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/germany.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/germany.json
@@ -1,0 +1,421 @@
+{
+  "id": "s1901m_germany",
+  "variant": "classical",
+  "nation": "Germany",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "ber",
+      "order_type": "Hold"
+    },
+    {
+      "source": "ber",
+      "order_type": "Move",
+      "target": "kie"
+    },
+    {
+      "source": "ber",
+      "order_type": "Move",
+      "target": "mun"
+    },
+    {
+      "source": "ber",
+      "order_type": "Move",
+      "target": "pru"
+    },
+    {
+      "source": "ber",
+      "order_type": "Move",
+      "target": "sil"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "kie",
+      "aux": "kie"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "kie",
+      "aux": "mun"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "mun",
+      "aux": "mun"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "mun"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "pru",
+      "aux": "war"
+    },
+    {
+      "source": "ber",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "war"
+    },
+    {
+      "source": "kie",
+      "order_type": "Hold"
+    },
+    {
+      "source": "kie",
+      "order_type": "Move",
+      "target": "bal"
+    },
+    {
+      "source": "kie",
+      "order_type": "Move",
+      "target": "ber"
+    },
+    {
+      "source": "kie",
+      "order_type": "Move",
+      "target": "den"
+    },
+    {
+      "source": "kie",
+      "order_type": "Move",
+      "target": "hel"
+    },
+    {
+      "source": "kie",
+      "order_type": "Move",
+      "target": "hol"
+    },
+    {
+      "source": "kie",
+      "order_type": "Support",
+      "target": "ber",
+      "aux": "ber"
+    },
+    {
+      "source": "kie",
+      "order_type": "Support",
+      "target": "ber",
+      "aux": "mun"
+    },
+    {
+      "source": "mun",
+      "order_type": "Hold"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "ber"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "boh"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "bur"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "kie"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "ruh"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "sil"
+    },
+    {
+      "source": "mun",
+      "order_type": "Move",
+      "target": "tyr"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "ber",
+      "aux": "ber"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "kie",
+      "aux": "ber"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "ber"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "ber",
+      "aux": "kie"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "kie",
+      "aux": "kie"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "mar"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "bur",
+      "aux": "par"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "ven"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "boh",
+      "aux": "vie"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "vie"
+    },
+    {
+      "source": "mun",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "war"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), Germany. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/italy.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/italy.json
@@ -1,0 +1,423 @@
+{
+  "id": "s1901m_italy",
+  "variant": "classical",
+  "nation": "Italy",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "nap",
+      "order_type": "Hold"
+    },
+    {
+      "source": "nap",
+      "order_type": "Move",
+      "target": "apu"
+    },
+    {
+      "source": "nap",
+      "order_type": "Move",
+      "target": "ion"
+    },
+    {
+      "source": "nap",
+      "order_type": "Move",
+      "target": "rom"
+    },
+    {
+      "source": "nap",
+      "order_type": "Move",
+      "target": "tys"
+    },
+    {
+      "source": "nap",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "rom"
+    },
+    {
+      "source": "nap",
+      "order_type": "Support",
+      "target": "rom",
+      "aux": "rom"
+    },
+    {
+      "source": "nap",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "ven"
+    },
+    {
+      "source": "nap",
+      "order_type": "Support",
+      "target": "rom",
+      "aux": "ven"
+    },
+    {
+      "source": "rom",
+      "order_type": "Hold"
+    },
+    {
+      "source": "rom",
+      "order_type": "Move",
+      "target": "apu"
+    },
+    {
+      "source": "rom",
+      "order_type": "Move",
+      "target": "nap"
+    },
+    {
+      "source": "rom",
+      "order_type": "Move",
+      "target": "tus"
+    },
+    {
+      "source": "rom",
+      "order_type": "Move",
+      "target": "ven"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "nap"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "nap",
+      "aux": "nap"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "ven",
+      "aux": "tri"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "ven"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "tus",
+      "aux": "ven"
+    },
+    {
+      "source": "rom",
+      "order_type": "Support",
+      "target": "ven",
+      "aux": "ven"
+    },
+    {
+      "source": "ven",
+      "order_type": "Hold"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "apu"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "pie"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "rom"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "tri"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "tus"
+    },
+    {
+      "source": "ven",
+      "order_type": "Move",
+      "target": "tyr"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "bud"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "pie",
+      "aux": "mar"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "mun"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "nap"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "rom",
+      "aux": "nap"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "apu",
+      "aux": "rom"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "rom",
+      "aux": "rom"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tus",
+      "aux": "rom"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "tri"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tri",
+      "aux": "vie"
+    },
+    {
+      "source": "ven",
+      "order_type": "Support",
+      "target": "tyr",
+      "aux": "vie"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), Italy. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/russia.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/russia.json
@@ -1,0 +1,442 @@
+{
+  "id": "s1901m_russia",
+  "variant": "classical",
+  "nation": "Russia",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "mos",
+      "order_type": "Hold"
+    },
+    {
+      "source": "mos",
+      "order_type": "Move",
+      "target": "lvn"
+    },
+    {
+      "source": "mos",
+      "order_type": "Move",
+      "target": "sev"
+    },
+    {
+      "source": "mos",
+      "order_type": "Move",
+      "target": "stp"
+    },
+    {
+      "source": "mos",
+      "order_type": "Move",
+      "target": "ukr"
+    },
+    {
+      "source": "mos",
+      "order_type": "Move",
+      "target": "war"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "sev",
+      "aux": "sev"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "stp"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "stp",
+      "aux": "stp"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "war"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "ukr",
+      "aux": "war"
+    },
+    {
+      "source": "mos",
+      "order_type": "Support",
+      "target": "war",
+      "aux": "war"
+    },
+    {
+      "source": "sev",
+      "order_type": "Hold"
+    },
+    {
+      "source": "sev",
+      "order_type": "Move",
+      "target": "arm"
+    },
+    {
+      "source": "sev",
+      "order_type": "Move",
+      "target": "bla"
+    },
+    {
+      "source": "sev",
+      "order_type": "Move",
+      "target": "rum"
+    },
+    {
+      "source": "sev",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "ank"
+    },
+    {
+      "source": "sev",
+      "order_type": "Support",
+      "target": "bla",
+      "aux": "ank"
+    },
+    {
+      "source": "sev",
+      "order_type": "Support",
+      "target": "rum",
+      "aux": "bud"
+    },
+    {
+      "source": "sev",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "smy"
+    },
+    {
+      "source": "stp",
+      "order_type": "Hold"
+    },
+    {
+      "source": "stp",
+      "order_type": "Move",
+      "target": "bot"
+    },
+    {
+      "source": "stp",
+      "order_type": "Move",
+      "target": "fin"
+    },
+    {
+      "source": "stp",
+      "order_type": "Move",
+      "target": "lvn"
+    },
+    {
+      "source": "stp",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "mos"
+    },
+    {
+      "source": "stp",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "war"
+    },
+    {
+      "source": "war",
+      "order_type": "Hold"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "gal"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "lvn"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "mos"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "pru"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "sil"
+    },
+    {
+      "source": "war",
+      "order_type": "Move",
+      "target": "ukr"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "pru",
+      "aux": "ber"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "ber"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "bud"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "mos"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "mos",
+      "aux": "mos"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "ukr",
+      "aux": "mos"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "sil",
+      "aux": "mun"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "lvn",
+      "aux": "stp"
+    },
+    {
+      "source": "war",
+      "order_type": "Support",
+      "target": "gal",
+      "aux": "vie"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), Russia. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/openings/s1901m/turkey.json
+++ b/service/harness/tasks/select_orders/openings/s1901m/turkey.json
@@ -1,0 +1,361 @@
+{
+  "id": "s1901m_turkey",
+  "variant": "classical",
+  "nation": "Turkey",
+  "phase": {
+    "season": "Spring",
+    "year": 1901,
+    "type": "Movement"
+  },
+  "units": [
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "type": "Army",
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "type": "Fleet",
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "type": "Fleet",
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "type": "Army",
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "type": "Army",
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "type": "Army",
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "type": "Army",
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "stp/sc"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "type": "Army",
+      "nation": "Russia",
+      "province": "war"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "type": "Army",
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "type": "Fleet",
+      "nation": "Turkey",
+      "province": "ank"
+    }
+  ],
+  "supply_centers": [
+    {
+      "nation": "England",
+      "province": "edi"
+    },
+    {
+      "nation": "England",
+      "province": "lvp"
+    },
+    {
+      "nation": "England",
+      "province": "lon"
+    },
+    {
+      "nation": "France",
+      "province": "bre"
+    },
+    {
+      "nation": "France",
+      "province": "par"
+    },
+    {
+      "nation": "France",
+      "province": "mar"
+    },
+    {
+      "nation": "Germany",
+      "province": "kie"
+    },
+    {
+      "nation": "Germany",
+      "province": "ber"
+    },
+    {
+      "nation": "Germany",
+      "province": "mun"
+    },
+    {
+      "nation": "Italy",
+      "province": "ven"
+    },
+    {
+      "nation": "Italy",
+      "province": "rom"
+    },
+    {
+      "nation": "Italy",
+      "province": "nap"
+    },
+    {
+      "nation": "Austria",
+      "province": "tri"
+    },
+    {
+      "nation": "Austria",
+      "province": "vie"
+    },
+    {
+      "nation": "Austria",
+      "province": "bud"
+    },
+    {
+      "nation": "Turkey",
+      "province": "con"
+    },
+    {
+      "nation": "Turkey",
+      "province": "ank"
+    },
+    {
+      "nation": "Turkey",
+      "province": "smy"
+    },
+    {
+      "nation": "Russia",
+      "province": "sev"
+    },
+    {
+      "nation": "Russia",
+      "province": "mos"
+    },
+    {
+      "nation": "Russia",
+      "province": "stp"
+    },
+    {
+      "nation": "Russia",
+      "province": "war"
+    }
+  ],
+  "order_options": [
+    {
+      "source": "ank",
+      "order_type": "Hold"
+    },
+    {
+      "source": "ank",
+      "order_type": "Move",
+      "target": "arm"
+    },
+    {
+      "source": "ank",
+      "order_type": "Move",
+      "target": "bla"
+    },
+    {
+      "source": "ank",
+      "order_type": "Move",
+      "target": "con"
+    },
+    {
+      "source": "ank",
+      "order_type": "Support",
+      "target": "con",
+      "aux": "con"
+    },
+    {
+      "source": "ank",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "sev"
+    },
+    {
+      "source": "ank",
+      "order_type": "Support",
+      "target": "bla",
+      "aux": "sev"
+    },
+    {
+      "source": "ank",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "smy"
+    },
+    {
+      "source": "ank",
+      "order_type": "Support",
+      "target": "con",
+      "aux": "smy"
+    },
+    {
+      "source": "con",
+      "order_type": "Hold"
+    },
+    {
+      "source": "con",
+      "order_type": "Move",
+      "target": "ank"
+    },
+    {
+      "source": "con",
+      "order_type": "Move",
+      "target": "bul"
+    },
+    {
+      "source": "con",
+      "order_type": "Move",
+      "target": "smy"
+    },
+    {
+      "source": "con",
+      "order_type": "Support",
+      "target": "ank",
+      "aux": "ank"
+    },
+    {
+      "source": "con",
+      "order_type": "Support",
+      "target": "ank",
+      "aux": "smy"
+    },
+    {
+      "source": "con",
+      "order_type": "Support",
+      "target": "smy",
+      "aux": "smy"
+    },
+    {
+      "source": "smy",
+      "order_type": "Hold"
+    },
+    {
+      "source": "smy",
+      "order_type": "Move",
+      "target": "ank"
+    },
+    {
+      "source": "smy",
+      "order_type": "Move",
+      "target": "arm"
+    },
+    {
+      "source": "smy",
+      "order_type": "Move",
+      "target": "con"
+    },
+    {
+      "source": "smy",
+      "order_type": "Move",
+      "target": "syr"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "ank",
+      "aux": "ank"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "ank"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "con",
+      "aux": "ank"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "ank",
+      "aux": "con"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "con",
+      "aux": "con"
+    },
+    {
+      "source": "smy",
+      "order_type": "Support",
+      "target": "arm",
+      "aux": "sev"
+    }
+  ],
+  "notes": "Classical opening (Spring 1901 Movement), Turkey. Sampler input; no ranked_options."
+}

--- a/service/harness/tasks/select_orders/system_prompt.py
+++ b/service/harness/tasks/select_orders/system_prompt.py
@@ -7,12 +7,14 @@ the complete list of legal orders available to you this phase, grouped by the pr
 that issues them."""
 
 PRINCIPLES = """Principles for choosing orders:
-- Prefer orders that improve your position to capture supply centres. Avoid dead-end moves \
-into provinces with no supply centre and no follow-up.
-- Only leave a unit holding when you have judged that holding beats every move available to \
-it; an aimless hold wastes the turn.
-- A support is wasted unless it matches an order actually being made this phase — support a \
-unit only for the exact move or hold it is issuing.
+- Move units closer to supply centres you could capture, even when the square you move to \
+has none itself. A move only wastes the turn if it carries a unit away from every centre it \
+could contest or into a corner it cannot advance from.
+- Holding does nothing for a unit's position. Hold only to defend a province genuinely under \
+threat this phase; do not hold merely because no move stands out.
+- Before ordering a support, confirm the unit you are supporting is itself ordered to make \
+exactly that move or hold this phase; a support of an action that is not being taken is \
+wasted.
 - Do not order two of your own units to the same destination unless you have a specific \
 reason; normally they bounce and both accomplish nothing.
 - Support or act for another power's unit only when it advances your own position and \

--- a/service/harness/tasks/select_orders/system_prompt.py
+++ b/service/harness/tasks/select_orders/system_prompt.py
@@ -6,6 +6,19 @@ ROLE = """You are an expert Diplomacy player. You will be given the state of a g
 the complete list of legal orders available to you this phase, grouped by the province \
 that issues them."""
 
+PRINCIPLES = """Principles for choosing orders:
+- Prefer orders that improve your position to capture supply centres. Avoid dead-end moves \
+into provinces with no supply centre and no follow-up.
+- Only leave a unit holding when you have judged that holding beats every move available to \
+it; an aimless hold wastes the turn.
+- A support is wasted unless it matches an order actually being made this phase — support a \
+unit only for the exact move or hold it is issuing.
+- Do not order two of your own units to the same destination unless you have a specific \
+reason; normally they bounce and both accomplish nothing.
+- Support or act for another power's unit only when it advances your own position and \
+follows a coordination you have agreed with them; without such an agreement, a unit spent \
+on a rival's move is spent for their benefit."""
+
 MOVEMENT_TASK = """Select exactly one order for every province listed. A province with no \
 order does nothing, which is almost always worse than the weakest listed alternative."""
 
@@ -42,4 +55,4 @@ def task_instruction(context: Context) -> str:
 
 
 def system_prompt(context: Context) -> str:
-    return "\n\n".join([ROLE, task_instruction(context), FORMAT])
+    return "\n\n".join([ROLE, PRINCIPLES, task_instruction(context), FORMAT])

--- a/service/harness/tests.py
+++ b/service/harness/tests.py
@@ -505,3 +505,25 @@ class TestOpeningLedger:
         ledger = ledger_for_nation(context, ["not json at all", _completion([("lon", 0)])])
         assert ledger["unparseable"] == 1
         assert ledger["samples"] == 2
+
+    def test_flags_self_bounce(self):
+        fixture = {
+            "id": "ledger_bounce",
+            "variant": "classical",
+            "nation": "England",
+            "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+            "units": [
+                {"type": "Fleet", "nation": "England", "province": "edi"},
+                {"type": "Fleet", "nation": "England", "province": "lon"},
+            ],
+            "supply_centers": [{"nation": "England", "province": "lon"}],
+            "order_options": [
+                {"source": "edi", "order_type": "Move", "target": "nth"},
+                {"source": "edi", "order_type": "Hold", "target": "edi"},
+                {"source": "lon", "order_type": "Move", "target": "nth"},
+                {"source": "lon", "order_type": "Hold", "target": "lon"},
+            ],
+        }
+        context = fixture_to_context(fixture)
+        flags = ledger_for_nation(context, [_completion([("edi", 0), ("lon", 0)])])["order_sets"][0]["flags"]
+        assert "self_bounce:nth" in flags

--- a/service/harness/tests.py
+++ b/service/harness/tests.py
@@ -477,10 +477,28 @@ class TestOpeningLedger:
         assert top["flags"] == ["hold:lon"]
         assert ledger["order_sets"][1]["flags"] == []
 
-    def test_flags_dangling_support(self):
+    def test_flags_dangling_support_of_own_unit(self):
         context = fixture_to_context(self._support_fixture())
         ledger = ledger_for_nation(context, [_completion([("kie", 0), ("mun", 1)])])
         assert "dangling_support:mun" in ledger["order_sets"][0]["flags"]
+
+    def test_flags_support_of_foreign_unit_separately(self):
+        fixture = {
+            "id": "ledger_foreign",
+            "variant": "classical",
+            "nation": "Austria",
+            "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+            "units": [{"type": "Fleet", "nation": "Austria", "province": "tri"}],
+            "supply_centers": [{"nation": "Austria", "province": "tri"}],
+            "order_options": [
+                {"source": "tri", "order_type": "Support", "target": "ven", "aux": "ven"},
+                {"source": "tri", "order_type": "Hold", "target": "tri"},
+            ],
+        }
+        context = fixture_to_context(fixture)
+        flags = ledger_for_nation(context, [_completion([("tri", 0)])])["order_sets"][0]["flags"]
+        assert "support_foreign:ven" in flags
+        assert not any(flag.startswith("dangling_support:") for flag in flags)
 
     def test_counts_unparseable_completions(self):
         context = fixture_to_context(self._hold_fixture())

--- a/service/harness/tests.py
+++ b/service/harness/tests.py
@@ -13,6 +13,7 @@ from common.constants import OrderType
 
 from harness.adapter import data_to_fixture, fixture_to_context, fixture_to_data
 from harness.exceptions import ContextError, FixtureError, ParsingError
+from harness.management.commands.sample_openings import ledger_for_nation
 from harness.tasks.reply.parser import parse_completion as parse_reply
 from harness.tasks.reply.user_prompt import user_prompt as reply_user_prompt
 from harness.tasks.select_orders.parser import parse_completion
@@ -426,3 +427,63 @@ class TestQualityMetricAggregation:
         metrics = {score.name: score.metrics["accuracy"].value for score in log.results.scores}
         assert metrics["quality_strong"] == 1.0
         assert metrics["quality_avoidance"] == 1.0
+
+
+class TestOpeningLedger:
+
+    def _hold_fixture(self):
+        return {
+            "id": "ledger",
+            "variant": "classical",
+            "nation": "England",
+            "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+            "units": [{"type": "Army", "nation": "England", "province": "lon"}],
+            "supply_centers": [{"nation": "England", "province": "lon"}],
+            "order_options": [
+                {"source": "lon", "order_type": "Hold", "target": "lon"},
+                {"source": "lon", "order_type": "Move", "target": "wal"},
+            ],
+        }
+
+    def _support_fixture(self):
+        return {
+            "id": "ledger_support",
+            "variant": "classical",
+            "nation": "Germany",
+            "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+            "units": [
+                {"type": "Army", "nation": "Germany", "province": "kie"},
+                {"type": "Army", "nation": "Germany", "province": "mun"},
+            ],
+            "supply_centers": [{"nation": "Germany", "province": "kie"}],
+            "order_options": [
+                {"source": "kie", "order_type": "Support", "target": "mun", "aux": "mun"},
+                {"source": "kie", "order_type": "Hold", "target": "kie"},
+                {"source": "mun", "order_type": "Hold", "target": "mun"},
+                {"source": "mun", "order_type": "Move", "target": "ruh"},
+            ],
+        }
+
+    def test_tallies_joint_sets_and_flags_holds(self):
+        context = fixture_to_context(self._hold_fixture())
+        completions = [_completion([("lon", 0)]), _completion([("lon", 0)]), _completion([("lon", 1)])]
+        ledger = ledger_for_nation(context, completions)
+
+        assert ledger["samples"] == 3
+        top = ledger["order_sets"][0]
+        assert top["orders"] == ["A lon Hold"]
+        assert top["count"] == 2
+        assert top["share"] == 0.667
+        assert top["flags"] == ["hold:lon"]
+        assert ledger["order_sets"][1]["flags"] == []
+
+    def test_flags_dangling_support(self):
+        context = fixture_to_context(self._support_fixture())
+        ledger = ledger_for_nation(context, [_completion([("kie", 0), ("mun", 1)])])
+        assert "dangling_support:mun" in ledger["order_sets"][0]["flags"]
+
+    def test_counts_unparseable_completions(self):
+        context = fixture_to_context(self._hold_fixture())
+        ledger = ledger_for_nation(context, ["not json at all", _completion([("lon", 0)])])
+        assert ledger["unparseable"] == 1
+        assert ledger["samples"] == 2


### PR DESCRIPTION
## What this PR does

A discovery tool for the `select_orders` harness. It samples every nation's **opening** decision many times on the fixed classical S1901M position and tallies the distribution, so that systematic bot blunders surface as frequencies — and a stronger model (or a human) can scan the resulting ledger for judgement errors to fold back as `ranked_options` evals.

Why the opening: S1901M is the same position in every game, so sampling it many times turns the model's nondeterminism (it runs at the default ~temperature 1.0) into a clean per-nation distribution — the one case where the fixed opening is a feature, not a limitation.

**Pieces:**
- `openings/s1901m/<nation>.json` — the seven fixed classical opening contexts (full board units, supply centres, and each nation's legal order options), harvested once via `dump_phase`. The opening never changes, so these are committed as the sampler's input.
- `sample_openings` management command — for each nation, runs `select_orders` N times **without persona** (matching the eval path, isolating the base harness we're improving), parses each completion, and writes a ledger of **joint order-sets** (counts + shares) plus per-unit marginals. Joint, not marginal, because "unmatched support" is a property of the whole order-set — whether a support dangles depends on the co-occurring move.
- Each order-set is annotated with **mechanical-blunder flags** — opening holds and dangling supports/convoys, reusing the existing coherence detector — so the objective mistakes are caught (and quantified) for free, and a judgement pass can focus on the legal-but-bad moves that actually need `ranked_options`.

Ledger output lands in the gitignored `phase_dumps/`. Even a 2-sample smoke run already flagged real blunders (Berlin supporting Kiel while Kiel moves away; an opening Berlin hold).

Intended loop: run the sampler → hand the ledger to a strong model for judgement blunders → add each confirmed one to `dataset.json` as a `ranked_options` fixture → re-run the eval to confirm the bot fails it, then improve the prompt against it.

## Checklist

- [x] This PR does one thing — the opening sampler, its fixtures, and its tests
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — unit tests for the pure ledger logic (joint-set tallying, hold + dangling-support flagging, unparseable counting); the model-calling path is a thin async wrapper
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a: no web-app UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWJcaV8KbfeKMSxa8VYtCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWJcaV8KbfeKMSxa8VYtCb)_