### PR TITLE
v3 ordering principles: uncontestable-support flag + set coordination

### DIFF
--- a/service/harness/management/commands/sample_openings.py
+++ b/service/harness/management/commands/sample_openings.py
@@ -27,20 +27,56 @@ def _order_str(order, context, unit_types):
     return f"{prefix} {order['source']} {describe_option(order, context)}"
 
 
-def _flags(orders):
+def _own_nation(context):
+    return next((member["nation"] for member in context["members"] if member["is_current_user"]), None)
+
+
+def _can_reach(context, from_province, to_province, unit_type):
+    allow = "army" if unit_type == "Army" else "fleet"
+    for province in context["provinces"]:
+        if province["id"] == from_province:
+            return any(adj["to"] == to_province and allow in adj["allows"] for adj in province["adjacencies"])
+    return False
+
+
+def _contested(context, province, own_nation):
+    for unit in context["units"]:
+        if unit["nation"] == own_nation:
+            continue
+        if unit["province"] == province or _can_reach(context, unit["province"], province, unit["type"]):
+            return True
+    return False
+
+
+def _flags(orders, context):
+    if not orders:
+        return ["no_orders"]
+
+    own_nation = _own_nation(context)
     sources = {order["source"] for order in orders}
     flags = [f"hold:{order['source']}" for order in orders if order["order_type"] == "Hold"]
+
     move_targets = Counter(
         order["target"] for order in orders if order["order_type"] in MOVEMENT_TYPES and order["target"]
     )
     flags += [f"self_bounce:{dest}" for dest, count in move_targets.items() if count >= 2]
+
+    dangling_aux = set()
     for order_type, own_label, foreign_label in (
         ("Support", "dangling_support", "support_foreign"),
         ("Convoy", "dangling_convoy", "convoy_foreign"),
     ):
         for aux, _target, _actual in dangling(orders, order_type):
+            dangling_aux.add(aux)
             label = own_label if aux in sources else foreign_label
             flags.append(f"{label}:{aux}")
+
+    for order in orders:
+        if order["order_type"] != "Support" or order["aux"] in dangling_aux:
+            continue
+        if order["target"] and not _contested(context, order["target"], own_nation):
+            flags.append(f"uncontestable_support:{order['target']}")
+
     return flags
 
 
@@ -69,7 +105,7 @@ def ledger_for_nation(context, completions):
             "count": count,
             "share": round(count / scored, 3) if scored else 0.0,
             "orders": list(key),
-            "flags": _flags(representative[key]),
+            "flags": _flags(representative[key], context),
         }
         for key, count in joint.most_common()
     ]

--- a/service/harness/tasks/select_orders/system_prompt.py
+++ b/service/harness/tasks/select_orders/system_prompt.py
@@ -12,11 +12,13 @@ has none itself. A move only wastes the turn if it carries a unit away from ever
 could contest or into a corner it cannot advance from.
 - Holding does nothing for a unit's position. Hold only to defend a province genuinely under \
 threat this phase; do not hold merely because no move stands out.
