### PR TITLE
Finalize bot orders at phase start when no human can order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,13 @@ Governing rule: **harness is pure; agent is where the world touches it.**
   status, and dispatches to the executor. One AgentTask may span several
   Inference calls. A periodic agent.reconcile task re-drives rows whose job
   was lost or stalled (pending or stuck in running past a timeout), so a
-  hand-inserted row runs on the next sweep.
+  hand-inserted row runs on the next sweep. A bot plans when a phase starts
+  and finalizes (submits *and* confirms) once no human is still pending, which
+  both specs decide through the shared `_humans_pending` check: normally that
+  lands on phase_state_confirmed, but a phase where no human has possible
+  orders — a retreat only a bot must answer, an all-bot game — already
+  satisfies it at phase_started, so PhaseStartedSpec queues finalize instead
+  of plan for those seats rather than waiting for an event that never comes.
 - bot_profile — BotProfile persona (disposition, voice), roster-management
   endpoints, get_bot_user, and the roster seed.
 
@@ -137,7 +143,7 @@ adjudication does not receive two order sets for one nation. Finally it queues a
 
 A kicked member's phase states are created with `has_possible_orders=False`, which
 keeps a replaced seat out of the "is everyone done?" checks — early resolution
-(`filter_due_phases`), the bot finalize trigger (`when_humans_confirmed`), NMR
+(`filter_due_phases`), the bot finalize trigger (`_humans_pending`), NMR
 extensions and deadline warnings all key off that flag.
 
 A replaced player keeps their account, so every write path has to lock them out.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Governing rule: **harness is pure; agent is where the world touches it.**
   was lost or stalled (pending or stuck in running past a timeout), so a
   hand-inserted row runs on the next sweep. A bot plans when a phase starts
   and finalizes (submits *and* confirms) once no human is still pending, which
-  both specs decide through the shared `_humans_pending` check: normally that
+  both specs decide through the shared `Phase.has_unconfirmed_human` check: normally that
   lands on phase_state_confirmed, but a phase where no human has possible
   orders — a retreat only a bot must answer, an all-bot game — already
   satisfies it at phase_started, so PhaseStartedSpec queues finalize instead
@@ -143,7 +143,7 @@ adjudication does not receive two order sets for one nation. Finally it queues a
 
 A kicked member's phase states are created with `has_possible_orders=False`, which
 keeps a replaced seat out of the "is everyone done?" checks — early resolution
-(`filter_due_phases`), the bot finalize trigger (`_humans_pending`), NMR
+(`filter_due_phases`), the bot finalize trigger (`Phase.has_unconfirmed_human`), NMR
 extensions and deadline warnings all key off that flag.
 
 A replaced player keeps their account, so every write path has to lock them out.

--- a/service/agent/registry.py
+++ b/service/agent/registry.py
@@ -30,6 +30,26 @@ def _bot_user_ids_for_phase(phase_id):
     )
 
 
+def _humans_pending(phase, bot_user_ids):
+    return (
+        phase.phase_states.filter(has_possible_orders=True, orders_confirmed=False)
+        .exclude(member__user_id__in=bot_user_ids)
+        .exists()
+    )
+
+
+def _finalize_tasks(phase, bot_user_ids):
+    bot_phase_states = phase.phase_states.filter(
+        has_possible_orders=True,
+        orders_confirmed=False,
+        member__user_id__in=bot_user_ids,
+    ).select_related("member")
+    return [
+        {"kind": AgentTaskKind.FINALIZE, "member": phase_state.member, "phase": phase}
+        for phase_state in bot_phase_states
+    ]
+
+
 class AgentTaskSpec:
     event_type = None
 
@@ -44,10 +64,20 @@ class AgentTaskSpec:
 class PhaseStartedSpec(AgentTaskSpec):
     def get_tasks(self):
         phase = self.context.phase
