### PR TITLE
Add The Gaffer to the bot roster

### DIFF
--- a/packages/web/src/mocks/fixtures/users.ts
+++ b/packages/web/src/mocks/fixtures/users.ts
@@ -63,6 +63,7 @@ export const botRoster: AvailableBot[] = [
   { userId: 103, name: "The Commissar", picture: null, kind: "llm" },
   { userId: 104, name: "The Dealmaker", picture: null, kind: "llm" },
   { userId: 105, name: "The Eagle", picture: null, kind: "llm" },
+  { userId: 113, name: "The Gaffer", picture: null, kind: "llm" },
   { userId: 106, name: "The Imperator", picture: null, kind: "llm" },
   { userId: 107, name: "The Iron Lady", picture: null, kind: "llm" },
   { userId: 108, name: "The Revolutionary", picture: null, kind: "llm" },

--- a/service/bot_profile/migrations/0005_seed_gaffer.py
+++ b/service/bot_profile/migrations/0005_seed_gaffer.py
@@ -1,0 +1,61 @@
+from django.db import migrations
+
+BOT_EMAIL_DOMAIN = "bots.diplicity.com"
+
+GAFFER = {
+    "name": "The Gaffer",
+    "slug": "gaffer",
+    "disposition": (
+        "posture: warm and coalition-minded; would rather have an understanding with everybody than a decisive move against anybody\n"
+        "alliances: offered generously and to more partners than the board can support; honoured sincerely toward whoever it spoke to most recently\n"
+        "betrayal trigger: rarely betrays by design, but blunders into it by promising the same province twice and having to choose\n"
+        "when losing: appeals to old friendships and long service, and insists the position is well in hand"
+    ),
+    "voice": (
+        "Reference: An elderly career politician of a great republic, decades of service and anecdotes behind him, folksy and well-meaning, whose sentences set off with total confidence and arrive somewhere else entirely.\n\n"
+        "Signature vocabulary & themes: look, here's the thing, folks, let me be clear, no joke, c'mon man, we're not gonna, I give you my word, the deal is, back when, anyway, you know.\n\n"
+        "Cadence: Opens firm and loses the thread halfway. Corrects itself mid-sentence and restates the claim differently from how it began. Trails off with \"...you know...\" or abandons the point outright. Restarts its own counting (\"three... uh, four things\"). Veers into an unrelated fact or an old anecdote before snapping back. Short clauses, false starts, a little breathless. Flashes of sudden clarity or raised-voice aggression cut through the confusion for comic contrast."
+    ),
+}
+
+
+def seed_gaffer(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    UserProfile = apps.get_model("user_profile", "UserProfile")
+    BotProfile = apps.get_model("bot_profile", "BotProfile")
+
+    email = f"{GAFFER['slug']}@{BOT_EMAIL_DOMAIN}"
+    username = f"{GAFFER['slug']}bot"
+    user, _ = User.objects.get_or_create(
+        email=email,
+        defaults={"username": username, "is_active": True},
+    )
+    UserProfile.objects.update_or_create(
+        user=user,
+        defaults={"name": GAFFER["name"]},
+    )
+    BotProfile.objects.update_or_create(
+        user=user,
+        defaults={
+            "kind": "llm",
+            "disposition": GAFFER["disposition"],
+            "voice": GAFFER["voice"],
+        },
+    )
+
+
+def remove_gaffer(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    User.objects.filter(email=f"{GAFFER['slug']}@{BOT_EMAIL_DOMAIN}").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bot_profile", "0004_seed_dumbbot_roster"),
+        ("user_profile", "0005_remove_userprofile_colorblind_mode"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_gaffer, remove_gaffer),
+    ]

--- a/service/bot_profile/tests.py
+++ b/service/bot_profile/tests.py
@@ -42,7 +42,7 @@ class TestBotRoster:
     @pytest.mark.django_db
     def test_roster_is_seeded(self):
         roster = BotProfile.objects.exclude(user=get_bot_user()).llm()
-        assert roster.count() == 12
+        assert roster.count() == 13
         assert all(profile.disposition and profile.voice for profile in roster)
 
     @pytest.mark.django_db
@@ -78,7 +78,7 @@ class TestAvailableBots:
         response = authenticated_client.get(reverse(available_bots_viewname, args=[game.id]))
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 20
+        assert len(response.data) == 21
         names = [bot["name"] for bot in response.data]
         assert names == sorted(names)
         assert all(bot["user_id"] for bot in response.data)
@@ -95,7 +95,7 @@ class TestAvailableBots:
         response = authenticated_client.get(reverse(available_bots_viewname, args=[game.id]))
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 19
+        assert len(response.data) == 20
         assert bot_user.id not in [bot["user_id"] for bot in response.data]
 
     @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does

Adds a thirteenth LLM bot persona, **The Gaffer**, to the roster via a data migration (`bot_profile/0005_seed_gaffer.py`), following the shape of `0002_seed_roster` and `0004_seed_dumbbot_roster` — `get_or_create` the `auth.User` keyed on `gaffer@bots.diplicity.com`, `update_or_create` the `UserProfile` name and the `BotProfile` (`kind="llm"`, disposition, voice), with a reverse that deletes the user.

The persona is written in the same three-field voice format the existing roster uses (Reference / Signature vocabulary & themes / Cadence): a folksy elderly statesman whose sentences start confident and lose the thread, self-correct mid-claim, trail off, wander into an old anecdote, and occasionally snap into sudden sharp clarity. The disposition is coalition-minded and over-promising — it offers alliances to more partners than the board can support and blunders into betrayal by promising the same province twice.

Also updates the roster counts in `bot_profile/tests.py` (12 → 13 LLM bots, 20 → 21 and 19 → 20 available bots) and adds The Gaffer to the frontend mock `botRoster` fixture so the mocked available-bots list stays in sync with the seeded roster.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, single seed migration plus test count updates
- [x] Tests cover the change — `test_roster_is_seeded` asserts the new count and that every LLM profile has a disposition and voice; full backend suite passes (2076 passed) and frontend suite passes (540 passed)
- [x] Screenshots embedded in the PR description for any visual changes — none; the only UI-visible effect is one extra name in the existing add-bot list

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtocA6BM95DtCbMPDNGndD)_