### PR TITLE
Add periodic reconciler to re-drive stalled AgentTasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Governing rule: **harness is pure; agent is where the world touches it.**
   durable record of bot work to be done (kind = plan/finalize/reply): a
   signal creates a pending row and defers the agent.run task, which loads
   the row, transitions its status, and dispatches to the executor. One
-  AgentTask may span several Inference calls.
+  AgentTask may span several Inference calls. A periodic agent.reconcile
+  task re-drives rows whose job was lost or stalled (pending or stuck in
+  running past a timeout), so a hand-inserted row runs on the next sweep.
 - bot_profile — BotProfile persona (disposition, voice), roster-management
   endpoints, get_bot_user, and the roster seed.
 

--- a/service/agent/models.py
+++ b/service/agent/models.py
@@ -1,8 +1,13 @@
+from datetime import timedelta
+
 from django.db import models
 from django.utils import timezone
 
 from agent.constants import AgentTaskKind, AgentTaskStatus
 from common.models import BaseModel
+
+PENDING_RECONCILE_AFTER = timedelta(minutes=2)
+RUNNING_RECONCILE_AFTER = timedelta(minutes=10)
 
 
 class AgentTaskManager(models.Manager):
@@ -15,11 +20,19 @@ class AgentTaskManager(models.Manager):
             defaults={"status": AgentTaskStatus.PENDING},
         )
         if created:
-            # Local import: agent.tasks imports this module at top level.
-            from agent.tasks import run
-
-            run.configure(lock=f"agent-task-{task.id}").defer(agent_task_id=task.id)
+            task.defer()
         return task
+
+    def reconcile(self):
+        now = timezone.now()
+        stalled = self.filter(
+            models.Q(status=AgentTaskStatus.PENDING, created_at__lt=now - PENDING_RECONCILE_AFTER)
+            | models.Q(status=AgentTaskStatus.RUNNING, started_at__lt=now - RUNNING_RECONCILE_AFTER)
+        )
+        tasks = list(stalled)
+        for task in tasks:
+            task.defer()
+        return tasks
 
 
 class AgentTask(BaseModel):
@@ -65,6 +78,12 @@ class AgentTask(BaseModel):
                 name="unique_reply_agent_task",
             ),
         ]
+
+    def defer(self):
+        # Local import: agent.tasks imports this module at top level.
+        from agent.tasks import run
+
+        run.configure(lock=f"agent-task-{self.id}").defer(agent_task_id=self.id)
 
     def mark_running(self):
         self.status = AgentTaskStatus.RUNNING

--- a/service/agent/tasks.py
+++ b/service/agent/tasks.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from procrastinate.contrib.django import app
 
 from agent.api_client import ApiClient, ApiClientError
-from agent.constants import AgentTaskKind
+from agent.constants import AgentTaskKind, AgentTaskStatus
 from agent.context import fetch_context
 from agent.fallback import first_legal_options
 from agent.models import AgentTask
@@ -169,6 +169,9 @@ def run(agent_task_id):
     if task is None:
         logger.error(f"[{label}] no agent task found; skipping")
         return
+    if task.status == AgentTaskStatus.SUCCEEDED:
+        logger.info(f"[{label}] already succeeded; skipping")
+        return
 
     logger.info(f"[{label}] running {task.kind} for member {task.member_id}")
     task.mark_running()
@@ -180,3 +183,11 @@ def run(agent_task_id):
         raise
     task.mark_succeeded()
     logger.info(f"[{label}] completed")
+
+
+@app.periodic(cron="* * * * *")
+@app.task(name="agent.reconcile")
+def reconcile(timestamp):
+    tasks = AgentTask.objects.reconcile()
+    if tasks:
+        logger.info(f"[agent.reconcile] re-drove {len(tasks)} stalled task(s)")

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -1,8 +1,10 @@
 import json
+from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -750,3 +752,66 @@ class TestAgentTaskRun:
 
         assert AgentTask.objects.filter(kind=AgentTaskKind.PLAN, member=bot_member).count() == 1
         assert len(_run_jobs_for(in_memory_procrastinate, task)) == 1
