### PR TITLE
Bump version to 1.5.8 for iOS release

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.7",
+  "version": "1.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## What this PR does

Bumps `packages/web/package.json` from 1.5.7 to 1.5.8 (and the matching `package-lock.json` entries) to cut a new iOS build. Fastlane reads that `version` field to set `MARKETING_VERSION` for the iOS release (`packages/web/fastlane/Fastfile:86,97`), so the version has to move for TestFlight to accept a new upload.

Note: `android/app/build.gradle:21` sets `versionName = packageJson.version` from the same field, so this also moves the Android `versionName`. That matches how previous bumps behaved (a7b22f5, f97cef5).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, version-bump-only diff, exempt as a trivial PR per CLAUDE.md
- [x] Tests cover the change — n/a, no behavioural change; the bump is consumed by the Fastlane/Gradle build config
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_011kokVJS71gwg1QB6mfhKtx)_