### PR TITLE
Allow non-members to spectate a game

### DIFF
--- a/packages/web/src/mocks/fixtures/games.ts
+++ b/packages/web/src/mocks/fixtures/games.ts
@@ -611,7 +611,20 @@ const buildNotJoined = () => {
     phases: [phase],
     ordersByPhase: { 701: [] },
     phaseStates: members.map(m => makePhaseState(m, [])),
-    channels: [makeChannel("Public Press", members, [])],
+    channels: [
+      makeChannel("Public Press", members, [
+        makeMessage(
+          members[0],
+          "England opens with a call for a quiet Channel.",
+          "2026-05-01T09:00:00Z"
+        ),
+        makeMessage(
+          members[2],
+          "France is listening, but making no promises.",
+          "2026-05-01T09:15:00Z"
+        ),
+      ]),
+    ],
   });
 };
 

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -188,7 +188,10 @@ export const handlers = [
 
   http.get("*/game/:gameId/phase-states/", ({ params }) => {
     const fixture = gameOr404(params.gameId as string);
-    return fixture ? HttpResponse.json(fixture.phaseStates) : notFound();
+    if (!fixture) return notFound();
+    return HttpResponse.json(
+      fixture.phaseStates.filter(ps => ps.member.isCurrentUser)
+    );
   }),
 
   http.get("*/game/:gameId/options/", ({ params }) => {

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.test.tsx
@@ -20,6 +20,7 @@ beforeAll(() => {
 });
 
 const mockChannelsData = vi.fn();
+const mockMembersData = vi.fn(() => [{ id: 1, nation: "Austria", isCurrentUser: true }]);
 
 vi.mock("@/api/generated/endpoints", () => ({
   useGameRetrieveSuspense: () => ({
@@ -28,7 +29,7 @@ vi.mock("@/api/generated/endpoints", () => ({
       pressType: "public_press",
       status: "active",
       variantId: "standard",
-      members: [],
+      members: mockMembersData(),
     },
   }),
   useGamesChannelsListSuspense: () => ({
@@ -130,5 +131,22 @@ describe("ChannelListScreen", () => {
     expect(screen.getByText("Public")).toBeInTheDocument();
     // No badge for zero unread
     expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows create channel button for a member", () => {
+    mockChannelsData.mockReturnValue([]);
+
+    renderChannelList();
+
+    expect(screen.getByRole("link", { name: /create channel/i })).toBeInTheDocument();
+  });
+
+  it("hides create channel button when the user is not a member", () => {
+    mockChannelsData.mockReturnValue([]);
+    mockMembersData.mockReturnValue([{ id: 1, nation: "Austria", isCurrentUser: false }]);
+
+    renderChannelList();
+
+    expect(screen.queryByRole("link", { name: /create channel/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelListScreen.tsx
@@ -47,8 +47,8 @@ const ChannelListScreen: React.FC = () => {
   const { data: channels } = useGamesChannelsListSuspense(gameId);
   const variant = useGameVariant(game);
 
-  const currentNationName =
-    game.members.find(m => m.isCurrentUser)?.nation ?? undefined;
+  const currentMember = game.members.find(m => m.isCurrentUser);
+  const currentNationName = currentMember?.nation ?? undefined;
   const variantNations = variant?.nations ?? [];
   const isSandboxGame = game.sandbox;
   const isNoPressActiveGame =
@@ -121,7 +121,7 @@ const ChannelListScreen: React.FC = () => {
               </ItemGroup>
             )}
           </Panel.Content>
-          {!isSandboxGame && !isNoPressActiveGame && (
+          {currentMember && !isSandboxGame && !isNoPressActiveGame && (
             <>
               <Separator />
               <Panel.Footer>

--- a/packages/web/src/screens/GameDetail/ChannelScreen.tsx
+++ b/packages/web/src/screens/GameDetail/ChannelScreen.tsx
@@ -321,29 +321,33 @@ const ChannelScreen: React.FC = () => {
               )}
             </div>
           </Panel.Content>
-          <Separator />
-          <Panel.Footer>
-            <div className="flex gap-2 w-full">
-              <Textarea
-                placeholder="Type a message"
-                value={message}
-                rows={1}
-                maxLength={500}
-                enterKeyHint="enter"
-                onChange={e => setMessage(e.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={createMessageMutation.isPending}
-                className="flex-1 min-h-0 max-h-32 resize-none py-2"
-              />
-              <Button
-                onClick={handleSubmit}
-                disabled={!message.trim() || createMessageMutation.isPending}
-                size="icon"
-              >
-                <Send className="size-4" />
-              </Button>
-            </div>
-          </Panel.Footer>
+          {currentMember && (
+            <>
+              <Separator />
+              <Panel.Footer>
+                <div className="flex gap-2 w-full">
+                  <Textarea
+                    placeholder="Type a message"
+                    value={message}
+                    rows={1}
+                    maxLength={500}
+                    enterKeyHint="enter"
+                    onChange={e => setMessage(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={createMessageMutation.isPending}
+                    className="flex-1 min-h-0 max-h-32 resize-none py-2"
+                  />
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={!message.trim() || createMessageMutation.isPending}
+                    size="icon"
+                  >
+                    <Send className="size-4" />
+                  </Button>
+                </div>
+              </Panel.Footer>
+            </>
+          )}
         </Panel>
       </div>
     </div>

--- a/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
+++ b/packages/web/src/screens/GameDetail/DrawProposalsScreen.tsx
@@ -238,7 +238,8 @@ const DrawProposalsScreen: React.FC = () => {
     p => p.status === "pending" && p.createdBy.id === currentMember?.id
   );
   const isGameCompleted = game.status === "completed";
-  const canProposeDraw = !game.sandbox && !hasActiveProposalByCurrentUser && !isGameCompleted;
+  const canProposeDraw =
+    !!currentMember && !game.sandbox && !hasActiveProposalByCurrentUser && !isGameCompleted;
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.test.tsx
@@ -222,6 +222,38 @@ describe("OrdersScreen confirm orders button", () => {
   });
 });
 
+describe("OrdersScreen spectating", () => {
+  beforeEach(() => {
+    mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
+    mockPhaseData.mockReturnValue({
+      id: 1, status: "active", supplyCenters: [], units: [],
+    });
+    mockPhaseStatesData.mockReturnValue([]);
+    mockOrdersData.mockReturnValue([]);
+    mockGameData.mockReturnValue({
+      variantId: "classical",
+      status: "active",
+      sandbox: false,
+      deadlineMode: "duration",
+      phaseConfirmed: false,
+      members: [baseMember({ isCurrentUser: false })],
+    });
+  });
+
+  it("shows the spectating notice when the user is not a member", () => {
+    renderOrdersScreen();
+
+    expect(screen.getByText(/spectating/i)).toBeInTheDocument();
+  });
+
+  it("hides the confirm orders button when the user is not a member", () => {
+    renderOrdersScreen();
+
+    expect(screen.queryByRole("button", { name: /orders confirmed/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /confirm orders/i })).not.toBeInTheDocument();
+  });
+});
+
 describe("OrdersScreen resilience to malformed list data", () => {
   beforeEach(() => {
     mockVariantsData.mockReturnValue([{ id: "classical", name: "Classical" }]);
@@ -244,7 +276,7 @@ describe("OrdersScreen resilience to malformed list data", () => {
 
     renderOrdersScreen();
 
-    expect(screen.getByText(/no orders required/i)).toBeInTheDocument();
+    expect(screen.getByText(/spectating/i)).toBeInTheDocument();
   });
 
   it("falls back to an unmatched member instead of crashing when game.members is not an array and there are past orders to group by nation", () => {

--- a/packages/web/src/screens/GameDetail/OrdersScreen.tsx
+++ b/packages/web/src/screens/GameDetail/OrdersScreen.tsx
@@ -11,6 +11,7 @@ import {
   Star,
   UserX,
   Handshake,
+  Eye,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -190,9 +191,13 @@ const OrdersScreen: React.FC = () => {
   const safeOrders = Array.isArray(orders) ? orders : [];
   const safePhaseStates = Array.isArray(phaseStates) ? phaseStates : [];
   const currentMember = members.find(m => m.isCurrentUser);
+  const isSpectator = !currentMember;
   const isCurrentMemberInCivilDisorder = currentMember?.civilDisorder ?? false;
   const canModifyOrders =
-    isActivePhase && !isGameFinished && !isCurrentMemberInCivilDisorder;
+    !isSpectator &&
+    isActivePhase &&
+    !isGameFinished &&
+    !isCurrentMemberInCivilDisorder;
 
   const getSupplyCenterCount = (nation: string) => {
     return phase.supplyCenters.filter(sc => sc.nation.name === nation).length;
@@ -315,17 +320,24 @@ const OrdersScreen: React.FC = () => {
     );
   })();
 
-  const emptyState = isActivePhase
+  const emptyState = !isActivePhase
     ? {
-        icon: Inbox,
-        title: "No orders required",
-        message: "You do not need to submit any orders during this phase",
-      }
-    : {
         icon: SearchX,
         title: "No orders created",
         message: "No orders were created by any nation in this phase.",
-      };
+      }
+    : isSpectator
+      ? {
+          icon: Eye,
+          title: "Spectating",
+          message:
+            "You are not playing in this game. Orders become visible once the phase resolves.",
+        }
+      : {
+          icon: Inbox,
+          title: "No orders required",
+          message: "You do not need to submit any orders during this phase",
+        };
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -51,16 +51,6 @@ class IsNotKickedGameMember(BasePermission):
         return True
 
 
-class IsGameMemberOrGameMaster(BasePermission):
-    message = "User is not a member of the game."
-
-    def has_permission(self, request, view):
-        game = resolve_game(request, view.kwargs.get("game_id"))
-        if game.game_master_id is not None and game.game_master_id == request.user.id:
-            return True
-        return game.members.filter(user=request.user).exists()
-
-
 class IsActiveGameMember(BasePermission):
     message = "User cannot perform this action."
 

--- a/service/draw_proposal/tests.py
+++ b/service/draw_proposal/tests.py
@@ -609,6 +609,28 @@ class TestDrawProposalListView:
         assert len(response.data) == 1
         assert response.data[0]["id"] == active.id
 
+    def test_list_proposals_as_non_member(
+        self, api_client, game_factory, phase_factory, member_factory,
+        draw_proposal_factory, primary_user, secondary_user,
+    ):
+        game = game_factory(variant__solo_victory_sc_count=18)
+        phase = phase_factory(game=game)
+        m1 = member_factory(game=game, user=primary_user)
+        m2 = member_factory(game=game)
+
+        proposal = draw_proposal_factory(
+            game=game, created_by=m1, phase=phase,
+            included_member_ids=[m1.id, m2.id],
+        )
+
+        self._auth(api_client, secondary_user)
+        response = api_client.get(f"/games/{game.id}/draw-proposals/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == proposal.id
+        assert response.data[0]["my_vote"] is None
+
     def test_list_response_no_longer_includes_combined_sc_count_or_threshold(
         self, api_client, game_factory, phase_factory, member_factory,
         draw_proposal_factory, primary_user,

--- a/service/game/tests/test_game_master.py
+++ b/service/game/tests/test_game_master.py
@@ -163,13 +163,14 @@ class TestGameMasterInGameAccess:
         assert response.data == []
 
     @pytest.mark.django_db
-    def test_non_member_cannot_list_phase_states(
+    def test_non_member_lists_no_phase_states(
         self, authenticated_client_for_secondary_user, active_game_with_game_master_factory
     ):
         game = active_game_with_game_master_factory()
         url = reverse(phase_state_list_viewname, args=[game.id])
         response = authenticated_client_for_secondary_user.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
 
 
 class TestGameMasterPowers:

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -150,6 +150,56 @@ class TestOrderListView:
         response = unauthenticated_client.get(url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @pytest.mark.django_db
+    def test_list_orders_active_phase_non_member(
+        self,
+        authenticated_client_for_tertiary_user,
+        order_active_game,
+        primary_user,
+        classical_london_province,
+        classical_english_channel_province,
+    ):
+        game = order_active_game
+        phase = game.current_phase
+        Order.objects.create(
+            phase_state=phase.phase_states.get(member__user=primary_user),
+            order_type=OrderType.MOVE,
+            source=classical_london_province,
+            target=classical_english_channel_province,
+        )
+
+        url = reverse("order-list", args=[game.id, phase.id])
+        response = authenticated_client_for_tertiary_user.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+    @pytest.mark.django_db
+    def test_list_orders_completed_phase_non_member(
+        self,
+        authenticated_client_for_tertiary_user,
+        order_active_game,
+        primary_user,
+        classical_london_province,
+        classical_english_channel_province,
+    ):
+        game = order_active_game
+        phase = game.current_phase
+        Order.objects.create(
+            phase_state=phase.phase_states.get(member__user=primary_user),
+            order_type=OrderType.MOVE,
+            source=classical_london_province,
+            target=classical_english_channel_province,
+        )
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+
+        url = reverse("order-list", args=[game.id, phase.id])
+        response = authenticated_client_for_tertiary_user.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
 
 class TestOrderListViewCompletedPhaseCaching:
 
@@ -3008,13 +3058,14 @@ class TestOrderOptionsView:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @pytest.mark.django_db
-    def test_non_member_rejected(self, game_with_options, tertiary_user):
-        from rest_framework.test import APIClient
-        client = APIClient()
-        client.force_authenticate(user=tertiary_user)
+    def test_non_member_returns_no_options(
+        self, game_with_options, tertiary_user, authenticated_client_factory
+    ):
+        client = authenticated_client_factory(tertiary_user)
         url = reverse("order-options", args=[game_with_options.id])
         response = client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["orders"] == []
 
     @pytest.mark.django_db
     def test_returns_own_nation_options(self, authenticated_client, game_with_options):

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -3068,6 +3068,26 @@ class TestOrderOptionsView:
         assert response.data["orders"] == []
 
     @pytest.mark.django_db
+    def test_kicked_member_returns_no_options(
+        self, authenticated_client, game_with_options, primary_user
+    ):
+        game_with_options.members.filter(user=primary_user).update(kicked=True)
+        url = reverse("order-options", args=[game_with_options.id])
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["orders"] == []
+
+    @pytest.mark.django_db
+    def test_eliminated_member_returns_no_options(
+        self, authenticated_client, game_with_options, primary_user
+    ):
+        game_with_options.members.filter(user=primary_user).update(eliminated=True)
+        url = reverse("order-options", args=[game_with_options.id])
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["orders"] == []
+
+    @pytest.mark.django_db
     def test_returns_own_nation_options(self, authenticated_client, game_with_options):
         url = reverse("order-options", args=[game_with_options.id])
         response = authenticated_client.get(url)

--- a/service/order/views.py
+++ b/service/order/views.py
@@ -59,7 +59,7 @@ class OrderCreateView(CurrentPhaseMixin, generics.CreateAPIView):
 
 
 class OrderOptionsView(CurrentPhaseMixin, generics.RetrieveAPIView):
-    permission_classes = [permissions.IsAuthenticated, IsActiveGame, IsActiveGameMember]
+    permission_classes = [permissions.IsAuthenticated, IsActiveGame]
     serializer_class = OrderOptionsResponseSerializer
 
     def retrieve(self, request, *args, **kwargs):

--- a/service/order/views.py
+++ b/service/order/views.py
@@ -66,7 +66,9 @@ class OrderOptionsView(CurrentPhaseMixin, generics.RetrieveAPIView):
         phase = self.get_phase()
         province_lookup = {p.province_id: p for p in phase.variant.provinces.all()}
         transformed = phase.transformed_options or {}
-        members = phase.game.members.select_related("nation").filter(user=request.user)
+        members = phase.game.members.select_related("nation").filter(
+            user=request.user, eliminated=False, kicked=False
+        )
         nation_names = [m.nation.name for m in members]
 
         all_orders = []

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -113,7 +113,8 @@ def test_list_orderable_provinces_sandbox_game(authenticated_client, sandbox_gam
 def test_list_orderable_provinces_not_member(authenticated_client, active_game_created_by_secondary_user):
     url = reverse("phase-state-list", args=[active_game_created_by_secondary_user.id])
     response = authenticated_client.get(url)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == []
 
 
 @pytest.mark.django_db
@@ -1659,6 +1660,14 @@ class TestPhaseListView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @pytest.mark.django_db
+    def test_list_phases_not_member(self, authenticated_client, active_game_created_by_secondary_user):
+        url = reverse("phase-list", args=[active_game_created_by_secondary_user.id])
+        response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
 
 class TestPhaseListViewPerformance:
 
@@ -1685,7 +1694,7 @@ class TestPhaseListViewPerformance:
 
         assert response.status_code == status.HTTP_200_OK
         query_count = len(connection.queries)
-        assert query_count == 3  # was 6 before resolve_game cache eliminated the dup phase fetches
+        assert query_count == 2
 
 
 class TestPhaseRetrieveViewQueryPerformance:

--- a/service/phase/views.py
+++ b/service/phase/views.py
@@ -9,8 +9,6 @@ from common.permissions import (
     IsUserPhaseStateExists,
     IsNotSandboxGame,
     IsSandboxGame,
-    IsGameMember,
-    IsGameMemberOrGameMaster,
 )
 from common.serializers import EmptySerializer
 from common.views import SelectedGameMixin, CurrentGameMemberMixin
@@ -43,7 +41,6 @@ class PhaseStateListView(SelectedGameMixin, generics.ListAPIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsActiveOrCompletedGame,
-        IsGameMemberOrGameMaster,
     ]
     serializer_class = PhaseStateSerializer
 
@@ -69,7 +66,6 @@ class PhaseListView(SelectedGameMixin, generics.ListAPIView):
     permission_classes = [
         permissions.IsAuthenticated,
         IsActiveOrCompletedGame,
-        IsGameMember,
     ]
     serializer_class = PhaseListSerializer
 


### PR DESCRIPTION
## What this PR does

A game detail link handed to another Diplicity user rendered for a second and then hit the error screen: `GameRetrieveView` and `PhaseRetrieveView` are already `AllowAny`, but three of the queries the detail screens fire were gated on game membership and returned 403, which the suspense boundary escalated to the root error boundary.

The three gates are dropped so a non-member can spectate:

| Endpoint | Was | Now |
|---|---|---|
| `GET /game/{id}/phase-states/` | `IsGameMemberOrGameMaster` | — |
| `GET /game/{id}/phases/` | `IsGameMember` | — |
| `GET /game/{id}/options/` | `IsActiveGameMember` | — |

Each already scopes its data to the requesting user (`phase_states.filter(member__user=request.user)`, `game.members.filter(user=request.user)`), so removing the gate returns an empty result for a spectator rather than exposing another player's phase state or options. `IsGameMemberOrGameMaster` had no other call site and is deleted; the game master's access to the phase-state list is unchanged (it was already an empty list, covered by `test_game_master_can_list_phase_states`).

The remaining detail-screen reads already served non-members and are untouched: order list (`visible_to_user_in_phase` yields nothing until the phase completes, then everything), channel list (`accessible_to_user` yields public channels only), draw proposal list (`my_vote` is `null`), game retrieve, phase retrieve.

**No write path is opened.** Creating orders, deleting orders, confirming a phase, creating channels, sending messages, and proposing/voting/cancelling a draw all still require an active membership. The UI no longer offers them to a spectator:

- Orders screen: `canModifyOrders` requires a member, so the confirm/resolve footer button is gone, and the active-phase empty state is a "Spectating" notice instead of "No orders required".
- Chat: the "Create Channel" button and the message composer are hidden.
- Draw proposals: "New proposal" is hidden; the list stays readable.

Clicking a province on the map already degrades correctly — with no options, the wizard has no source choices, so a click just surfaces the province/unit banner.

One mock fidelity fix rides along because it is load-bearing for the spectator view: `GET /game/:gameId/phase-states/` returned every member's phase state, where the API returns only the current user's. Under mocks a spectator would have seen all seven nations' orderable provinces. The handler now filters on `member.isCurrentUser`. This also makes the member view under mocks match production — `active-movement` now shows England alone rather than all seven nations.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

Tests: `2083 passed` (`pytest -n auto --create-db`), `545 passed` (`npm run test`), `npm run lint` and `npx tsc -b --noEmit` clean. New/updated coverage — phase-state list, phase list, order options, order list (active and completed phase) and draw proposal list all asserted for a non-member; frontend tests for the spectating notice, the hidden confirm button and the hidden create-channel button.

Screenshots were taken against the `not-joined` fixture (spectator) and `active-movement` (member, to show no regression) but could not be uploaded as attachments from this environment — GitHub exposes no attachment API, and CLAUDE.md forbids committing them or serving them from `raw.githubusercontent.com`. They have been handed to the author to attach. To reproduce:

```
cd packages/web && npm run dev:mocks
npm run screenshot -- /game/not-joined/phase/701/orders /tmp/shots/spectate-orders.png
npm run screenshot -- /game/not-joined/phase/701/chat /tmp/shots/spectate-chat-list.png
npm run screenshot -- /game/not-joined/phase/701/chat/channel/10 /tmp/shots/spectate-channel.png
```

Note: this repo is at 14 open PRs against a soft limit of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PCfSCFNbHX6rw7dZMEPVa

---
_Generated by [Claude Code](https://claude.ai/code/session_012PCfSCFNbHX6rw7dZMEPVa)_