+
+    @pytest.mark.django_db
+    def test_run_skips_already_succeeded_task(self, member_factory, in_memory_procrastinate):
+        task = AgentTask.objects.create(
+            kind=AgentTaskKind.PLAN, member=member_factory(), status=AgentTaskStatus.SUCCEEDED, attempts=1
+        )
+
+        with patch("agent.tasks._dispatch") as dispatch:
+            tasks.run(agent_task_id=task.id)
+            dispatch.assert_not_called()
+
+        task.refresh_from_db()
+        assert task.status == AgentTaskStatus.SUCCEEDED
+        assert task.attempts == 1
+
+
+class TestAgentTaskReconcile:
+
+    @pytest.mark.django_db
+    def test_redrives_stale_pending_task(self, member_factory, in_memory_procrastinate):
+        task = AgentTask.objects.create(kind=AgentTaskKind.PLAN, member=member_factory())
+        AgentTask.objects.filter(pk=task.pk).update(created_at=timezone.now() - timedelta(minutes=5))
+
+        redriven = AgentTask.objects.reconcile()
+
+        assert [t.id for t in redriven] == [task.id]
+        assert len(_run_jobs_for(in_memory_procrastinate, task)) == 1
+
+    @pytest.mark.django_db
+    def test_skips_fresh_pending_task(self, member_factory, in_memory_procrastinate):
+        task = AgentTask.objects.create(kind=AgentTaskKind.PLAN, member=member_factory())
+
+        assert AgentTask.objects.reconcile() == []
+        assert _run_jobs_for(in_memory_procrastinate, task) == []
+
+    @pytest.mark.django_db
+    def test_redrives_stuck_running_task(self, member_factory, in_memory_procrastinate):
+        task = AgentTask.objects.create(
+            kind=AgentTaskKind.PLAN, member=member_factory(), status=AgentTaskStatus.RUNNING
+        )
+        AgentTask.objects.filter(pk=task.pk).update(started_at=timezone.now() - timedelta(minutes=15))
+
+        redriven = AgentTask.objects.reconcile()
+
+        assert [t.id for t in redriven] == [task.id]
+        assert len(_run_jobs_for(in_memory_procrastinate, task)) == 1
+
+    @pytest.mark.django_db
+    def test_skips_recent_running_task(self, member_factory, in_memory_procrastinate):
+        task = AgentTask.objects.create(
+            kind=AgentTaskKind.PLAN, member=member_factory(), status=AgentTaskStatus.RUNNING
+        )
+        AgentTask.objects.filter(pk=task.pk).update(started_at=timezone.now() - timedelta(minutes=1))
+
+        assert AgentTask.objects.reconcile() == []
+
+    @pytest.mark.django_db
+    def test_skips_succeeded_and_failed_tasks(self, member_factory, in_memory_procrastinate):
+        for status_value in (AgentTaskStatus.SUCCEEDED, AgentTaskStatus.FAILED):
+            task = AgentTask.objects.create(kind=AgentTaskKind.PLAN, member=member_factory(), status=status_value)
+            AgentTask.objects.filter(pk=task.pk).update(created_at=timezone.now() - timedelta(minutes=30))
+
+        assert AgentTask.objects.reconcile() == []


### PR DESCRIPTION
## What this PR does

Step 2 of the AgentTask direction (step 1 added the model in #1110). Adds `agent.reconcile`, a per-minute periodic task that re-drives `AgentTask` rows whose queue job never ran or stalled, so bot work is self-healing rather than lost-on-first-failure.

Reconcile re-drives two cases (`AgentTaskManager.reconcile()`):
- **pending** rows older than `PENDING_RECONCILE_AFTER` (2 min) — a job that was lost, or a row inserted by hand;
- **running** rows whose `started_at` is older than `RUNNING_RECONCILE_AFTER` (10 min) — a worker that died mid-run.

This delivers two things from the original discussion: a bot dropped into an abandoned game can be started by inserting a pending `AgentTask` row (it runs on the next sweep — no need to fake a phase-activated signal), and a bot recovers on its own from a transient worker/provider outage.

### Safety

- Re-driving is idempotent: `agent.run` now skips a task already marked `succeeded`, and the existing per-task Procrastinate lock (`agent-task-{id}`) serialises execution, so a duplicate re-drive can't double-act.
- Reconcile deliberately leaves `failed` rows alone (no poison-task loop) — those can be re-driven by hand.
- The queue defer is extracted into `AgentTask.defer()` so `create_from_event` (reactive path) and `reconcile` (safety-net path) share one code path. Reactive creation stays primary; reconcile is the fallback, so normal bot latency is unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: self-reviewed the diff against `main` (the `/review-pr` skill's `gh` dependency isn't wired in this environment, so the review was run manually) — no correctness issues found
- [x] Tests cover the change — reconcile re-drives stale-pending and stuck-running, skips fresh/recent/succeeded/failed; `run` skips already-succeeded
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend-only, no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJpwkPRdgx4u6H2bMchrUk)_