### PR TITLE
Widen Channel.name so large-variant channels can be created

### DIFF
--- a/service/channel/migrations/0006_widen_channel_name.py
+++ b/service/channel/migrations/0006_widen_channel_name.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("channel", "0005_channelevent"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="channel",
+            name="name",
+            field=models.CharField(max_length=1000),
+        ),
+    ]

--- a/service/channel/models.py
+++ b/service/channel/models.py
@@ -84,7 +84,7 @@ class Channel(BaseModel):
 
     objects = ChannelManager()
 
-    name = models.CharField(max_length=250)
+    name = models.CharField(max_length=1000)
     private = models.BooleanField(default=False)
     game = models.ForeignKey("game.Game", on_delete=models.CASCADE, related_name="channels")
     members = models.ManyToManyField(

--- a/service/channel/tests/test_channel.py
+++ b/service/channel/tests/test_channel.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
 from channel.models import Channel, ChannelMessage
+from nation.models import Nation
 from bot_profile.utils import get_bot_user
 from game.models import Game
 from game.serializers import GameRetrieveSerializer
@@ -34,6 +35,30 @@ class TestChannelCreateView:
         assert response.status_code == status.HTTP_201_CREATED
         assert "id" in response.data
         assert response.data["name"] == "England, France"
+
+    @pytest.mark.django_db
+    def test_create_channel_name_longer_than_250_characters(
+        self, authenticated_client, active_game_with_phase_state, classical_variant
+    ):
+        nations = [
+            Nation.objects.create(
+                nation_id=f"long-name-nation-{index:02d}",
+                name=f"Nation With A Long Name {index:02d}",
+                color="#000000",
+                variant=classical_variant,
+            )
+            for index in range(12)
+        ]
+        members = [active_game_with_phase_state.members.create(nation=nation) for nation in nations]
+
+        url = reverse("channel-create", args=[active_game_with_phase_state.id])
+        payload = {"member_ids": [member.id for member in members]}
+        response = authenticated_client.post(url, payload, format="json")
+
+        expected_name = ", ".join(sorted(["England"] + [nation.name for nation in nations]))
+        assert len(expected_name) > 250
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == expected_name
 
     @pytest.mark.django_db
     def test_create_channel_unauthenticated(self, unauthenticated_client, active_game_with_phase_state):


### PR DESCRIPTION
## What this PR does

Fixes #1164. `POST /games/{game_id}/channels/create/` 500s with `DataError: value too long for type character varying(250)` when a channel spans enough nations that the joined name overflows the column, so the user gets no channel (Sentry `DIPLICITY-API-9M`, game `chaotic-evil`). This widens `Channel.name` from 250 to 1000 characters.

**Why widen rather than truncate.** The stored name isn't only a label — it does two other jobs, and both break if it's shortened:

- It's the dedup key: `ChannelSerializer.validate_member_ids` rejects a create when `game.channels.filter(name=channel_name).exists()`. Two different member sets sharing a sorted prefix would truncate to the same string, so the second create would be refused as a duplicate and the user dropped into a channel with the wrong participants — worse than the 500.
- It's the wire format the web client parses: `channelUtils.ts` splits it on `,` to derive a private channel's display name and its flag avatars, because `ChannelSerializer` doesn't expose members (`member_ids` is `write_only`). A truncated name silently drops nations from both.

**Why 1000.** Joining the sorted nation names of every bundled variant gives a worst case of 301 characters (`chaos`, 34 nations); the next largest is 184. 1000 leaves roughly 3x headroom for larger variants. Increasing a `varchar` length is a catalog-only change in Postgres — no table rewrite.

The name still reads poorly at the top of the chat list when it lists 30-odd nations. That half of the issue — deriving a display name from the channel's members instead of parsing the stored string — is deliberately not in this PR.

No codegen: `Channel.name` is a plain read-only `CharField` on a non-model serializer, so `openapi-schema.yaml` carries no `maxLength` for it and is unchanged.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, single-field schema widening
- [x] Tests cover the change — `test_create_channel_name_longer_than_250_characters` creates a channel across 13 nations whose joined name is 343 characters and asserts the full name round-trips untruncated. Verified it fails on `main` with the exact `DataError` from the Sentry report and passes here; full `channel/` suite green (68 passed).
- [x] Screenshots embedded in the PR description for any visual changes — n/a, no visual change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew23oYxKwab4EEbrLPQuz9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew23oYxKwab4EEbrLPQuz9)_