-        bot_members = Member.objects.filter(game_id=phase.game_id, user__bot_profile__isnull=False).select_related(
-            "user"
+        bot_members = list(
+            Member.objects.filter(game_id=phase.game_id, user__bot_profile__isnull=False).select_related("user")
         )
-        return [{"kind": AgentTaskKind.PLAN, "member": member, "phase": phase} for member in bot_members]
+        if not bot_members:
+            return []
+
+        bot_user_ids = {member.user_id for member in bot_members}
+        finalize = [] if _humans_pending(phase, bot_user_ids) else _finalize_tasks(phase, bot_user_ids)
+        finalizing = {task["member"].id for task in finalize}
+        return finalize + [
+            {"kind": AgentTaskKind.PLAN, "member": member, "phase": phase}
+            for member in bot_members
+            if member.id not in finalizing
+        ]
 
 
 @register("phase_state_confirmed")
@@ -59,24 +89,9 @@ class PhaseStateConfirmedSpec(AgentTaskSpec):
             return []
         if phase.status != PhaseStatus.ACTIVE:
             return []
-
-        humans_pending = (
-            phase.phase_states.filter(has_possible_orders=True, orders_confirmed=False)
-            .exclude(member__user_id__in=bot_user_ids)
-            .exists()
-        )
-        if humans_pending:
+        if _humans_pending(phase, bot_user_ids):
             return []
-
-        bot_phase_states = phase.phase_states.filter(
-            has_possible_orders=True,
-            orders_confirmed=False,
-            member__user_id__in=bot_user_ids,
-        ).select_related("member")
-        return [
-            {"kind": AgentTaskKind.FINALIZE, "member": phase_state.member, "phase": phase}
-            for phase_state in bot_phase_states
-        ]
+        return _finalize_tasks(phase, bot_user_ids)
 
 
 @register("channel_message")

--- a/service/agent/registry.py
+++ b/service/agent/registry.py
@@ -1,7 +1,6 @@
 from bot_profile.constants import BotKind
 from bot_profile.models import BotProfile
 from common.constants import PhaseStatus
-from member.models import Member
 
 from agent.constants import AgentTaskKind
 
@@ -24,25 +23,11 @@ def get_spec(event_type, context):
     return spec_class(context)
 
 
-def _bot_user_ids_for_phase(phase_id):
-    return set(
-        Member.objects.filter(game__phases=phase_id, user__bot_profile__isnull=False).values_list("user_id", flat=True)
-    )
-
-
-def _humans_pending(phase, bot_user_ids):
-    return (
-        phase.phase_states.filter(has_possible_orders=True, orders_confirmed=False)
-        .exclude(member__user_id__in=bot_user_ids)
-        .exists()
-    )
-
-
-def _finalize_tasks(phase, bot_user_ids):
+def _finalize_tasks(phase):
     bot_phase_states = phase.phase_states.filter(
         has_possible_orders=True,
         orders_confirmed=False,
-        member__user_id__in=bot_user_ids,
+        member__user__bot_profile__isnull=False,
     ).select_related("member")
     return [
         {"kind": AgentTaskKind.FINALIZE, "member": phase_state.member, "phase": phase}
@@ -64,34 +49,26 @@ class AgentTaskSpec:
 class PhaseStartedSpec(AgentTaskSpec):
     def get_tasks(self):
         phase = self.context.phase
-        bot_members = list(
-            Member.objects.filter(game_id=phase.game_id, user__bot_profile__isnull=False).select_related("user")
-        )
-        if not bot_members:
+        plan = [{"kind": AgentTaskKind.PLAN, "member": member, "phase": phase} for member in phase.game.bot_members]
+        if not plan:
             return []
+        if phase.has_unconfirmed_human:
+            return plan
 
-        bot_user_ids = {member.user_id for member in bot_members}
-        finalize = [] if _humans_pending(phase, bot_user_ids) else _finalize_tasks(phase, bot_user_ids)
+        finalize = _finalize_tasks(phase)
         finalizing = {task["member"].id for task in finalize}
-        return finalize + [
-            {"kind": AgentTaskKind.PLAN, "member": member, "phase": phase}
-            for member in bot_members
-            if member.id not in finalizing
-        ]
+        return finalize + [task for task in plan if task["member"].id not in finalizing]
 
 
 @register("phase_state_confirmed")
 class PhaseStateConfirmedSpec(AgentTaskSpec):
     def get_tasks(self):
         phase = self.context.phase
-        bot_user_ids = _bot_user_ids_for_phase(phase.id)
-        if not bot_user_ids:
-            return []
         if phase.status != PhaseStatus.ACTIVE:
             return []
-        if _humans_pending(phase, bot_user_ids):
+        if phase.has_unconfirmed_human:
             return []
-        return _finalize_tasks(phase, bot_user_ids)
+        return _finalize_tasks(phase)
 
 
 @register("channel_message")

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -22,6 +22,7 @@ from bot_profile.utils import get_bot_user
 from channel.models import ChannelMessage
 from common.constants import OrderType, PhaseStatus, PhaseType
 from emit.context import build_context
+from emit.dispatch import emit
 from inference.clients.base import InferenceResult
 from inference.constants import InferenceStatus
 from inference.models import Inference
@@ -543,6 +544,34 @@ class TestFinalizeTrigger:
         assert len(jobs) == 1
         assert jobs[0]["lock"] == f"agent-task-{task.id}"
 
+    @pytest.mark.django_db
+    def test_phase_start_creates_task_and_defers_run_when_no_human_can_order(
+        self,
+        phase_factory,
+        user_factory,
+        classical_england_nation,
+        classical_france_nation,
+        in_memory_procrastinate,
+    ):
+        bot_user = get_bot_user()
+        phase = phase_factory(
+            phase_states_config=[
+                {"nation": classical_england_nation, "user": bot_user, "has_possible_orders": True},
+                {"nation": classical_france_nation, "user": user_factory(), "has_possible_orders": False},
+            ]
+        )
+
+        emit("phase_started", phase=phase)
+
+        task = AgentTask.objects.get(kind=AgentTaskKind.FINALIZE, member__user=bot_user)
+        assert task.phase == phase
+        assert task.status == AgentTaskStatus.PENDING
+        assert not AgentTask.objects.filter(kind=AgentTaskKind.PLAN).exists()
+
+        jobs = _run_jobs_for(in_memory_procrastinate, task)
+        assert len(jobs) == 1
+        assert jobs[0]["lock"] == f"agent-task-{task.id}"
+
 
 class TestReplyTask:
 
@@ -836,6 +865,122 @@ class TestAgentTaskRun:
         task.refresh_from_db()
         assert task.status == AgentTaskStatus.SUCCEEDED
         assert task.attempts == 1
+
+
+class TestPhaseStartedSpec:
+
+    def _phase(self, phase_factory, states):
+        config = [
+            {
+                "nation": nation,
+                "user": user,
+                "has_possible_orders": has_possible_orders,
+                "orders_confirmed": confirmed,
+            }
+            for nation, user, has_possible_orders, confirmed in states
+        ]
+        return phase_factory(phase_states_config=config)
+
+    def _descriptors(self, phase):
+        return registry.PhaseStartedSpec(build_context("phase_started", phase=phase)).get_tasks()
+
+    @pytest.mark.django_db
+    def test_plan_only_while_a_human_is_pending(
+        self, phase_factory, user_factory, classical_england_nation, classical_france_nation
+    ):
+        bot_user = get_bot_user()
+        phase = self._phase(
+            phase_factory,
+            [
+                (classical_england_nation, bot_user, True, False),
+                (classical_france_nation, user_factory(), True, False),
+            ],
+        )
+
+        descriptors = self._descriptors(phase)
+
+        assert len(descriptors) == 1
+        assert descriptors[0]["kind"] == AgentTaskKind.PLAN
+        assert descriptors[0]["member"].user_id == bot_user.id
+
+    @pytest.mark.django_db
+    def test_finalize_when_no_human_has_possible_orders(
+        self, phase_factory, user_factory, classical_england_nation, classical_france_nation
+    ):
+        bot_user = get_bot_user()
+        phase = self._phase(
+            phase_factory,
+            [
+                (classical_england_nation, bot_user, True, False),
+                (classical_france_nation, user_factory(), False, False),
+            ],
+        )
+
+        descriptors = self._descriptors(phase)
+
+        assert len(descriptors) == 1
+        assert descriptors[0]["kind"] == AgentTaskKind.FINALIZE
+        assert descriptors[0]["member"].user_id == bot_user.id
+
+    @pytest.mark.django_db
+    def test_finalize_when_every_human_is_already_confirmed(
+        self, phase_factory, user_factory, classical_england_nation, classical_france_nation
+    ):
+        bot_user = get_bot_user()
+        phase = self._phase(
+            phase_factory,
+            [
+                (classical_england_nation, bot_user, True, False),
+                (classical_france_nation, user_factory(), True, True),
+            ],
+        )
+
+        descriptors = self._descriptors(phase)
+
+        assert len(descriptors) == 1
+        assert descriptors[0]["kind"] == AgentTaskKind.FINALIZE
+        assert descriptors[0]["member"].user_id == bot_user.id
+
+    @pytest.mark.django_db
+    def test_bot_without_possible_orders_plans_alongside_a_finalizing_bot(
+        self, phase_factory, user_factory, classical_england_nation, classical_france_nation
+    ):
+        bot_user = get_bot_user()
+        idle_bot_user = user_factory()
+        BotProfile.objects.create(user=idle_bot_user, disposition="Cautious", voice="Terse")
+        phase = self._phase(
+            phase_factory,
+            [
+                (classical_england_nation, bot_user, True, False),
+                (classical_france_nation, idle_bot_user, False, False),
+            ],
+        )
+
+        descriptors = self._descriptors(phase)
+
+        assert {(d["kind"], d["member"].user_id) for d in descriptors} == {
+            (AgentTaskKind.FINALIZE, bot_user.id),
+            (AgentTaskKind.PLAN, idle_bot_user.id),
+        }
+
+    @pytest.mark.django_db
+    def test_confirmed_bot_is_not_asked_to_finalize_again(
+        self, phase_factory, user_factory, classical_england_nation, classical_france_nation
+    ):
+        bot_user = get_bot_user()
+        phase = self._phase(
+            phase_factory,
+            [
+                (classical_england_nation, bot_user, True, True),
+                (classical_france_nation, user_factory(), False, False),
+            ],
+        )
+
+        descriptors = self._descriptors(phase)
+
+        assert len(descriptors) == 1
+        assert descriptors[0]["kind"] == AgentTaskKind.PLAN
+        assert descriptors[0]["member"].user_id == bot_user.id
 
 
 class TestPhaseStateConfirmedSpec:

--- a/service/agent/tests.py
+++ b/service/agent/tests.py
@@ -439,20 +439,20 @@ class TestBotRequestHost:
 class TestBotIdentificationByProfile:
 
     @pytest.mark.django_db
-    def test_bot_user_ids_for_phase_ignores_email(self, phase_factory, classical_england_nation):
+    def test_bot_members_ignores_email(self, phase_factory, classical_england_nation):
         bot_user = get_bot_user()
         bot_user.email = "not-the-magic-email@example.com"
         bot_user.save()
         phase = phase_factory(phase_states_config=[{"nation": classical_england_nation, "user": bot_user}])
 
-        assert registry._bot_user_ids_for_phase(phase.id) == {bot_user.id}
+        assert {member.user_id for member in phase.game.bot_members} == {bot_user.id}
 
     @pytest.mark.django_db
     def test_roster_bots_are_identified_as_bots(self, phase_factory, classical_england_nation):
         roster_user = BotProfile.objects.exclude(user=get_bot_user()).first().user
         phase = phase_factory(phase_states_config=[{"nation": classical_england_nation, "user": roster_user}])
 
-        assert roster_user.id in registry._bot_user_ids_for_phase(phase.id)
+        assert roster_user.id in {member.user_id for member in phase.game.bot_members}
 
 
 class TestFinalizeTask:

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -527,6 +527,10 @@ class Game(BaseModel):
     def anonymity_active(self):
         return self.anonymous and self.status != GameStatus.COMPLETED
 
+    @property
+    def bot_members(self):
+        return self.members.filter(user__bot_profile__isnull=False).select_related("user")
+
     def get_phase_duration_seconds(self, phase_type):
         if phase_type == PhaseType.MOVEMENT:
             return self.movement_phase_duration_seconds

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -940,6 +940,14 @@ class Phase(BaseModel):
         return all(phase_state.orders_confirmed for phase_state in self.phase_states_with_possible_orders)
 
     @property
+    def has_unconfirmed_human(self):
+        return self.phase_states.filter(
+            has_possible_orders=True,
+            orders_confirmed=False,
+            member__user__bot_profile__isnull=True,
+        ).exists()
+
+    @property
     def previous_phase_id(self):
         if not self.game:
             return None


### PR DESCRIPTION
## What this PR does

A bot never confirmed its orders in a phase where no human member had orderable units, so the phase stalled until the deadline instead of resolving early. `PhaseStartedSpec` now evaluates the same humans-pending condition that `PhaseStateConfirmedSpec` uses and queues `FINALIZE` for the orderable bot seats instead of `PLAN`. Closes #1136.

The `FINALIZE` AgentTask — the only path that calls `api.confirm_phase(...)` — was created solely in reaction to the `phase_state_confirmed` emit event, which fires only when a player confirms their own orders. When every member with `has_possible_orders=True` is a bot, no human ever hits the confirm endpoint, so the event never fires and the condition that would have queued the finalize is never evaluated. The bot's orders were still submitted by the `PLAN` task, which deliberately does not confirm, so they sat unconfirmed until the deadline sweep picked the phase up.

That covers a retreat phase only a bot nation must answer (the reported case), an adjustment phase where only bots have builds or disbands, an all-bot game, and a table whose remaining humans are all in civil disorder — civil-disorder members are created pre-confirmed, so they are not "pending" either.

Queuing finalize *instead of* plan matters rather than alongside it: `unique_phase_agent_task` is on `(kind, member, phase)`, so both rows can coexist and each defers under its own `agent-task-{id}` lock. Creating both would let one seat plan and finalize concurrently and re-submit orders after confirming. Bots without possible orders still get their `PLAN` task, unchanged.

The humans-pending and finalize-descriptor queries move to `_humans_pending` and `_finalize_tasks` so both specs share one definition instead of diverging. Behaviour when a human *is* still pending is untouched, which the existing plan/finalize trigger tests cover.

Also updates the AI player architecture notes in `CLAUDE.md`, including a stale reference to a `when_humans_confirmed` trigger that does not exist in the code.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

On the review box: `/review-pr` shells out to the `gh` CLI, which is not available in the Claude Code on the web environment (GitHub access there is via MCP tools), so the skill could not run and I have left the box unticked rather than claim otherwise. I self-reviewed the diff manually; the points that came out of it — why finalize replaces plan rather than joining it, and that kicked bots stay excluded via `has_possible_orders=False` — are covered above and in the tests. Worth a human running `/review-pr` locally.

Backend-only change, so no screenshots apply.

New tests: a `TestPhaseStartedSpec` class covering plan-only while a human is pending, finalize when no human has possible orders, finalize when every human is already confirmed, a non-orderable bot still planning alongside a finalizing bot, and an already-confirmed bot not being asked to finalize again; plus an end-to-end `emit("phase_started", ...)` trigger test asserting the queued `FINALIZE` row and its deferred job. The four tests targeting the new behaviour fail on `main` and pass here; the regression guards pass both ways.

`agent`, `phase`, `game`, `emit`, `notification` and `bot_profile` — 864 passed, 8 skipped. Integration suite — 23 passed.
