### PR TITLE
Record LLM-vs-dumbbot integration match results

### DIFF
--- a/service/integration/MATCH_RESULTS.md
+++ b/service/integration/MATCH_RESULTS.md
@@ -1,0 +1,61 @@
+# dumbbot match results
+
+Latest recorded run of `integration/test_dumbbot_match.py`. Update this file
+when a new match is played.
+
+- **Date:** 2026-07-29
+- **Model:** `claude-haiku-4-5` (`BOT_LLM_MODEL` unset, so the settings default applied)
+- **Variant:** classical, `nation_assignment: ordered`, both games driven to Spring 1910 Movement
+- **Command:** `pytest integration/test_dumbbot_match.py::<test> -s -q`
+
+Seats follow join order: the test adds every LLM profile before every dumbbot
+profile, and `ordered` assignment zips members sorted by id onto the variant's
+nation order. The minority bot therefore lands on a fixed power in each game —
+Turkey in Game A, Austria in Game B.
+
+## Game A — 6 LLM + 1 dumbbot
+
+Reached Spring 1910 Movement. 17m 48s wall clock, 136 model calls.
+
+| Nation | Kind | Centres | Score |
+|---|---|---|---|
+| Austria | llm | 2 | 4 |
+| England | llm | 3 | 9 |
+| France | llm | 5 | 25 |
+| Germany | llm | 10 | 100 |
+| Italy | llm | 4 | 16 |
+| Russia | llm | 1 | 1 |
+| Turkey | dumbbot | 9 | 81 |
+
+Cohorts: llm 155, dumbbot 81. Total 236.
+
+## Game B — 1 LLM + 6 dumbbots
+
+Reached Spring 1910 Movement. 4m 38s wall clock, 19 model calls.
+
+| Nation | Kind | Centres | Score |
+|---|---|---|---|
+| Austria | llm | 2 | 4 |
+| England | dumbbot | 4 | 16 |
+| France | dumbbot | 5 | 25 |
+| Germany | dumbbot | 4 | 16 |
+| Italy | dumbbot | 5 | 25 |
+| Russia | dumbbot | 6 | 36 |
+| Turkey | dumbbot | 6 | 36 |
+
+Cohorts: dumbbot 154, llm 4. Total 158.
+
+## Reading these numbers
+
+Neither game ended early; no power reached the 18 centres needed for a solo, so
+both totals are ordinary Spring 1910 positions.
+
+Cohort sums are not a head-to-head result. They aggregate unequal seat counts (6
+versus 1), so the larger cohort dominates its game's total by construction, and
+sum-of-squares further rewards concentration — Game A's llm cohort owes 100 of
+its 155 to Germany alone. Seat assignment is a second confound: `ordered` pins
+the minority bot to one specific power, and Turkey (Game A's dumbbot) and
+Austria (Game B's llm) are not comparable starting positions.
+
+One game per configuration is a sample of one. Treat these as a recorded
+measurement of two specific games, not evidence that either cohort plays better.


### PR DESCRIPTION
## What this PR does

Records the observed figures from the first run of `integration/test_dumbbot_match.py` (added in #1117) in a new `service/integration/MATCH_RESULTS.md`, mirroring how `harness/tasks/select_orders/EVAL_RESULTS.md` records the latest eval baseline. Doc-only — no test or policy code is touched.

Both games were run against the real model on 2026-07-29 with `BOT_LLM_MODEL` unset, so `claude-haiku-4-5` (the settings default) applied. Both reached Spring 1910 Movement; neither ended early and no power reached the 18 centres needed for a solo.

| | Game A (6 LLM + 1 dumbbot) | Game B (1 LLM + 6 dumbbots) |
|---|---|---|
| Outcome | reached Spring 1910 Movement | reached Spring 1910 Movement |
| Wall clock | 17m 48s | 4m 38s |
| Model calls | 136 | 19 |
| Cohort scores | llm 155, dumbbot 81 | dumbbot 154, llm 4 |
| Total | 236 | 158 |

The file deliberately states that these numbers are a measurement, not a head-to-head result: cohort sums aggregate unequal seat counts (6 versus 1), sum-of-squares rewards concentration (100 of Game A's llm 155 is Germany alone), `nation_assignment: ordered` pins the minority bot to a fixed power by join order (Turkey in A, Austria in B), and one game per configuration is a sample of one.

**File placement.** The brief said "next to `EVAL_RESULTS.md`". I put it in `service/integration/` next to the test it describes rather than literally inside `harness/tasks/select_orders/`, since that directory belongs to the `select_orders` eval task and the match is an integration test. Happy to move it if you'd rather the two results files sit together.

**WIP limit.** The repo currently has 10 open PRs against the soft limit of 5. Flagging per CLAUDE.md; this one is doc-only.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — not run; doc-only change with no code paths to review
- [ ] Tests cover the change — n/a, this records the output of an existing test rather than changing behaviour
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no web app changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmWSGFdnheFHVf3qHyMHaa)_