-- Before ordering a support, confirm the unit you are supporting is itself ordered to make \
-exactly that move or hold this phase; a support of an action that is not being taken is \
-wasted.
-- Do not order two of your own units to the same destination unless you have a specific \
-reason; normally they bounce and both accomplish nothing.
+- A support helps only when both hold: the unit you support is actually ordered to make \
+exactly that move or hold this phase, and an enemy could otherwise contest that province. If \
+the supported action is not being made, or no enemy can reach the province, the support is \
+wasted — use the unit elsewhere.
+- Choose your orders as a set, not one unit at a time. If two of your own units would move to \
+the same province they bounce and both fail, so send one of them elsewhere unless the bounce \
+itself serves a purpose.
 - Support or act for another power's unit only when it advances your own position and \
 follows a coordination you have agreed with them; without such an agreement, a unit spent \
 on a rival's move is spent for their benefit."""

--- a/service/harness/tests.py
+++ b/service/harness/tests.py
@@ -527,3 +527,40 @@ class TestOpeningLedger:
         context = fixture_to_context(fixture)
         flags = ledger_for_nation(context, [_completion([("edi", 0), ("lon", 0)])])["order_sets"][0]["flags"]
         assert "self_bounce:nth" in flags
+
+    def test_flags_no_orders(self):
+        context = fixture_to_context(self._hold_fixture())
+        ledger = ledger_for_nation(context, [_completion([])])
+        assert ledger["order_sets"][0]["flags"] == ["no_orders"]
+
+    def _uncontestable_fixture(self, with_enemy=False):
+        units = [
+            {"type": "Fleet", "nation": "England", "province": "lon"},
+            {"type": "Fleet", "nation": "England", "province": "edi"},
+        ]
+        if with_enemy:
+            units.append({"type": "Fleet", "nation": "Germany", "province": "hol"})
+        return {
+            "id": "ledger_uncontestable",
+            "variant": "classical",
+            "nation": "England",
+            "phase": {"season": "Spring", "year": 1901, "type": "Movement"},
+            "units": units,
+            "supply_centers": [{"nation": "England", "province": "lon"}],
+            "order_options": [
+                {"source": "lon", "order_type": "Move", "target": "nth"},
+                {"source": "lon", "order_type": "Hold", "target": "lon"},
+                {"source": "edi", "order_type": "Support", "target": "nth", "aux": "lon"},
+                {"source": "edi", "order_type": "Hold", "target": "edi"},
+            ],
+        }
+
+    def test_flags_uncontestable_support(self):
+        context = fixture_to_context(self._uncontestable_fixture())
+        flags = ledger_for_nation(context, [_completion([("lon", 0), ("edi", 0)])])["order_sets"][0]["flags"]
+        assert "uncontestable_support:nth" in flags
+
+    def test_contested_support_is_not_flagged_uncontestable(self):
+        context = fixture_to_context(self._uncontestable_fixture(with_enemy=True))
+        flags = ledger_for_nation(context, [_completion([("lon", 0), ("edi", 0)])])["order_sets"][0]["flags"]
+        assert not any(flag.startswith("uncontestable_support") for flag in flags)


### PR DESCRIPTION
## What this PR does

Third iteration of the principled `select_orders` guidance, driven by the ledger + Fable's read of it. Two new ledger flags and two prompt changes.

**New ledger flags (`sample_openings`):**
- `no_orders` — the model returned valid JSON whose choices mapped to *zero* legal orders (bad ids / out-of-range indices, silently dropped by the parser). Previously these empty sets hid in the "clean" bucket and deflated the flag rates; now they're visible. Production's `first_legal_options` fallback still covers this at runtime.
- `uncontestable_support` — a *coherent* support of a move or hold into a province **no enemy unit can reach or occupy this phase**. It's provably wasted but invisible to the dangling check (the supported unit *is* making the move). Computed adjacency-aware from unit positions + the variant's pass rules. This makes Fable's top qualitative finding measurable.

**Prompt (v3):**
- Merged the matched-support and contestable-support conditions into one support principle ("a support helps only when the supported action is actually being made *and* an enemy could otherwise contest the province").
- Rewrote the self-bounce clause to "choose your orders as a set, not one unit at a time."

## Result

Against a v2 baseline re-scored with the new flags (50 samples/nation):

| flag | v2 → v3 | change |
|---|---|---|
| **uncontestable_support** | 28 → 13 | **−54%** |
| dangling_support | 34 → 22 | −35% |
| self_bounce | 21 → 15 | −29% |
| **any flag** | 100 → 73 | **−27%** |

Per-nation "any": Russia 25→13, Italy 21→12, Turkey 15→10, Austria 17→15 all improved. The support principle is the big lever — it cut the uncontestable-support class (Fable's #1) by more than half and dragged dangling supports down with it.

**Honest caveat:** the self-bounce rewrite helped Russia (8→2) but **did not crack England's North Sea double-move** (8→9) — the one case it targeted. Two same-direction fleets remain a stubborn case for a general principle at this model tier; it's the clear next target, likely needing a different mechanism than prompt wording. Holds and `no_orders` ticked up marginally (7→9 each), within single-run noise.

Dataset eval (regression guard): no regression — legality/dedup/coverage/convoy 1.00, support_coherence 0.90, quality in the usual single-epoch band.

## Checklist

- [x] This PR does one thing — the v3 principle iteration and the two flags that measure it
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — `no_orders`, `uncontestable_support` (contested vs uncontested), plus the existing ledger tests
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a: no web-app UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWJcaV8KbfeKMSxa8VYtCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWJcaV8KbfeKMSxa8VYtCb)_