### PR TITLE
Serialise order writes against phase resolution

### DIFF
--- a/service/agent/management/commands/replace_member_with_bot.py
+++ b/service/agent/management/commands/replace_member_with_bot.py
@@ -5,10 +5,9 @@ from agent.constants import AgentTaskKind
 from agent.models import AgentTask
 from bot_profile.models import BotProfile
 from channel.models import ChannelMember
-from common.constants import PhaseStatus
 from game.models import Game
 from order.models import Order
-from phase.models import PhaseState
+from phase.models import Phase, PhaseState
 
 
 class Command(BaseCommand):
@@ -53,8 +52,9 @@ class Command(BaseCommand):
             member.replaced_by = replacement
             member.save(update_fields=["kicked", "replaced_by"])
 
-            phase = game.current_phase
-            if phase is not None and phase.status == PhaseStatus.ACTIVE:
+            current_phase = game.current_phase
+            phase = Phase.objects.lock_if_active(current_phase.id) if current_phase else None
+            if phase is not None:
                 replaced_states = phase.phase_states.filter(member=member)
                 Order.objects.filter(phase_state__in=replaced_states).delete()
                 replaced_states.update(has_possible_orders=False)

--- a/service/agent/replan.py
+++ b/service/agent/replan.py
@@ -2,8 +2,8 @@ from django.db import transaction
 
 from agent.constants import AgentTaskKind
 from agent.models import AgentTask
-from common.constants import PhaseStatus
 from order.models import Order
+from phase.models import Phase
 
 
 class ReplanError(Exception):
@@ -17,9 +17,9 @@ def replan(member):
         raise ReplanError(f"{member} has been kicked")
 
     phase = member.game.current_phase
-    if phase is None or phase.status != PhaseStatus.ACTIVE:
-        raise ReplanError(f"game '{member.game_id}' has no active phase")
 
     with transaction.atomic():
+        if phase is None or Phase.objects.lock_if_active(phase.id) is None:
+            raise ReplanError(f"game '{member.game_id}' has no active phase")
         Order.objects.filter(phase_state__member=member, phase_state__phase=phase).delete()
         return AgentTask.objects.requeue(kind=AgentTaskKind.PLAN, member=member, phase=phase)

--- a/service/order/serializers.py
+++ b/service/order/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 from django.core import exceptions
+from django.db import transaction
 from order.utils import get_options_for_order
+from phase.models import Phase
 from province.serializers import ProvinceSerializer
 from nation.serializers import NationSerializer
 from .models import Order
@@ -89,13 +91,16 @@ class OrderSerializer(serializers.Serializer):
             )
 
         if order.complete:
-            Order.objects.delete_existing_for_source(order.phase_state, order.source)
-            if self.context["phase"].type == PhaseType.ADJUSTMENT:
-                try:
-                    order.clean()
-                except exceptions.ValidationError as e:
-                    raise serializers.ValidationError(e.messages)
-            order.save()
+            with transaction.atomic():
+                if Phase.objects.lock_if_active(self.context["phase"].id) is None:
+                    raise serializers.ValidationError("Current phase is not active.")
+                Order.objects.delete_existing_for_source(order.phase_state, order.source)
+                if self.context["phase"].type == PhaseType.ADJUSTMENT:
+                    try:
+                        order.clean()
+                    except exceptions.ValidationError as e:
+                        raise serializers.ValidationError(e.messages)
+                order.save()
             return Order.objects.with_related_data().get(id=order.id)
 
         return order

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -660,7 +660,52 @@ class TestOrderCreateView:
         assert second_order.id != first_order.id
 
 
+    def test_order_create_rejected_once_the_phase_is_no_longer_active(
+        self, authenticated_client, game_with_options
+    ):
+        game = game_with_options
+        url = reverse("order-create", args=[game.id])
+
+        response = authenticated_client.post(url, {"selected": ["bud", "Hold"]}, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        phase = game.current_phase
+        phase.status = PhaseStatus.COMPLETED
+        phase.save(update_fields=["status"])
+
+        response = authenticated_client.post(url, {"selected": ["bud", "Move", "gal"]}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert Order.objects.count() == 1
+        assert Order.objects.get().order_type == OrderType.HOLD
+
+
 class TestOrderDeleteView:
+    @pytest.mark.django_db
+    def test_delete_order_rejected_once_the_phase_is_no_longer_active(
+        self,
+        authenticated_client,
+        order_active_game,
+        primary_user,
+        classical_london_province,
+    ):
+        game = order_active_game
+        phase = game.current_phase
+        phase_state = phase.phase_states.get(member__user=primary_user)
+        Order.objects.create(
+            phase_state=phase_state,
+            order_type=OrderType.HOLD,
+            source=classical_london_province,
+        )
+        phase.status = PhaseStatus.COMPLETED
+        phase.save(update_fields=["status"])
+
+        url = reverse("order-delete", args=[game.id, "lon"])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert Order.objects.count() == 1
+
     @pytest.mark.django_db
     def test_delete_order_success(
         self,
@@ -1011,7 +1056,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 15  # was 18 before resolve_game cache + dedup create_from_selected
+        assert query_count == 18  # 15 + BEGIN, SELECT ... FOR UPDATE, COMMIT for the phase lock
 
     @pytest.mark.django_db
     def test_order_create_query_count_with_support_order(self, authenticated_client, game_with_options):
@@ -1026,7 +1071,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 15
+        assert query_count == 18
 
     @pytest.mark.django_db
     def test_order_create_query_count_with_many_phase_states(self, authenticated_client, game_with_many_phase_states):
@@ -1041,7 +1086,7 @@ class TestOrderCreateViewQueryPerformance:
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
 
-        assert query_count == 15
+        assert query_count == 18
 
 
 class TestOrderDeleteViewQueryPerformance:
@@ -1075,7 +1120,7 @@ class TestOrderDeleteViewQueryPerformance:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         query_count = len(connection.queries)
 
-        assert query_count == 6
+        assert query_count == 9
 
 
 class TestGetOptionsForOrder:

--- a/service/order/views.py
+++ b/service/order/views.py
@@ -1,9 +1,11 @@
 import hashlib
 
+from django.db import transaction
 from django.shortcuts import get_object_or_404
-from rest_framework import permissions, generics, status
+from rest_framework import permissions, generics, serializers, status
 from rest_framework.response import Response
 
+from phase.models import Phase
 from .models import Order
 from .serializers import OrderSerializer, OrderOptionsResponseSerializer
 from .utils import flatten_options, build_move_coast_lookup, FIELD_ORDER
@@ -86,8 +88,14 @@ class OrderDeleteView(CurrentPhaseMixin, generics.DestroyAPIView):
     def get_object(self):
         phase = self.get_phase()
         return get_object_or_404(
-            Order,
+            Order.objects.select_related("phase_state"),
             source__province_id=self.kwargs["source_id"],
             phase_state__member__user=self.request.user,
             phase_state__phase=phase,
         )
+
+    def perform_destroy(self, instance):
+        with transaction.atomic():
+            if Phase.objects.lock_if_active(instance.phase_state.phase_id) is None:
+                raise serializers.ValidationError("Current phase is not active.")
+            instance.delete()

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -125,6 +125,14 @@ class PhaseManager(models.Manager):
 
             return phases_to_resolve
 
+    def lock_if_active(self, phase_id):
+        return (
+            self.defer("options")
+            .select_for_update()
+            .filter(pk=phase_id, status=PhaseStatus.ACTIVE)
+            .first()
+        )
+
     def resolve_if_due(self, phase_id):
         with tracer.start_as_current_span("phase.manager.resolve_if_due") as span:
             span.set_attribute("phase.id", phase_id)

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4,7 +4,7 @@ import pytest
 from django.db import IntegrityError, DatabaseError, transaction
 from django.urls import reverse
 from django.utils import timezone
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.db import connection
 from datetime import timedelta, time
 from unittest.mock import patch, Mock
@@ -998,6 +998,29 @@ class TestOptionsTransformation:
         expected = {"Russia": {"stp": {"Build": {"Army": {}, "Fleet": {"stp/nc": {}, "stp/sc": {}}}}}}
 
         assert result == expected
+
+
+class TestLockIfActive:
+
+    @pytest.mark.django_db
+    def test_returns_the_phase_and_locks_the_row(self, order_active_game):
+        phase = order_active_game.current_phase
+
+        with transaction.atomic():
+            with CaptureQueriesContext(connection) as queries:
+                locked = Phase.objects.lock_if_active(phase.id)
+
+        assert locked == phase
+        assert "FOR UPDATE" in queries[0]["sql"]
+
+    @pytest.mark.django_db
+    def test_returns_none_for_a_phase_that_is_no_longer_active(self, order_active_game):
+        phase = order_active_game.current_phase
+        phase.status = PhaseStatus.COMPLETED
+        phase.save(update_fields=["status"])
+
+        with transaction.atomic():
+            assert Phase.objects.lock_if_active(phase.id) is None
 
 
 class TestCreateFromAdjudicationData:


### PR DESCRIPTION
## What this PR does

Fixes [DIPLICITY-API-9G](https://johnpooch.sentry.io/issues/137948615/) — `ForeignKeyViolation: insert or update on table "order_orderresolution" violates foreign key constraint ... Key (order_id)=(632035) is not present in table "order_order"`, which aborts the whole phase resolution.

The stack trace is the tell: it fires at `transaction.atomic().__exit__` → `connection.commit()`, not at the insert. Django's foreign keys are `DEFERRABLE INITIALLY DEFERRED`, so the reference is checked at COMMIT. The order existed when `create_from_adjudication_data` wrote its `OrderResolution` and was deleted by another transaction before the resolver committed.

`resolve_if_due` locks the phase row for the duration of its transaction (`phase/models.py:132`), but nothing on the write side took that lock:

- `OrderSerializer.create` deletes the existing order for a source before saving the replacement (`OrderManager.delete_existing_for_source`) — and did so in autocommit, with no transaction of its own.
- `OrderDeleteView` deleted straight through DRF's default `perform_destroy`.
- `replan` and `replace_member_with_bot` delete a member's orders for the current phase.

Any of those landing during resolution takes an order out from under a resolution row that references it. Bots submit through the same endpoints as players, so a bot finalising its orders as the deadline sweep picks the phase up hits exactly this window.

## The fix

`PhaseManager.lock_if_active(phase_id)` takes the same row lock the resolver holds and returns the phase only while it is still `ACTIVE`. Under `READ COMMITTED`, a writer that queues behind a resolution re-evaluates the row once the lock is released, sees `status = COMPLETED`, and gets `None` — so the same call both waits out the resolution and detects that it lost the race.

All four order-deleting paths now go through it, so the invariant holds rather than being patched at the one site Sentry happened to catch. Writers block until an in-flight resolution commits and are then rejected with `Current phase is not active.` (400) instead of mutating a phase whose history is already written. Lock ordering is unchanged — phase row first, then orders — so there is no new deadlock edge.

Two consequences worth calling out, both visible in the diff:

- **Query counts.** Order create and delete each cost three more queries: `BEGIN`, the locking `SELECT ... FOR UPDATE`, `COMMIT`. The `TestOrderCreateViewQueryPerformance` / `TestOrderDeleteViewQueryPerformance` guards move from 15 → 18 and 6 → 9. The delete view also gains a `select_related("phase_state")` so the lock can reuse the phase id already loaded rather than re-deriving the current phase — without it the delete path costs four extra queries, not three.
- **Adjustment orders.** `delete_existing_for_source` and `order.save()` now share a transaction, so an adjustment order rejected by `clean()` no longer destroys the order it was replacing. That only bites when the limit is 0 (a disband phase where the same source is re-ordered), but it was a silent data loss and the transaction removes it.

`replan` had a status pre-check immediately before the transaction it now duplicates, so that pre-check is folded into the locked one — same error, one code path. Its existing "no active phase" test now exercises the locked check.

## Testing

- `TestLockIfActive` — returns the phase and emits `FOR UPDATE` for an active phase; returns `None` for one that is not.
- `test_order_create_rejected_once_the_phase_is_no_longer_active` — the existing order survives and no replacement is written.
- `test_delete_order_rejected_once_the_phase_is_no_longer_active` — the order survives.
- Both endpoint tests fail on `main` (201 / 204 — the write lands on a resolved phase) and pass here.
- `order`, `phase`, `agent`, `game` and `integration` suites: 977 passed.

The race itself is not directly reproducible in a single-connection test — what the tests pin down is the observable guarantee, that a write against a phase which is no longer active is rejected instead of applied. The blocking half is the lock itself, covered by asserting the statement is `FOR UPDATE` against the same row `resolve_if_due` locks.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — not run; it shells out to `gh pr diff` and this session's git remote is a local proxy rather than a GitHub host. I self-reviewed instead: the cases I worked through are lock ordering (no new deadlock), the deferred-fields cost of `lock_if_active` on `replace_member_with_bot` (one lazy fetch of `options` when it reads `nations_with_possible_orders`), and whether a blocked writer could exceed the 60s gunicorn timeout (resolution is in-process adjudication, sub-second in practice).
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxKm5ihkgtu3WpwmC8u6EX)_