### PR TITLE
Fall back to the email local part when Google omits the name claim

### DIFF
--- a/service/login/conftest.py
+++ b/service/login/conftest.py
@@ -32,6 +32,20 @@ def mock_google_auth_without_picture(settings):
 
 
 @pytest.fixture
+def mock_google_auth_without_name(settings):
+    settings.GOOGLE_CLIENT_ID = "web-client-id"
+    settings.GOOGLE_IOS_CLIENT_ID = "ios-client-id"
+    with patch("login.utils.google_id_token.verify_oauth2_token") as mock:
+        mock.return_value = {
+            "iss": "accounts.google.com",
+            "aud": "web-client-id",
+            "email": "test@example.com",
+            "picture": "http://example.com/picture.jpg",
+        }
+        yield mock
+
+
+@pytest.fixture
 def mock_refresh_token():
     with patch("login.serializers.RefreshToken.for_user") as mock:
         mock.return_value = type(

--- a/service/login/models.py
+++ b/service/login/models.py
@@ -8,12 +8,12 @@ from django.conf import settings
 class AuthUserManager(models.Manager):
     def create_from_google_id_info(self, id_info):
         email = id_info.get("email")
-        name = id_info.get("name")
+        name = id_info.get("name") or email.split("@")[0]
 
         user, created = self.get_or_create(
             email=email, defaults={"username": self.generate_username(name), "password": settings.SOCIAL_AUTH_PASSWORD}
         )
-        return user, created
+        return user, created, name
 
     def create_from_apple_id_info(self, decoded_token, first_name=None, last_name=None):
         email = decoded_token.get("email")

--- a/service/login/serializers.py
+++ b/service/login/serializers.py
@@ -47,13 +47,13 @@ class AuthSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         id_info = verify_google_id_token(validated_data["id_token"])
-        user, _ = AuthUser.objects.create_from_google_id_info(id_info)
+        user, _, name = AuthUser.objects.create_from_google_id_info(id_info)
         if not user.is_active:
             user.is_active = True
             user.save(update_fields=["is_active"])
         profile, created = UserProfile.objects.get_or_create(
             user=user,
-            defaults={"name": id_info.get("name"), "picture": id_info.get("picture")},
+            defaults={"name": name, "picture": id_info.get("picture")},
         )
         if not created:
             profile.picture = id_info.get("picture")

--- a/service/login/tests.py
+++ b/service/login/tests.py
@@ -120,6 +120,35 @@ def test_updates_existing_user_picture_to_null(unauthenticated_client, mock_goog
 
 
 @pytest.mark.django_db
+def test_creates_new_user_without_name(unauthenticated_client, mock_google_auth_without_name, mock_refresh_token):
+    url = reverse(viewname)
+    response = unauthenticated_client.post(url, {"id_token": "valid_token"}, format="json")
+    assert response.status_code == status.HTTP_201_CREATED
+
+    user_profile = UserProfile.objects.get(user__email="test@example.com")
+    assert user_profile.name == "test"
+    assert user_profile.user.username == "test"
+
+
+@pytest.mark.django_db
+def test_existing_user_sign_in_without_name(unauthenticated_client, mock_google_auth_without_name, mock_refresh_token):
+    user = User.objects.create_user(
+        username="testuser",
+        email="test@example.com",
+        password="testpass123"
+    )
+    user_profile = UserProfile.objects.create(user=user, name="Custom Name")
+
+    url = reverse(viewname)
+    response = unauthenticated_client.post(url, {"id_token": "valid_token"}, format="json")
+    assert response.status_code == status.HTTP_201_CREATED
+
+    user_profile.refresh_from_db()
+    assert user_profile.name == "Custom Name"
+    assert User.objects.filter(email="test@example.com").count() == 1
+
+
+@pytest.mark.django_db
 def test_ios_client_id_audience_accepted(unauthenticated_client, mock_google_auth, mock_refresh_token):
     mock_google_auth.return_value = {
         "iss": "accounts.google.com",


### PR DESCRIPTION
## What this PR does

Fixes [DIPLICITY-API-9E](https://johnpooch.sentry.io/issues/137874650/) — `AttributeError: 'NoneType' object has no attribute 'split'` at `login/models.py:29`, on `POST /auth/login/`. Four events in nineteen seconds from one device: a user retrying a login that could not succeed.

Google Sign-In does not guarantee a `name` claim in the verified id token. When it is absent, `create_from_google_id_info` passed `None` into `generate_username`, which does `name.split(" ")`, and the request 500'd.

Two details make this worse than a new-signup edge case:

- `get_or_create(defaults={"username": self.generate_username(name), ...})` evaluates its `defaults` dict eagerly, so `generate_username` runs on *every* Google login, not just the ones that create a user. An affected account was locked out entirely, not merely blocked at registration.
- `UserProfile.name` is `CharField(max_length=255)` with no `null=True`, and `AuthSerializer.create` passed `id_info.get("name")` straight into `UserProfile.objects.get_or_create(defaults=...)`. Guarding only `generate_username` would have swapped the `AttributeError` for a `NOT NULL` `IntegrityError` one step later, so the name is derived once and used for both.

The fix mirrors the Apple path, which already handles exactly this at `login/models.py:21`: fall back to the email local part, and return the derived name to the caller the way `create_from_apple_id_info` does. Behaviour is unchanged whenever the claim is present.

## Testing

- `test_creates_new_user_without_name` — new user, no name claim: profile name and username both become `test` (from `test@example.com`).
- `test_existing_user_sign_in_without_name` — returning user, no name claim: logs in, existing profile name is preserved, no duplicate user created. This is the case that reproduces the production stack trace.
- Both fail on `main` with the production `AttributeError` and pass with the change; the full `login` suite passes (51 tests).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — not run; the change is a four-line fallback with direct test coverage. I did verify the only caller of `create_from_google_id_info` is `AuthSerializer.create`, so the return-arity change is fully covered.
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxKm5ihkgtu3WpwmC8u6EX)_