### PR TITLE
Replace an abandoned seat with a new bot member

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,22 @@ appending it to `dataset.json`. Order *options* only exist for a game's current
 phase, so a resolved/historical phase (`--phase <id>`) is render-only. Output
 lives in the gitignored `phase_dumps/`.
 
+### Seating a bot in an abandoned seat
+
+`replace_member_with_bot` (in `agent`) hands a nation over to a roster bot —
+used when a player deletes their account or walks away mid-game:
+
+```bash
+python manage.py replace_member_with_bot --game <id> --nation Italy --bot dealmakerbot
+```
+
+It reassigns the member row to the bot user (keeping the nation, orders, phase
+states and channel memberships), clears `kicked`/`civil_disorder` so the bot can
+act, and queues a `plan` AgentTask for the current phase. An unrecognised
+`--bot` errors with the list of bots still available for that game. A production
+run needs a shell on the deployed service (`railway ssh`), because `railway run`
+executes locally and cannot resolve Railway's internal database host.
+
 ---
 
 ## Development Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,12 +123,24 @@ used when a player deletes their account or walks away mid-game:
 python manage.py replace_member_with_bot --game <id> --nation Italy --bot dealmakerbot
 ```
 
-It reassigns the member row to the bot user (keeping the nation, orders, phase
-states and channel memberships), clears `kicked`/`civil_disorder` so the bot can
-act, and queues a `plan` AgentTask for the current phase. An unrecognised
-`--bot` errors with the list of bots still available for that game. A production
-run needs a shell on the deployed service (`railway ssh`), because `railway run`
-executes locally and cannot resolve Railway's internal database host.
+It creates a *new* member for the bot in the same nation and marks the original
+`kicked`, pointing `replaced_by` at the replacement — the original row is kept so
+its phase states and messages remain attributable for statistics. The
+replacement joins every channel the original was in (the original stays too, so
+its past messages still render with the right sender). On the current phase it
+takes over the phase state, and the original's pending orders are discarded so
+adjudication does not receive two order sets for one nation. Finally it queues a
+`plan` AgentTask so the bot acts in the phase already under way.
+
+A kicked member's phase states are created with `has_possible_orders=False`, which
+keeps a replaced seat out of the "is everyone done?" checks — early resolution
+(`filter_due_phases`), the bot finalize trigger (`when_humans_confirmed`), NMR
+extensions and deadline warnings all key off that flag.
+
+An unrecognised `--bot` errors with the list of bots still available for that
+game. A production run needs a shell on the deployed service (`railway ssh`),
+because `railway run` executes locally and cannot resolve Railway's internal
+database host.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,13 @@ keeps a replaced seat out of the "is everyone done?" checks — early resolution
 (`filter_due_phases`), the bot finalize trigger (`when_humans_confirmed`), NMR
 extensions and deadline warnings all key off that flag.
 
+A replaced player keeps their account, so every write path has to lock them out.
+Orders, order confirmation and draw proposals were already gated on
+`IsActiveGameMember`, which rejects kicked members; chat and civil-disorder
+recovery only checked `IsGameMember` and now use `IsNotKickedGameMember`. Read
+access is deliberately left open — a replaced player can still view the game and
+the channels they were in.
+
 An unrecognised `--bot` errors with the list of bots still available for that
 game. A production run needs a shell on the deployed service (`railway ssh`),
 because `railway run` executes locally and cannot resolve Railway's internal

--- a/packages/web/src/components/GameMap.test.tsx
+++ b/packages/web/src/components/GameMap.test.tsx
@@ -128,7 +128,7 @@ const mockGame = {
   canDelete: false,
   phases: [1],
   currentPhaseId: 1,
-  members: [],
+  members: [] as { nation: string; civilDisorder: boolean; kicked: boolean }[],
   sandbox: false,
   victory: null,
   nationAssignment: "random",
@@ -199,6 +199,13 @@ function getLastOrdersProp(): Order[] {
   return props.orders ?? [];
 }
 
+function getLastCivilDisorderNationsProp(): string[] {
+  const last = mockMapView.mock.calls.at(-1);
+  if (!last) return [];
+  const props = (last[0] as unknown) as { civilDisorderNations: string[] };
+  return props.civilDisorderNations ?? [];
+}
+
 // --- Tests ---
 describe("GameMap", () => {
   beforeAll(() => {
@@ -224,6 +231,19 @@ describe("GameMap", () => {
     mockWizardState = buildIdleWizard();
     mockPublishedVariants = [mockVariant];
     mockRetrievedVariant = undefined;
+    mockGame.members = [];
+  });
+
+  it("stops shading a nation in civil disorder once its member has been replaced", async () => {
+    mockGame.members = [
+      { nation: "England", civilDisorder: true, kicked: true },
+      { nation: "England", civilDisorder: false, kicked: false },
+    ];
+
+    render(gameMapJsx());
+
+    await waitFor(() => expect(mockMapView).toHaveBeenCalled());
+    expect(getLastCivilDisorderNationsProp()).toEqual([]);
   });
 
   it("renders the map using a fetched draft variant when it is absent from the published list", async () => {

--- a/packages/web/src/components/GameMap.tsx
+++ b/packages/web/src/components/GameMap.tsx
@@ -103,7 +103,7 @@ const GameMap: React.FC = () => {
   const civilDisorderNations = useMemo(
     () =>
       (game?.members ?? [])
-        .filter((m) => m.civilDisorder && m.nation)
+        .filter((m) => m.civilDisorder && !m.kicked && m.nation)
         .map((m) => m.nation as string),
     [game?.members]
   );

--- a/packages/web/src/screens/GameDetail/ChannelCreateScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelCreateScreen.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { ChannelCreateScreen } from "./ChannelCreateScreen";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const member = (id: number, nation: string, overrides = {}) => ({
+  id,
+  userId: id,
+  name: `Player ${id}`,
+  picture: null,
+  isCurrentUser: false,
+  isBot: false,
+  commitment: null,
+  nation,
+  eliminated: false,
+  kicked: false,
+  isGameCreator: false,
+  nmrExtensionsRemaining: 0,
+  civilDisorder: false,
+  seekingReplacement: false,
+  replaceable: false,
+  ...overrides,
+});
+
+vi.mock("@/api/generated/endpoints", () => ({
+  useGameRetrieveSuspense: () => ({
+    data: {
+      members: [
+        member(1, "England", { isCurrentUser: true }),
+        member(2, "Italy", { kicked: true, name: "Departed Player" }),
+        member(3, "Italy", { name: "The Dealmaker" }),
+      ],
+    },
+  }),
+  useGamesChannelsCreateCreate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  getGamesChannelsListQueryKey: (gameId: string) => [`/game/${gameId}/channels/`],
+}));
+
+const renderScreen = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter initialEntries={["/game/game-1/phase/1/chat/create"]}>
+        <Routes>
+          <Route
+            path="/game/:gameId/phase/:phaseId/chat/create"
+            element={<ChannelCreateScreen />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+describe("ChannelCreateScreen", () => {
+  it("offers the replacement for a seat but not the member it replaced", () => {
+    renderScreen();
+
+    expect(screen.getByText("The Dealmaker")).toBeInTheDocument();
+    expect(screen.queryByText("Departed Player")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Italy")).toHaveLength(1);
+  });
+});

--- a/packages/web/src/screens/GameDetail/ChannelCreateScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelCreateScreen.tsx
@@ -88,9 +88,9 @@ const ChannelCreateScreen: React.FC = () => {
           <Panel.Content>
             <ItemGroup>
               {game.members
-                .filter(m => !m.isCurrentUser)
+                .filter(m => !m.isCurrentUser && !m.kicked)
                 .map(member => (
-                  <React.Fragment key={member.nation}>
+                  <React.Fragment key={member.id}>
                     <Item
                       className="cursor-pointer hover:bg-accent/50"
                       onClick={() => handleToggle(member.id)}

--- a/packages/web/src/screens/GameDetail/channelUtils.test.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { Channel, Member } from "@/api/generated/endpoints";
+import { getChannelFlagUrls } from "./channelUtils";
+
+const member = (id: number, nation: string, overrides: Partial<Member> = {}) =>
+  ({
+    id,
+    userId: id,
+    name: `Player ${id}`,
+    picture: null,
+    isCurrentUser: false,
+    isBot: false,
+    commitment: null,
+    nation,
+    eliminated: false,
+    kicked: false,
+    isGameCreator: false,
+    nmrExtensionsRemaining: 0,
+    civilDisorder: false,
+    seekingReplacement: false,
+    replaceable: false,
+    ...overrides,
+  }) as Member;
+
+const publicChannel = { id: 1, name: "Public Press", private: false } as Channel;
+
+const variantNations = [
+  { name: "England", flagUrl: "england.svg", color: "#ff0000" },
+  { name: "Italy", flagUrl: "italy.svg", color: "#00ff00" },
+];
+
+describe("getChannelFlagUrls", () => {
+  it("shows one flag per seat when a replaced member still sits in the channel", () => {
+    const members = [
+      member(1, "England"),
+      member(2, "Italy", { kicked: true }),
+      member(3, "Italy"),
+    ];
+
+    expect(
+      getChannelFlagUrls(publicChannel, members, "England", variantNations)
+    ).toEqual([
+      { flagUrl: "england.svg", color: "#ff0000" },
+      { flagUrl: "italy.svg", color: "#00ff00" },
+    ]);
+  });
+
+  it("takes private channel flags from the channel name rather than the member list", () => {
+    const privateChannel = { id: 2, name: "England, Italy", private: true } as Channel;
+
+    expect(
+      getChannelFlagUrls(privateChannel, [], "England", variantNations)
+    ).toEqual([{ flagUrl: "italy.svg", color: "#00ff00" }]);
+  });
+});

--- a/packages/web/src/screens/GameDetail/channelUtils.ts
+++ b/packages/web/src/screens/GameDetail/channelUtils.ts
@@ -42,6 +42,7 @@ export const getChannelFlagUrls = (
   const nationNames = channel.private
     ? channel.name.split(",").map(s => s.trim()).filter(n => n !== currentNationName)
     : members
+        .filter(m => !m.kicked)
         .map(m => m.nation)
         .filter((n): n is string => n !== null);
   return nationNames.map(name => {

--- a/service/agent/management/commands/replace_member_with_bot.py
+++ b/service/agent/management/commands/replace_member_with_bot.py
@@ -4,12 +4,15 @@ from django.db import transaction
 from agent.constants import AgentTaskKind
 from agent.models import AgentTask
 from bot_profile.models import BotProfile
+from channel.models import ChannelMember
 from common.constants import PhaseStatus
 from game.models import Game
+from order.models import Order
+from phase.models import PhaseState
 
 
 class Command(BaseCommand):
-    help = "Seat a bot in a game member's nation, replacing whoever holds it."
+    help = "Replace a game member with a bot, seating the bot in that member's nation."
 
     def add_arguments(self, parser):
         parser.add_argument("--game", required=True, help="game id")
@@ -24,6 +27,8 @@ class Command(BaseCommand):
         member = game.members.filter(nation__name__iexact=options["nation"]).select_related("nation").first()
         if member is None:
             raise CommandError(f"game '{game.id}' has no member for nation '{options['nation']}'")
+        if member.kicked:
+            raise CommandError(f"{member.nation.name} in game '{game.id}' has already been replaced")
 
         available = BotProfile.objects.available_for_game(game)
         bot_profile = available.filter(user__username=options["bot"]).first()
@@ -32,14 +37,29 @@ class Command(BaseCommand):
             raise CommandError(f"no bot '{options['bot']}' available for game '{game.id}'; available: {usernames}")
 
         with transaction.atomic():
-            member.user = bot_profile.user
-            member.kicked = False
-            member.civil_disorder = False
-            member.save(update_fields=["user", "kicked", "civil_disorder"])
+            replacement = game.members.create(user=bot_profile.user, nation=member.nation)
+            ChannelMember.objects.bulk_create(
+                [
+                    ChannelMember(member=replacement, channel_id=channel_id)
+                    for channel_id in member.member_channels.values_list("channel_id", flat=True)
+                ]
+            )
+
+            member.kicked = True
+            member.replaced_by = replacement
+            member.save(update_fields=["kicked", "replaced_by"])
 
             phase = game.current_phase
             if phase is not None and phase.status == PhaseStatus.ACTIVE:
-                AgentTask.objects.create_from_event(kind=AgentTaskKind.PLAN, member=member, phase=phase)
+                replaced_states = phase.phase_states.filter(member=member)
+                Order.objects.filter(phase_state__in=replaced_states).delete()
+                replaced_states.update(has_possible_orders=False)
+                PhaseState.objects.create(
+                    member=replacement,
+                    phase=phase,
+                    has_possible_orders=member.nation.name in phase.nations_with_possible_orders,
+                )
+                AgentTask.objects.create_from_event(kind=AgentTaskKind.PLAN, member=replacement, phase=phase)
 
         self.stdout.write(
             self.style.SUCCESS(f"{bot_profile.user.profile.name} now plays {member.nation.name} in '{game.id}'.")

--- a/service/agent/management/commands/replace_member_with_bot.py
+++ b/service/agent/management/commands/replace_member_with_bot.py
@@ -1,0 +1,46 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from agent.constants import AgentTaskKind
+from agent.models import AgentTask
+from bot_profile.models import BotProfile
+from common.constants import PhaseStatus
+from game.models import Game
+
+
+class Command(BaseCommand):
+    help = "Seat a bot in a game member's nation, replacing whoever holds it."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--game", required=True, help="game id")
+        parser.add_argument("--nation", required=True, help="nation of the member to replace")
+        parser.add_argument("--bot", required=True, help="username of the bot to seat")
+
+    def handle(self, *args, **options):
+        game = Game.objects.filter(id=options["game"]).first()
+        if game is None:
+            raise CommandError(f"no game with id '{options['game']}'")
+
+        member = game.members.filter(nation__name__iexact=options["nation"]).select_related("nation").first()
+        if member is None:
+            raise CommandError(f"game '{game.id}' has no member for nation '{options['nation']}'")
+
+        available = BotProfile.objects.available_for_game(game)
+        bot_profile = available.filter(user__username=options["bot"]).first()
+        if bot_profile is None:
+            usernames = ", ".join(profile.user.username for profile in available)
+            raise CommandError(f"no bot '{options['bot']}' available for game '{game.id}'; available: {usernames}")
+
+        with transaction.atomic():
+            member.user = bot_profile.user
+            member.kicked = False
+            member.civil_disorder = False
+            member.save(update_fields=["user", "kicked", "civil_disorder"])
+
+            phase = game.current_phase
+            if phase is not None and phase.status == PhaseStatus.ACTIVE:
+                AgentTask.objects.create_from_event(kind=AgentTaskKind.PLAN, member=member, phase=phase)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"{bot_profile.user.profile.name} now plays {member.nation.name} in '{game.id}'.")
+        )

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -23,6 +23,7 @@ from common.constants import OrderType, PhaseType
 from inference.clients.base import InferenceResult
 from inference.constants import InferenceStatus
 from inference.models import Inference
+from order.models import Order
 
 
 def _option(source, order_type, target=None, aux=None, unit_type=None, named_coast=None):
@@ -821,15 +822,7 @@ class TestAgentTaskReconcile:
 
 class TestReplaceMemberWithBotCommand:
 
-    @pytest.mark.django_db
-    def test_seats_bot_and_restores_the_seat(self, active_game_factory, in_memory_procrastinate):
-        game = active_game_factory()
-        member = game.members.first()
-        member.user = None
-        member.kicked = True
-        member.civil_disorder = True
-        member.save()
-
+    def _replace(self, game, member, bot="dealmakerbot"):
         call_command(
             "replace_member_with_bot",
             "--game",
@@ -837,30 +830,74 @@ class TestReplaceMemberWithBotCommand:
             "--nation",
             member.nation.name,
             "--bot",
-            "dealmakerbot",
+            bot,
         )
+
+    @pytest.mark.django_db
+    def test_seats_the_bot_in_a_new_member_and_kicks_the_original(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+
+        self._replace(game, member)
+
+        replacement = game.members.get(user__username="dealmakerbot")
+        assert replacement.nation == member.nation
+        assert replacement.kicked is False
 
         member.refresh_from_db()
-        assert member.user.username == "dealmakerbot"
-        assert member.kicked is False
-        assert member.civil_disorder is False
+        assert member.kicked is True
+        assert member.replaced_by == replacement
+        assert member.user is not None
 
     @pytest.mark.django_db
-    def test_defers_plan_task_for_the_current_phase(self, active_game_factory, in_memory_procrastinate):
+    def test_replacement_joins_every_channel_the_original_was_in(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+        public = game.channels.create(name="Public Press", private=False)
+        private = game.channels.create(name="Private", private=True)
+        for channel in (public, private):
+            channel.member_channels.create(member=member)
+
+        self._replace(game, member)
+
+        replacement = game.members.get(user__username="dealmakerbot")
+        assert set(replacement.member_channels.values_list("channel_id", flat=True)) == {public.id, private.id}
+        assert set(member.member_channels.values_list("channel_id", flat=True)) == {public.id, private.id}
+
+    @pytest.mark.django_db
+    def test_moves_the_current_phase_state_to_the_replacement(self, active_game_factory, in_memory_procrastinate):
         game = active_game_factory()
         member = game.members.first()
 
-        call_command(
-            "replace_member_with_bot",
-            "--game",
-            game.id,
-            "--nation",
-            member.nation.name,
-            "--bot",
-            "dealmakerbot",
-        )
+        self._replace(game, member)
 
-        task = AgentTask.objects.get(kind=AgentTaskKind.PLAN, member=member)
+        phase = game.current_phase
+        replacement = game.members.get(user__username="dealmakerbot")
+        assert phase.phase_states.get(member=member).has_possible_orders is False
+        assert phase.phase_states.get(member=replacement).has_possible_orders is True
+
+    @pytest.mark.django_db
+    def test_discards_orders_the_replaced_member_left_behind(
+        self, active_game_factory, in_memory_procrastinate, classical_london_province
+    ):
+        game = active_game_factory()
+        member = game.members.first()
+        phase_state = game.current_phase.phase_states.get(member=member)
+        Order.objects.create(phase_state=phase_state, source=classical_london_province, order_type=OrderType.HOLD)
+
+        self._replace(game, member)
+
+        assert not Order.objects.filter(phase_state__member=member).exists()
+
+    @pytest.mark.django_db
+    def test_defers_plan_task_for_the_replacement(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+
+        self._replace(game, member)
+
+        replacement = game.members.get(user__username="dealmakerbot")
+        task = AgentTask.objects.get(kind=AgentTaskKind.PLAN, member=replacement)
         assert task.phase == game.current_phase
         assert task.status == AgentTaskStatus.PENDING
         assert len(_run_jobs_for(in_memory_procrastinate, task)) == 1
@@ -880,36 +917,29 @@ class TestReplaceMemberWithBotCommand:
             "dealmakerbot",
         )
 
-        member.refresh_from_db()
-        assert member.user.username == "dealmakerbot"
+        assert game.members.filter(user__username="dealmakerbot", nation=member.nation).exists()
+
+    @pytest.mark.django_db
+    def test_rejects_a_seat_that_was_already_replaced(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+        self._replace(game, member)
+
+        with pytest.raises(CommandError, match="already been replaced"):
+            self._replace(game, member, bot="bearbot")
+
+        assert not game.members.filter(user__username="bearbot").exists()
 
     @pytest.mark.django_db
     def test_rejects_bot_already_in_the_game(self, active_game_factory, in_memory_procrastinate):
         game = active_game_factory()
         seated, other = game.members.all()[:2]
-        call_command(
-            "replace_member_with_bot",
-            "--game",
-            game.id,
-            "--nation",
-            seated.nation.name,
-            "--bot",
-            "dealmakerbot",
-        )
+        self._replace(game, seated)
 
         with pytest.raises(CommandError, match="available"):
-            call_command(
-                "replace_member_with_bot",
-                "--game",
-                game.id,
-                "--nation",
-                other.nation.name,
-                "--bot",
-                "dealmakerbot",
-            )
+            self._replace(game, other)
 
-        other.refresh_from_db()
-        assert other.user.username != "dealmakerbot"
+        assert game.members.filter(user__username="dealmakerbot").count() == 1
 
     @pytest.mark.django_db
     def test_rejects_unknown_nation(self, active_game_factory, in_memory_procrastinate):

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -815,3 +817,126 @@ class TestAgentTaskReconcile:
             AgentTask.objects.filter(pk=task.pk).update(created_at=timezone.now() - timedelta(minutes=30))
 
         assert AgentTask.objects.reconcile() == []
+
+
+class TestReplaceMemberWithBotCommand:
+
+    @pytest.mark.django_db
+    def test_seats_bot_and_restores_the_seat(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+        member.user = None
+        member.kicked = True
+        member.civil_disorder = True
+        member.save()
+
+        call_command(
+            "replace_member_with_bot",
+            "--game",
+            game.id,
+            "--nation",
+            member.nation.name,
+            "--bot",
+            "dealmakerbot",
+        )
+
+        member.refresh_from_db()
+        assert member.user.username == "dealmakerbot"
+        assert member.kicked is False
+        assert member.civil_disorder is False
+
+    @pytest.mark.django_db
+    def test_defers_plan_task_for_the_current_phase(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+
+        call_command(
+            "replace_member_with_bot",
+            "--game",
+            game.id,
+            "--nation",
+            member.nation.name,
+            "--bot",
+            "dealmakerbot",
+        )
+
+        task = AgentTask.objects.get(kind=AgentTaskKind.PLAN, member=member)
+        assert task.phase == game.current_phase
+        assert task.status == AgentTaskStatus.PENDING
+        assert len(_run_jobs_for(in_memory_procrastinate, task)) == 1
+
+    @pytest.mark.django_db
+    def test_matches_nation_case_insensitively(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+
+        call_command(
+            "replace_member_with_bot",
+            "--game",
+            game.id,
+            "--nation",
+            member.nation.name.lower(),
+            "--bot",
+            "dealmakerbot",
+        )
+
+        member.refresh_from_db()
+        assert member.user.username == "dealmakerbot"
+
+    @pytest.mark.django_db
+    def test_rejects_bot_already_in_the_game(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        seated, other = game.members.all()[:2]
+        call_command(
+            "replace_member_with_bot",
+            "--game",
+            game.id,
+            "--nation",
+            seated.nation.name,
+            "--bot",
+            "dealmakerbot",
+        )
+
+        with pytest.raises(CommandError, match="available"):
+            call_command(
+                "replace_member_with_bot",
+                "--game",
+                game.id,
+                "--nation",
+                other.nation.name,
+                "--bot",
+                "dealmakerbot",
+            )
+
+        other.refresh_from_db()
+        assert other.user.username != "dealmakerbot"
+
+    @pytest.mark.django_db
+    def test_rejects_unknown_nation(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+
+        with pytest.raises(CommandError, match="no member for nation"):
+            call_command(
+                "replace_member_with_bot",
+                "--game",
+                game.id,
+                "--nation",
+                "Atlantis",
+                "--bot",
+                "dealmakerbot",
+            )
+
+    @pytest.mark.django_db
+    def test_rejects_unknown_game(self, active_game_factory, in_memory_procrastinate):
+        active_game_factory()
+
+        with pytest.raises(CommandError, match="no game with id"):
+            call_command(
+                "replace_member_with_bot",
+                "--game",
+                "not-a-game",
+                "--nation",
+                "England",
+                "--bot",
+                "dealmakerbot",
+            )

--- a/service/channel/tests/test_channel.py
+++ b/service/channel/tests/test_channel.py
@@ -885,3 +885,32 @@ class TestChannelMemberAutoCreation:
 
         new_member = game.members.filter(user__username="primaryuser").first()
         assert ChannelMember.objects.filter(member=new_member, channel=public_channel).exists()
+
+
+class TestKickedMemberCannotChat:
+
+    @pytest.mark.django_db
+    def test_create_message_as_kicked_member_forbidden(
+        self, authenticated_client_for_secondary_user, active_game_with_kicked_member, in_memory_procrastinate
+    ):
+        game = active_game_with_kicked_member
+        channel = Channel.objects.create(game=game, name="Public Press", private=False)
+        channel.members.add(game.members.get(kicked=True))
+
+        url = reverse("channel-message-create", args=[game.id, channel.id])
+        response = authenticated_client_for_secondary_user.post(url, {"body": "Still here"}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not ChannelMessage.objects.filter(channel=channel).exists()
+
+    @pytest.mark.django_db
+    def test_create_channel_as_kicked_member_forbidden(
+        self, authenticated_client_for_secondary_user, active_game_with_kicked_member
+    ):
+        game = active_game_with_kicked_member
+        url = reverse("channel-create", args=[game.id])
+        payload = {"member_ids": [game.members.get(kicked=False).id]}
+        response = authenticated_client_for_secondary_user.post(url, payload, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not Channel.objects.filter(game=game).exists()

--- a/service/channel/views.py
+++ b/service/channel/views.py
@@ -1,6 +1,6 @@
 from rest_framework import permissions, generics, status
 from rest_framework.response import Response
-from common.permissions import IsActiveOrCompletedGame, IsGameMember, IsChannelMember, IsNotSandboxGame, IsNotNoPressActiveGame
+from common.permissions import IsActiveOrCompletedGame, IsGameMember, IsChannelMember, IsNotKickedGameMember, IsNotSandboxGame, IsNotNoPressActiveGame
 
 from .models import Channel
 from .serializers import ChannelSerializer, ChannelMessageSerializer, ChannelMarkReadSerializer
@@ -8,12 +8,12 @@ from common.views import SelectedGameMixin, SelectedChannelMixin, CurrentGameMem
 
 
 class ChannelCreateView(SelectedGameMixin, CurrentGameMemberMixin, generics.CreateAPIView):
-    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsGameMember, IsNotSandboxGame, IsNotNoPressActiveGame]
+    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsNotKickedGameMember, IsNotSandboxGame, IsNotNoPressActiveGame]
     serializer_class = ChannelSerializer
 
 
 class ChannelMessageCreateView(SelectedGameMixin, SelectedChannelMixin, CurrentGameMemberMixin, generics.CreateAPIView):
-    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsGameMember, IsChannelMember, IsNotSandboxGame, IsNotNoPressActiveGame]
+    permission_classes = [permissions.IsAuthenticated, IsActiveOrCompletedGame, IsNotKickedGameMember, IsChannelMember, IsNotSandboxGame, IsNotNoPressActiveGame]
     serializer_class = ChannelMessageSerializer
 
 

--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -37,6 +37,20 @@ class IsGameMember(BasePermission):
         return game.members.filter(user=request.user).exists()
 
 
+class IsNotKickedGameMember(BasePermission):
+    message = "User is not a member of the game."
+
+    def has_permission(self, request, view):
+        game = resolve_game(request, view.kwargs.get("game_id"))
+        member = game.members.filter(user=request.user).first()
+        if not member:
+            return False
+        if member.kicked:
+            self.message = "Cannot perform action for kicked players."
+            return False
+        return True
+
+
 class IsGameMemberOrGameMaster(BasePermission):
     message = "User is not a member of the game."
 

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -920,3 +920,22 @@ def test_leave_pending_game_with_only_bots_remaining_deletes_game(
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not Game.objects.filter(id=game_id).exists()
+
+
+class TestKickedMemberCivilDisorderRecovery:
+
+    @pytest.mark.django_db
+    def test_recovery_as_kicked_member_forbidden(
+        self, authenticated_client_for_secondary_user, active_game_with_kicked_member
+    ):
+        game = active_game_with_kicked_member
+        member = game.members.get(kicked=True)
+        member.civil_disorder = True
+        member.save(update_fields=["civil_disorder"])
+
+        url = reverse(recovery_viewname, args=[game.id])
+        response = authenticated_client_for_secondary_user.post(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        member.refresh_from_db()
+        assert member.civil_disorder is True

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import extend_schema
 from .models import Member
 from .serializers import MemberSerializer
 from common.serializers import EmptySerializer
-from common.permissions import IsActiveGame, IsGameMember, IsGameManager, IsInCivilDisorder, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsCommitmentRequirement
+from common.permissions import IsActiveGame, IsGameMember, IsGameManager, IsInCivilDisorder, IsNotKickedGameMember, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsCommitmentRequirement
 from common.views import SelectedGameMixin
 from emit import emit
 
@@ -69,7 +69,7 @@ class CivilDisorderRecoveryView(SelectedGameMixin, generics.GenericAPIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsActiveGame,
-        IsGameMember,
+        IsNotKickedGameMember,
         IsInCivilDisorder,
     ]
 

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -830,7 +830,7 @@ class PhaseManager(models.Manager):
                             new_phase.phase_states.model(
                                 member=member,
                                 phase=new_phase,
-                                has_possible_orders=member.nation.name in nations_with_orders,
+                                has_possible_orders=member.nation.name in nations_with_orders and not member.kicked,
                                 orders_confirmed=member.civil_disorder,
                             )
                         )

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -5376,3 +5376,26 @@ class TestCheckEliminations:
         Phase.objects._check_eliminations(previous_phase, new_phase)
 
         assert not _elimination_notifications().exists()
+
+
+class TestKickedMemberPhaseStates:
+
+    @pytest.mark.django_db
+    def test_kicked_member_has_no_possible_orders_in_the_next_phase(
+        self,
+        italy_vs_germany_phase_with_orders,
+        mock_adjudication_data_basic,
+        adjudication_data_italy_vs_germany,
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        kicked = phase.game.members.get(nation__name="Italy")
+        kicked.kicked = True
+        kicked.save(update_fields=["kicked"])
+
+        new_phase = Phase.objects.create_from_adjudication_data(
+            phase,
+            {**mock_adjudication_data_basic, "options": adjudication_data_italy_vs_germany["options"]},
+        )
+
+        assert new_phase.phase_states.get(member=kicked).has_possible_orders is False
+        assert new_phase.phase_states.get(member__nation__name="Germany").has_possible_orders is True


### PR DESCRIPTION
## What this PR does

When a player deletes their account mid-game, `UserAccountDeleteView` sets `kicked=True` and nulls the member's `user`, leaving a nation that NMRs for the rest of the game. `BotMemberCreateView` is gated on `IsPendingGame`, so there was no way to hand that seat to a bot once play had started.

`python manage.py replace_member_with_bot --game <id> --nation Italy --bot dealmakerbot` seats a roster bot in the nation as a **new member**, keeping the original row intact so the departed player stays attributable for statistics:

- The original is marked `kicked` with `replaced_by` pointing at the replacement (both fields already existed on `Member` and had no production writer).
- The replacement joins every channel the original was in, and **the original stays in them too** — so its past messages keep rendering against the right sender rather than being reassigned to the bot.
- On the current phase the replacement gets the phase state, and the original's pending orders are deleted. `phase_to_canonical_game_state` (`phase/utils.py:630-634`) collects orders from *every* phase state regardless of flags, so leaving them would feed the engine two order sets for one nation.
- A `plan` AgentTask is queued, because the `plan` signal fires on phase activation and that has already passed.

## The bug this design forced us to fix

Creating a second member per nation only works if a leftover kicked member stops counting as a live seat. It didn't: `create_from_adjudication_data` set `has_possible_orders` from the nation alone, so a kicked member accumulated a permanently unconfirmed phase state every phase. It's now `... and not member.kicked`.

Every "is everyone done?" check keys off that flag, so this fixes three bugs that are **already live** for seats abandoned by account deletion:

| Site | Symptom |
|---|---|
| `filter_due_phases` (`phase/models.py:76-78`) | phase never ready early — the game always waits out the full deadline, permanently |
| `when_humans_confirmed` (`agent/decorators.py:101-107`) | bots never finalize; the dead seat reads as a pending human |
| `_check_and_apply_nmr_extensions` (`phase/models.py:199-208`) | excludes `civil_disorder` but not `kicked`, so the dead seat consumes an extension |

Deadline warnings (`phase/models.py:303-331`) and commitment scoring are covered by the same flag, so a replaced player stops being pinged about, and rated on, a seat they no longer hold.

## Locking the replaced player out

A replaced player keeps their account, so unlike an account deletion they can still call the API. Auditing every write path:

| Action | Gate | Was |
|---|---|---|
| Create/delete orders | `IsActiveGameMember` | already blocked |
| Confirm orders | `IsActiveGameMember` | already blocked |
| Draw propose/vote/cancel | `IsActiveGameMember` | already blocked |
| Send a message | `IsGameMember` | **allowed** — now `IsNotKickedGameMember` |
| Create a private channel | `IsGameMember` | **allowed** — now `IsNotKickedGameMember` |
| Recover from civil disorder | `IsGameMember` | **allowed** — now `IsNotKickedGameMember` |

`IsGameMember` is a bare `members.filter(user=...).exists()`. `IsActiveGameMember` isn't reusable here because it also rejects eliminated members, who are still allowed to chat. Read access stays open deliberately — a replaced player can still view the game and the channels they were in, which is what keeps their old messages readable in context.

## Frontend

Two members can now share a nation, which breaks three spots:

- `channelUtils.getChannelFlagUrls` built public-channel flags from the raw member list — one flag per member meant a duplicate flag per replaced seat.
- `ChannelCreateScreen` offered kicked members as private-channel recipients and keyed the list on `member.nation`, so two members in one nation produced duplicate React keys.
- `GameMap` shaded a nation as in civil disorder from any member carrying the flag, including a replaced one.

No visual changes beyond removing those duplicates — nothing new is rendered, so there is nothing to screenshot.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

`/review-pr` could not be run from the session that opened this PR — the skill shells out to `gh pr diff`, and that session's git remote points at a local proxy rather than a GitHub host, so `gh` exits with "none of the git remotes configured for this repository point to a known GitHub host". Worth running from a normal checkout before merge.

Tests: ten in `agent/tests.py` for the command (new member and kicked original, channel inheritance, phase state handover, order discard, deferred plan task, four error paths); one in `phase/tests.py` for the `has_possible_orders` fix; two in `channel/tests/test_channel.py` and one in `member/tests.py` for the permission gates; three on the frontend. Every behavioural test was confirmed to fail with its fix reverted. Full backend suite 2035 passed; full frontend suite 543 passed; lint and `tsc -b --noEmit` clean.