### PR TITLE
Exclude replaced members from the game members list

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -81,7 +81,7 @@ class GameQuerySet(models.QuerySet):
     def with_list_data(self):
         members_prefetch = Prefetch(
             "members",
-            queryset=Member.objects.select_related("nation", "user__profile", "user__bot_profile"),
+            queryset=Member.objects.not_replaced().select_related("nation", "user__profile", "user__bot_profile"),
         )
 
         victory_members_prefetch = Prefetch(
@@ -146,7 +146,7 @@ class GameQuerySet(models.QuerySet):
     def with_retrieve_data(self):
         members_prefetch = Prefetch(
             "members",
-            queryset=Member.objects.select_related("nation__flag", "user__profile", "user__bot_profile"),
+            queryset=Member.objects.not_replaced().select_related("nation__flag", "user__profile", "user__bot_profile"),
         )
 
         victory_members_prefetch = Prefetch(
@@ -233,7 +233,7 @@ class GameQuerySet(models.QuerySet):
 
         members_prefetch = Prefetch(
             "members",
-            queryset=Member.objects.select_related("nation__flag", "user__profile", "user__bot_profile"),
+            queryset=Member.objects.not_replaced().select_related("nation__flag", "user__profile", "user__bot_profile"),
         )
 
         victory_members_prefetch = Prefetch(

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -14,6 +14,7 @@ from phase.models import Phase
 from nation.models import Nation
 from province.models import Province
 from user_profile.models import UserProfile
+from bot_profile.utils import get_bot_user
 from .models import Game
 
 retrieve_viewname = "game-retrieve"
@@ -210,6 +211,38 @@ class TestGameRetrieveView:
         member_names = [member["name"] for member in response.data["members"]]
         assert primary_user.profile.name in member_names
         assert secondary_user.profile.name in member_names
+
+    @pytest.mark.django_db
+    def test_replaced_member_is_excluded_from_members(
+        self,
+        authenticated_client,
+        db,
+        classical_variant,
+        primary_user,
+        secondary_user,
+        classical_england_nation,
+        classical_france_nation,
+    ):
+        game = Game.objects.create(
+            name="Replaced Member Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+        game.members.create(user=primary_user, nation=classical_england_nation)
+        replaced = game.members.create(user=secondary_user, nation=classical_france_nation)
+        replacement = game.members.create(user=get_bot_user(), nation=classical_france_nation)
+        replaced.kicked = True
+        replaced.replaced_by = replacement
+        replaced.save(update_fields=["kicked", "replaced_by"])
+
+        url = reverse(retrieve_viewname, args=[game.id])
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        member_ids = [member["id"] for member in response.data["members"]]
+        assert replaced.id not in member_ids
+        assert replacement.id in member_ids
+        assert len(response.data["members"]) == 2
 
     @pytest.mark.django_db
     def test_game_with_multiple_phases(
@@ -416,6 +449,30 @@ class TestGameListView:
         response = authenticated_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert isinstance(response.data["results"], list)
+
+    @pytest.mark.django_db
+    def test_list_excludes_replaced_member(
+        self,
+        authenticated_client,
+        classical_variant,
+        base_pending_phase,
+        primary_user,
+        classical_england_nation,
+    ):
+        game = Game.objects.create(name="Replaced Member Game", variant=classical_variant, status=GameStatus.ACTIVE)
+        base_pending_phase(game)
+        replaced = game.members.create(user=primary_user, nation=classical_england_nation)
+        replacement = game.members.create(user=get_bot_user(), nation=classical_england_nation)
+        replaced.kicked = True
+        replaced.replaced_by = replacement
+        replaced.save(update_fields=["kicked", "replaced_by"])
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        listed = next(g for g in response.data["results"] if g["id"] == game.id)
+        assert [member["id"] for member in listed["members"]] == [replacement.id]
 
     @pytest.mark.django_db
     def test_list_games_unauthenticated(self, unauthenticated_client, pending_game_created_by_primary_user):

--- a/service/member/models.py
+++ b/service/member/models.py
@@ -5,7 +5,13 @@ from common.models import BaseModel
 User = get_user_model()
 
 
+class MemberQuerySet(models.QuerySet):
+    def not_replaced(self):
+        return self.filter(replaced_by__isnull=True)
+
+
 class Member(BaseModel):
+    objects = models.Manager.from_queryset(MemberQuerySet)()
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name="members")
     game = models.ForeignKey("game.Game", on_delete=models.CASCADE, related_name="members")
     nation = models.ForeignKey("nation.Nation", on_delete=models.CASCADE, related_name="members", null=True, blank=True)

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -762,19 +762,20 @@ class TestReplaceableSerialization:
         assert response.data["members"][0]["replaceable"] is False
 
     @pytest.mark.django_db
-    def test_not_replaceable_when_replaced(
+    def test_replaced_member_is_not_listed(
         self, authenticated_client, classical_variant, classical_england_nation, primary_user, secondary_user
     ):
         game = Game.objects.create(name="T", variant=classical_variant, status=GameStatus.ACTIVE)
         replacement = game.members.create(user=secondary_user, nation=classical_england_nation)
-        game.members.create(
+        replaced = game.members.create(
             user=primary_user, nation=classical_england_nation, civil_disorder=True, replaced_by=replacement
         )
         url = reverse(retrieve_viewname, args=[game.id])
         response = authenticated_client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        primary_member = next(m for m in response.data["members"] if m["is_current_user"])
-        assert primary_member["replaceable"] is False
+        assert [m["id"] for m in response.data["members"]] == [replacement.id]
+        assert not any(m["is_current_user"] for m in response.data["members"])
+        assert replaced.replaceable is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does

After `replace_member_with_bot` hands a seat over, the Player Info screen showed that nation **twice** — once as the bot now playing it, once as the player it replaced.

The replaced member is deliberately kept (so its past messages and phase states stay attributable for statistics), but it should not be presented as a current participant.

Adds `MemberQuerySet.not_replaced()` and applies it to the three `members` prefetches behind `with_list_data`, `with_retrieve_data` and `with_related_data`, so every consumer of `game.members` sees one member per seat. Fixing it at the queryset rather than in `PlayerInfoContent` also corrects the counts derived from that list — the open-seat maths in `GameInfo`/`PlayerInfoContent` and the "n/7 joined" label on `GameCard` were all counting the vacated seat.

Read access for a replaced player is unchanged: they can still view the game and the channels they were in, they are just no longer listed as playing.

### Why not filter on `kicked`

`getChannelFlagUrls` and `ProposeDrawScreen` already filter `kicked`, but `kicked` is the wrong signal here — account deletion kicks a member without replacing them, and that seat *should* still be listed until someone takes it over. `replaced_by` is what marks a seat as handed on.

### Checked for collateral damage

- **Chat sender attribution** — unaffected. `ChannelMessageSerializer.sender` is a nested `ChannelMemberSerializer`, so past messages carry their own sender; they don't look the member up in `game.members`.
- **Draw proposals** — `DrawProposalsScreen` resolves `includedMemberIds` against `game.members` and already `.filter(Boolean)`s misses, and draw proposals only ever include non-kicked members.
- **Orders screen** — `PhaseStateListView` returns only the requesting user's own phase state, so no duplicate-nation grouping there.
- **`replaceable`** — a read-only serializer field with no backend gate and no frontend consumer. `test_not_replaceable_when_replaced` located its member via `is_current_user`, which no longer matches; it is re-aimed at the now-stronger guarantee (the replaced member is absent entirely) and still asserts the model property directly.

## Screenshots

Captured against the real stack (local Postgres, seeded classical game, Italy handed to `dealmakerbot`), not MSW mocks — the change is in the API payload, so mocks would render identically before and after.

**Before** — Italy listed twice, "The Dealmaker" and "Player 6"; 8 rows for a 7-seat variant:

<!-- screenshot: before.png -->

**After** — 7 rows, Italy held by The Dealmaker alone:

<!-- screenshot: after.png -->

I could not attach the image files from this session: there is no `gh` CLI here and GitHub's attachment upload is not exposed through the API, so the two placeholders above need the PNGs dropping in. I have sent both files to the author in chat.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — captured, but see the note above

`/review-pr` shells out to `gh pr diff`, and this session's git remote points at a local proxy rather than a GitHub host, so `gh` exits with "none of the git remotes configured for this repository point to a known GitHub host". Worth running from a normal checkout before merge.

Two new API tests (`test_replaced_member_is_excluded_from_members` on retrieve, `test_list_excludes_replaced_member` on list) assert exactly which member IDs come back; both were confirmed failing against `main`. Full backend suite 2064 passed. No serializer fields changed, so the OpenAPI schemas and generated clients are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwghUozEdWnxAsxy5A46Gg)_