### PR TITLE
Stop dislodged neutral units from awaiting retreat orders

### DIFF
--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -78,10 +78,17 @@ def _should_skip(options, units, supply_centers, skip_nations, nation_name_by_id
         return True
     if not skip_nations:
         return False
-    location_to_nation = {
+    standing_location_to_nation = {
         u.location: nation_name_by_id.get(u.nation, u.nation)
         for u in units
+        if not u.dislodged
     }
+    dislodged_location_to_nation = {
+        u.location: nation_name_by_id.get(u.nation, u.nation)
+        for u in units
+        if u.dislodged
+    }
+    location_to_nation = {**standing_location_to_nation, **dislodged_location_to_nation}
     province_to_nation = {
         sc.province: nation_name_by_id.get(sc.nation, sc.nation)
         for sc in supply_centers

--- a/service/adjudication/tests.py
+++ b/service/adjudication/tests.py
@@ -976,6 +976,73 @@ class TestAdjudicationService:
         italy_options = data["options"].get("Italy", {})
         assert italy_options != {}
 
+    @pytest.mark.django_db
+    def test_resolve_cd_retreat_phase_is_skipped_when_dislodger_shares_province(
+        self,
+        phase_spring_1901_movement,
+        member_italy,
+        member_germany,
+    ):
+        member_germany.civil_disorder = True
+        member_germany.save()
+
+        phase_state_italy = phase_spring_1901_movement.phase_states.create(member=member_italy)
+        phase_state_germany = phase_spring_1901_movement.phase_states.create(member=member_germany)
+
+        create_supply_center(phase_state_italy, "ber")
+        create_supply_center(phase_state_italy, "mun")
+        create_supply_center(phase_state_germany, "kie")
+
+        create_unit(phase_state_germany, "kie", "Fleet")
+        create_unit(phase_state_italy, "ber", "Army")
+        create_unit(phase_state_italy, "mun", "Army")
+
+        create_order(phase_state_italy, "ber", OrderType.MOVE, "kie")
+        create_order(phase_state_italy, "mun", OrderType.SUPPORT, "kie", "ber")
+
+        data = adjudication_service.resolve(phase_spring_1901_movement)
+
+        assert data["year"] == 1901
+        assert data["season"] == "Fall"
+        assert data["type"] == "Movement"
+
+        germany_units = [u for u in data["units"] if u["nation"] == "Germany"]
+        assert germany_units == []
+
+    @pytest.mark.django_db
+    def test_resolve_neutral_retreat_phase_is_skipped(
+        self,
+        phase_spring_1901_movement,
+        member_italy,
+    ):
+        variant = phase_spring_1901_movement.variant
+        nation_germany = variant.nations.get(name="Germany")
+        nation_germany.non_playable = True
+        nation_germany.save()
+
+        phase_state_italy = phase_spring_1901_movement.phase_states.create(member=member_italy)
+
+        create_supply_center(phase_state_italy, "ber")
+        create_supply_center(phase_state_italy, "mun")
+        create_unit(phase_state_italy, "ber", "Army")
+        create_unit(phase_state_italy, "mun", "Army")
+
+        kiel = variant.provinces.get(province_id="kie")
+        phase_spring_1901_movement.supply_centers.create(province=kiel, nation=nation_germany)
+        phase_spring_1901_movement.units.create(province=kiel, type=UnitType.FLEET, nation=nation_germany)
+
+        create_order(phase_state_italy, "ber", OrderType.MOVE, "kie")
+        create_order(phase_state_italy, "mun", OrderType.SUPPORT, "kie", "ber")
+
+        data = adjudication_service.resolve(phase_spring_1901_movement)
+
+        assert data["year"] == 1901
+        assert data["season"] == "Fall"
+        assert data["type"] == "Movement"
+
+        germany_units = [u for u in data["units"] if u["nation"] == "Germany"]
+        assert germany_units == []
+
 
 class TestUserUploadedVariant:
     """Regression: prior to dropping the godip HTTP adjudicator, creating a

--- a/service/adjudicator/options.py
+++ b/service/adjudicator/options.py
@@ -395,6 +395,8 @@ def _retreat_options(view: StateView) -> List[OrderOption]:
         list(variant.provinces.keys()) + list(variant.named_coasts.keys())
     )
     for source_loc, unit in dislodged:
+        if view.nation(unit.nation).is_non_playable():
+            continue
         options.append(
             OrderOption(
                 source=source_loc,

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -10971,6 +10971,69 @@ def test_options_adjustment_no_disbands_for_non_playable_nation():
     assert [o for o in options if o.order_type == "Disband"] == []
 
 
+def test_options_retreat_no_options_for_non_playable_nation():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.RETREAT,
+        units=[
+            Unit(
+                nation=SOUTH,
+                type=Unit.ARMY,
+                location="mid",
+                dislodged=True,
+                dislodged_from="lhs",
+            ),
+        ],
+    )
+    assert get_options(state) == []
+
+
+def test_options_retreat_still_emitted_for_playable_nation_alongside_non_playable():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.RETREAT,
+        units=[
+            Unit(
+                nation=SOUTH,
+                type=Unit.ARMY,
+                location="mid",
+                dislodged=True,
+                dislodged_from="lhs",
+            ),
+            Unit(
+                nation=NORTH,
+                type=Unit.ARMY,
+                location="iso",
+                dislodged=True,
+                dislodged_from="sea",
+            ),
+        ],
+    )
+    assert {o.source for o in get_options(state)} == {"iso"}
+
+
+def test_retreat_dislodged_non_playable_unit_is_removed_without_orders():
+    variant = _with_non_playable_south(make_variant())
+    state = make_state(
+        variant,
+        phase_type=Phase.RETREAT,
+        units=[
+            Unit(nation=NORTH, type=Unit.ARMY, location="lhs"),
+            Unit(
+                nation=SOUTH,
+                type=Unit.ARMY,
+                location="mid",
+                dislodged=True,
+                dislodged_from="lhs",
+            ),
+        ],
+    )
+    result = Engine().adjudicate(state)
+    assert [u for u in result[0].units if u.nation == SOUTH] == []
+
+
 def _with_neutral_auto_build(variant: Variant) -> Variant:
     return replace(variant, adjudication_modifiers=("neutral-nations-auto-build",))
 

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -1063,16 +1063,16 @@ class NationView:
         )
 
     def allowed_builds(self) -> int:
-        if self._is_non_playable():
+        if self.is_non_playable():
             return 0
         return max(0, len(self.owned_supply_centers()) - self.standing_unit_count())
 
     def required_disbands(self) -> int:
-        if self._is_non_playable():
+        if self.is_non_playable():
             return 0
         return max(0, self.standing_unit_count() - len(self.owned_supply_centers()))
 
-    def _is_non_playable(self) -> bool:
+    def is_non_playable(self) -> bool:
         for nation in self._state.variant.nations:
             if nation.id == self._nation:
                 return nation.non_playable


### PR DESCRIPTION
## What this PR does

Fixes a Discord bug report: neutral units await orders instead of auto-disbanding, with the reporter's worry that "in a normal game there will be a day when no one has orders to submit".

Two defects, both in the Retreat phase:

**1. `_retreat_options` emitted Retreat/Disband options for dislodged neutral units.** A non-playable nation has no member, so nobody can ever submit those orders — the nation just sits in the phase's options blob awaiting them. Per the neutral-nations contract (#624), a dislodged neutral unit is removed from the board and never retreats, which is exactly what `ApplyRetreatOutcomes` already does with an unordered dislodged unit. `_retreat_options` now skips non-playable nations, matching how `allowed_builds` / `required_disbands` already gate them out of adjustments. `NationView._is_non_playable` becomes public `is_non_playable` so the options module can ask.

Before the fix, a dislodged neutral army at `mid` produced three options (`Disband mid`, `Retreat mid→rhs`, `Retreat mid→iso`); it now produces none, and the unit is removed when the phase resolves.

**2. `_should_skip` resolved a retreat option to the wrong nation.** A dislodged unit keeps its location, and the unit that dislodged it moves into that same province — so the `location -> nation` map built from `next_state.units` had two units competing for one key, and last-writer-wins decided the answer. When the dislodger won, a Retreat phase whose only retreating nation was neutral (or in civil disorder) failed the skip check and got created anyway, burning a full deadline with nothing for any player to submit. Dislodged units now win that lookup, which is correct because only dislodged units carry Retreat-phase options.

This one was order-dependent rather than always-wrong: `test_resolve_cd_retreat_phase_is_skipped` passed only because of the order its units happened to be created in. The new test creates them the other way round and fails on `main`.

### Deliberately unchanged

`_drop_dislodged_units_with_no_retreat` evaluates `RetreatOrder.LEGALITY_CHECKS` directly rather than going through `get_options`, so it is unaffected: a dislodged neutral unit with a legal retreat target still enters the Retreat phase and stays visible on the board as dislodged, and is removed when that phase resolves. Movement-phase options for neutral units are also left alone — nobody can submit them either, but they cost nothing and no member is ever seated on a neutral nation.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — **not run**: `gh` cannot authenticate against this session's git proxy, so the skill errors out. I self-reviewed the diff instead; the "Deliberately unchanged" section above records what that turned up.
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only

Tests added: `test_options_retreat_no_options_for_non_playable_nation`, `test_options_retreat_still_emitted_for_playable_nation_alongside_non_playable`, `test_retreat_dislodged_non_playable_unit_is_removed_without_orders`, `test_resolve_cd_retreat_phase_is_skipped_when_dislodger_shares_province`, `test_resolve_neutral_retreat_phase_is_skipped`. Three of them fail on `main`; the other two lock in the auto-disband outcome the fix depends on. Full backend suite green locally (2084 passed, 8 skipped).