### PR TITLE
Stop treating doomed attacks on convoying fleets as paradoxes

### DIFF
--- a/service/adjudicator/resolution.py
+++ b/service/adjudicator/resolution.py
@@ -27,20 +27,21 @@ The internal representation is an explicit Decision graph:
         strictly exceeds every external competitor's prevent, all
         members succeed (DATC 6.F.4).
 
+      - Guaranteed bounces: a Move whose maximum possible attack
+        strength cannot exceed a resolved competitor's prevent
+        strength, or the resolved hold strength of the unit at its
+        target, is beaten however the rest of the graph settles and
+        is forced to bounce; the rest of the cycle then collapses
+        through normal propagation. This covers contested rotations
+        (DATC 6.C) and doomed attacks on convoying fleets.
+
       - Convoy paradoxes (Szykman's rule): cycles in the dependency
         graph that involve at least one `_CONVOY_PATH_INTACT`
         decision are broken by forcing all such decisions in the
         cycle to False, disrupting the relevant convoys (DATC
         Szykman's rule, 6.F.13ff). This matches the modern
-        adjudication consensus.
-
-      - Contested rotations: a rotational cycle (DATC 6.C) whose
-        members are attacked from outside by an equal-or-greater
-        force is not clean, but each member is still individually
-        determined. Any member whose maximum possible attack
-        strength cannot exceed a resolved competitor's prevent is
-        forced to bounce; the rest of the cycle then collapses
-        through normal propagation.
+        adjudication consensus. It is tried last, because a cycle
+        that some other breaker can decide is not a paradox.
 
     Cycles that match none of these shapes are unresolvable in the
     current solver and will exhaust the `_MAX_CYCLE_PASSES` cap, raising
@@ -193,12 +194,12 @@ class _Solver:
                 if passes > self._MAX_CYCLE_PASSES:
                     raise RuntimeError("Decision graph did not converge")
                 continue
-            if self._try_resolve_szykman_paradoxes():
+            if self._try_resolve_guaranteed_bounces():
                 passes += 1
                 if passes > self._MAX_CYCLE_PASSES:
                     raise RuntimeError("Decision graph did not converge")
                 continue
-            if self._try_resolve_guaranteed_bounces():
+            if self._try_resolve_szykman_paradoxes():
                 passes += 1
                 if passes > self._MAX_CYCLE_PASSES:
                     raise RuntimeError("Decision graph did not converge")
@@ -1105,22 +1106,32 @@ class _Solver:
         possibly enter its target regardless of how the remaining
         decisions settle.
 
-        A Move needs its attack strength to *strictly exceed* every
-        competitor's prevent strength. The most attack strength a Move
-        could ever muster is one plus each of its matched supports —
-        support cuts and the own-nation exclusion only ever reduce it.
-        So if that ceiling is no greater than some already-resolved
-        competitor's prevent strength, the Move is beaten no matter what
-        the unresolved decisions turn out to be, and it bounces.
+        A Move needs its attack strength to *strictly exceed* both every
+        competitor's prevent strength and the defender's hold strength.
+        The most attack strength a Move could ever muster is one plus
+        each of its matched supports — support cuts and the own-nation
+        exclusion only ever reduce it. So if that ceiling is no greater
+        than an already-resolved competitor's prevent strength, or no
+        greater than the already-resolved hold strength of the unit at
+        its target, the Move is beaten no matter what the unresolved
+        decisions turn out to be, and it bounces.
 
-        This is the last-resort breaker: it runs only after the clean-
-        cycle and Szykman handlers have declined. It resolves rotational
-        cycles (DATC 6.C) whose members are contested from outside by an
-        equal-or-greater attack — the external competition makes the
-        cycle un-clean (so the clean-cycle handler rejects it) while
-        leaving each member individually determined. Forcing the beaten
-        member to bounce collapses the rest of the cycle through normal
-        propagation.
+        It runs after the clean-cycle handler has declined but *before*
+        Szykman. Order matters: a doomed attack on a convoying fleet
+        puts a `_CONVOY_PATH_INTACT` decision in a dependency cycle even
+        though the cycle has a unique solution (the convoy survives,
+        because the attack could never have dislodged the fleet). Szykman
+        would break that cycle by disrupting the convoy, which is wrong —
+        a cyclic dependency is not the same thing as a paradox. Deciding
+        the doomed attack first dissolves the cycle and leaves the
+        paradox rule for genuine paradoxes.
+
+        It also resolves rotational cycles (DATC 6.C) whose members are
+        contested from outside by an equal-or-greater attack — the
+        external competition makes the cycle un-clean (so the clean-cycle
+        handler rejects it) while leaving each member individually
+        determined. Forcing the beaten member to bounce collapses the
+        rest of the cycle through normal propagation.
 
         Only fires for a convoyed Move once its convoy path is known
         intact, so a broken-convoy failure is never mislabelled as a
@@ -1143,6 +1154,7 @@ class _Solver:
                 continue
             ceiling = 1 + len(_matching_attack_supports(self._state, i))
             target_parent = variant.parent_of(order.target)
+            forced_reason: Optional[str] = None
             for j, other in enumerate(parsed):
                 if j == i:
                     continue
@@ -1156,17 +1168,27 @@ class _Solver:
                 if prevent is None:
                     continue
                 if ceiling <= prevent:
-                    self._decisions[key] = replace(
-                        decision,
-                        value=(
-                            Status.BOUNCE,
-                            "The attack was prevented by a competing move "
-                            "of equal or greater strength.",
-                        ),
+                    forced_reason = (
+                        "The attack was prevented by a competing move "
+                        "of equal or greater strength."
                     )
-                    self._enqueue_dependents(key)
-                    changed = True
                     break
+            if forced_reason is None:
+                defender_idx = _defender_order_index(self._state, i)
+                if defender_idx is not None:
+                    hold = self._dec_value((_HOLD_STRENGTH, defender_idx))
+                    if hold is not None and ceiling <= hold:
+                        forced_reason = (
+                            "The attack was not strong enough to dislodge "
+                            "the defender."
+                        )
+            if forced_reason is None:
+                continue
+            self._decisions[key] = replace(
+                decision, value=(Status.BOUNCE, forced_reason)
+            )
+            self._enqueue_dependents(key)
+            changed = True
         return changed
 
     # --- Completeness check ---

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -3369,6 +3369,37 @@ def test_f_25_cut_support_last():
     assert _datc_has_unit(result, "germany", "Army", "nwy")
 
 
+def test_doomed_attack_on_convoying_fleet_does_not_disrupt_convoy():
+    variant = _datc_classical_variant()
+    state = (
+        _DatcStateBuilder(variant)
+        .at_phase("Spring", 1901, "Movement")
+        .with_unit("france", "Army", "hol")
+        .with_unit("france", "Fleet", "nth")
+        .with_unit("france", "Fleet", "eng")
+        .with_unit("england", "Fleet", "lon")
+        .with_unit("england", "Fleet", "nrg")
+        .with_unit("germany", "Fleet", "hel")
+        .with_order("france", "hol", "Move", target="lon")
+        .with_order("france", "nth", "Convoy", aux="hol", target="lon")
+        .with_order("france", "eng", "Support", aux="hol", target="lon")
+        .with_order("england", "lon", "Support", aux="nrg", target="nth")
+        .with_order("england", "nrg", "Move", target="nth")
+        .with_order("germany", "hel", "Support", aux="nth")
+        .build()
+    )
+
+    result = _datc_adjudicate_one(variant, state)
+
+    assert _datc_resolution_for(result, "hol") == "OK"
+    assert _datc_has_unit(result, "france", "Army", "lon")
+    assert _datc_has_unit(result, "france", "Fleet", "nth")
+    assert not _datc_is_dislodged(result, "nth")
+    assert _datc_is_dislodged(result, "lon")
+    assert _datc_resolution_for(result, "nrg") == "BOUNCE"
+    assert _datc_resolution_for(result, "lon") == "CUT"
+
+
 # === DATC 6.G: CONVOYING TO ADJACENT PROVINCES ===
 
 


### PR DESCRIPTION
## What this PR does

Fixes the incorrect convoy resolution reported in [Discussion #1132](https://github.com/johnpooch/diplicity-react/discussions/1132). A convoy was being disrupted by an attack on the convoying fleet that never had a chance of dislodging it, so a convoyed army bounced when it should have taken the province.

### The bug, in game terms

The reported position:

```
France:   A hol - lon,  F nth C hol - lon,  F eng S hol - lon
England:  F lon S nrg - nth,  F nrg - nth
Germany:  F hel S nth
```

England attacks the convoying fleet in the North Sea, but that attack is doomed: `nrg - nth` musters at most strength 2 (itself plus London's support), and the North Sea defends at 2 (itself plus Heligoland's support). 2 does not beat 2, so the North Sea survives no matter what else happens on the board. The convoy should therefore go through, and `A hol - lon` at strength 2 should dislodge the London fleet, which is only holding at 1.

Instead the engine bounced the army with the reason *"The convoy was disrupted."* — while reporting, in the very same result, that the North Sea fleet was **not** dislodged. A convoy can only be disrupted by its fleet being dislodged, so that result contradicted itself.

### Why it happened

The movement resolver works on a graph of interdependent decisions ("is this support cut?", "does this move succeed?"). Some of those decisions genuinely depend on each other in a loop, and the solver has a set of handlers for breaking loops it cannot otherwise resolve.

This position produces a loop:

```
is the convoy intact?  →  does nrg - nth succeed?  →  how strong is that attack?
      ↑                                                          ↓
      └──────────────  is London's support cut?  ←───────────────┘
```

Every loop touching a convoy was handed to **Szykman's rule**, the standard remedy for genuine convoy paradoxes, which resolves them by disrupting the convoy. That was the wrong call here, because **a cyclic dependency is not the same thing as a paradox**. A real paradox has no consistent answer (or two competing ones); this loop has exactly one. Assuming the convoy is intact is self-consistent: London's support gets cut, the attack on the North Sea weakens to 1, the fleet survives, and the convoy is indeed intact. Assuming the convoy is disrupted contradicts itself: London's support stands, the attack reaches 2, that still fails to dislodge, and the convoy turns out to have been intact after all. Szykman's rule was being applied to a question that already had an answer.

### The fix

The solver already had a handler for exactly this kind of reasoning — `_try_resolve_guaranteed_bounces`, which bounces a move whose best possible attack strength cannot win, regardless of how the undecided parts of the graph settle. It missed this case for two reasons, both addressed here:

1. **It only compared against competing moves.** It checked a move's attack ceiling against rival moves racing for the same province, but never against the hold strength of the unit already sitting there. It now checks both. This is a safe comparison: a move's true attack strength can never exceed its ceiling of one plus its matched supports, since cuts and the own-nation exclusion only ever subtract.

2. **It ran after Szykman.** The order in the solve loop is now clean cycles → guaranteed bounces → Szykman. Deciding the doomed attack first dissolves the loop on its own, so the paradox rule is only reached for positions that are actually paradoxical.

With that, `nrg - nth` is settled as a bounce before any loop-breaking is attempted, and the rest of the position falls out normally: the army reaches London, the London fleet is dislodged, and the North Sea holds.

## Testing

- New regression test `test_doomed_attack_on_convoying_fleet_does_not_disrupt_convoy` covering the reported position.
- Full adjudicator suite passes (377 tests), including the complete DATC 6.F convoy-paradox set 6.F.13–6.F.25 — genuine paradoxes still resolve via Szykman exactly as before. Verified by instrumentation that the Szykman handler no longer fires on this position and did fire before.
- `order`, `phase`, `game` and `integration` suites pass (908 and 894 tests respectively).
- I also ran `integration/test_replay.py`, the full-game replay suite that is excluded from the default run. It has 4 pre-existing failures on `main`; the failure output is byte-identical with and without this change, so the replay fixtures are unaffected. Those failures are error-label mismatches against the godip fixtures (e.g. expected `ErrMissingConvoyPath`, got `ErrBounce`) and are out of scope here.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — the skill could not run in this environment (it shells out to `gh pr diff`, and the session's git remote is a local proxy rather than a GitHub host). I self-reviewed the diff manually instead; the edge cases I worked through are head-to-head pairs, defenders that vacate, illegal orders at the target, and convoyed swaps, none of which change behaviour.
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only