### PR TITLE
Pin Django below 6.1 to unbreak DRF imports

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,4 +1,4 @@
-Django>=6.0.7,<7.0
+Django>=6.0.7,<6.1
 djangorestframework>=3.17.1,<4.0
 django-cors-headers>=4.9.0,<5.0
 djangorestframework-camel-case>=1.4.2,<2.0


### PR DESCRIPTION
## What this PR does

Production is down with `ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'` (Sentry `DIPLICITY-API-9P`). Django 6.1 removed `django.utils.cache.cc_delim_re`, but `djangorestframework` 3.17.2 still imports it at `rest_framework/views.py:10` — so every DRF import fails and the service cannot boot. This pins `Django<6.1` so the image build stops resolving 6.1.

Fixes DIPLICITY-API-9P

### This was not caused by a code change

`requirements.txt` allowed `Django>=6.0.7,<7.0` and there is no lockfile, so version resolution happens at image build time. Django 6.1 was published 2026-08-05 19:21 UTC; the next deploy after that resolved it and broke. Nothing in the merged diff touched `requirements.txt`, `nation/views.py`, or anything on the failing import path — the merge only acted as the trigger for a rebuild.

That is why a revert would not have helped: reverting rebuilds from the same unpinned range and resolves Django 6.1 again.

Dependabot never opened a PR for it either, because 6.1 already sat inside the permitted range — so the version that broke production was never reviewed and never ran through CI before deploying.

### Evidence

Reproduced the exact production error in a clean venv:

```
$ pip install "Django==6.1" "djangorestframework==3.17.2"
$ python -c "from rest_framework import generics, permissions, status"
  File ".../rest_framework/views.py", line 10, in <module>
    from django.utils.cache import cc_delim_re, patch_vary_headers
ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'
```

- `grep -rn cc_delim_re` over the Django 6.1 sdist returns nothing — the name is gone from the whole tree.
- DRF 3.17.2 metadata declares `Framework :: Django :: 4.2` through `6.0` only, but its dependency is the unbounded `django>=4.2` — which is how pip was free to install 6.1 alongside it.
- The `Test Service` run on `main` for the merge commit (`9c754da`) failed with the identical traceback, and its log shows `Successfully installed Django-6.1 ... djangorestframework-3.17.2`.

With the pin applied, resolution lands on Django 6.0.8 and the import proceeds past `cc_delim_re`.

### Upstream status

DRF fixed this in [encode/django-rest-framework#9978](https://github.com/encode/django-rest-framework/pull/9978) (merged 2026-06-25), replacing `cc_delim_re` with `split_header_value`. That fix is not in any published release — 3.17.2 predates it. The ceiling can be lifted once a DRF release carries the fix.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, one-line dependency pin
- [x] Tests cover the change — existing suite is the coverage here: `2067 passed, 8 skipped` locally, and the whole suite was failing at collection before the pin
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

## Follow-ups worth considering (not in this PR)

- **The deploy is not gated on tests.** `build-and-deploy-service.yml` triggers on push to `main` with no `needs:` on `test-service.yml`, so Railway deployed while CI was failing on the same commit. Gating deploy on tests would have caught this before it reached production.
- **No lockfile.** Unpinned upper ranges mean any dependency's new release can break a build with no diff to review. A lockfile (or hash-pinned compiled requirements) would make dependency changes explicit and reviewable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJbAQHuzDqk6diVH4uEqYB)_