### PR TITLE
Target the seat's current holder in replace_member_with_bot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,12 @@ recovery only checked `IsGameMember` and now use `IsNotKickedGameMember`. Read
 access is deliberately left open — a replaced player can still view the game and
 the channels they were in.
 
+`--nation` resolves to the seat's *current* holder — the member with no
+`replaced_by` — so a seat already handed over once resolves to the bot rather
+than the member it replaced. Note that `kicked` does not mean "replaced": account
+deletion kicks a member without ever setting `replaced_by`, and that is precisely
+the seat the command exists to fill.
+
 An unrecognised `--bot` errors with the list of bots still available for that
 game. A production run needs a shell on the deployed service (`railway ssh`),
 because `railway run` executes locally and cannot resolve Railway's internal

--- a/service/agent/management/commands/replace_member_with_bot.py
+++ b/service/agent/management/commands/replace_member_with_bot.py
@@ -24,11 +24,15 @@ class Command(BaseCommand):
         if game is None:
             raise CommandError(f"no game with id '{options['game']}'")
 
-        member = game.members.filter(nation__name__iexact=options["nation"]).select_related("nation").first()
+        member = (
+            game.members.filter(nation__name__iexact=options["nation"], replaced_by__isnull=True)
+            .select_related("nation", "user")
+            .first()
+        )
         if member is None:
             raise CommandError(f"game '{game.id}' has no member for nation '{options['nation']}'")
-        if member.kicked:
-            raise CommandError(f"{member.nation.name} in game '{game.id}' has already been replaced")
+        if member.user is not None and hasattr(member.user, "bot_profile"):
+            raise CommandError(f"{member.nation.name} in game '{game.id}' is already played by a bot")
 
         available = BotProfile.objects.available_for_game(game)
         bot_profile = available.filter(user__username=options["bot"]).first()

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -997,12 +997,25 @@ class TestReplaceMemberWithBotCommand:
         assert game.members.filter(user__username="dealmakerbot", nation=member.nation).exists()
 
     @pytest.mark.django_db
-    def test_rejects_a_seat_that_was_already_replaced(self, active_game_factory, in_memory_procrastinate):
+    def test_replaces_a_seat_abandoned_by_account_deletion(self, active_game_factory, in_memory_procrastinate):
+        game = active_game_factory()
+        member = game.members.first()
+        member.user = None
+        member.kicked = True
+        member.save(update_fields=["user", "kicked"])
+
+        self._replace(game, member)
+
+        member.refresh_from_db()
+        assert member.replaced_by == game.members.get(user__username="dealmakerbot")
+
+    @pytest.mark.django_db
+    def test_rejects_a_seat_already_played_by_a_bot(self, active_game_factory, in_memory_procrastinate):
         game = active_game_factory()
         member = game.members.first()
         self._replace(game, member)
 
-        with pytest.raises(CommandError, match="already been replaced"):
+        with pytest.raises(CommandError, match="already played by a bot"):
             self._replace(game, member, bot="bearbot")
 
         assert not game.members.filter(user__username="bearbot").exists()


### PR DESCRIPTION
## What this PR does

Follow-up to #1116. The command refused the one case it was written for:

```
$ python manage.py replace_member_with_bot \
    --game scholars-diplomats-scoundrels-and-stabbers --nation Italy --bot dealmakerbot
CommandError: Italy in game 'scholars-diplomats-scoundrels-and-stabbers' has already been replaced
```

The guard used `member.kicked` to mean "already replaced". But `kicked` and "replaced" are different things: `UserAccountDeleteView` sets `kicked=True` and leaves `replaced_by` NULL, and that seat — a nation abandoned by a deleted account — is exactly what the command exists to fill. Every such seat was rejected.

Two changes:

- **`--nation` resolves to the seat's current holder**, the member with `replaced_by IS NULL`, rather than an arbitrary member for that nation. This also removes a latent ordering bug: after one replacement two members share a nation, `Member` declares no `Meta.ordering`, and `.first()` picked between them by unspecified ordering — so on a different plan the "already replaced" check could have inspected the bot instead of the member it replaced.
- **The guard is now that the current holder is already a bot**, using the same `hasattr(user, "bot_profile")` test as `MemberSerializer._is_bot` and `MemberKickView`. That is what actually protects against running the command twice, and it says something true about the seat rather than about how it was vacated.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

`/review-pr` could not be run from the session that opened this PR — the skill shells out to `gh pr diff`, and that session's git remote points at a local proxy rather than a GitHub host, so `gh` exits with "none of the git remotes configured for this repository point to a known GitHub host". Worth running from a normal checkout before merge.

`test_rejects_a_seat_that_was_already_replaced` becomes `test_rejects_a_seat_already_played_by_a_bot`, and a new `test_replaces_a_seat_abandoned_by_account_deletion` covers the scenario that failed in production — a member with `kicked=True`, no user, and no `replaced_by`. Both were confirmed to fail against the old guard. Full backend suite 2062 passed. Backend-only, so no screenshots.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwghUozEdWnxAsxy5A46Gg)_