### PR TITLE
Guard Leaflet's deferred callbacks against a torn-down map

### DIFF
--- a/packages/web/src/components/GameMapCanvas/GameMapController.ts
+++ b/packages/web/src/components/GameMapCanvas/GameMapController.ts
@@ -5,6 +5,7 @@ import { toLatLng, viewBoxBounds } from "./leafletCoords";
 import type { ProvinceRing } from "./provincePolygons";
 import { focusBounds } from "./focusBounds";
 import { buildHighlightSvg } from "./highlightSvg";
+import { createSafeMap } from "./safeMap";
 
 export type MapMode = "static" | "pannable" | "interactive";
 
@@ -128,7 +129,7 @@ export class GameMapController {
     this.fill = options.initialFill ?? true;
     this.bounds = L.latLngBounds(viewBoxBounds(options.viewBox));
 
-    this.map = L.map(container, {
+    this.map = createSafeMap(container, {
       crs: L.CRS.Simple,
       attributionControl: false,
       zoomControl: false,

--- a/packages/web/src/components/GameMapCanvas/safeMap.test.ts
+++ b/packages/web/src/components/GameMapCanvas/safeMap.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import L from "leaflet";
+import { createSafeMap } from "./safeMap";
+
+type ZoomAnimation = {
+  _animateZoom: (center: L.LatLng, zoom: number, startAnim: boolean) => void;
+};
+
+const mountMap = (): L.Map => {
+  const container = document.createElement("div");
+  Object.defineProperty(container, "clientWidth", { value: 800 });
+  Object.defineProperty(container, "clientHeight", { value: 600 });
+  document.body.appendChild(container);
+  const map = createSafeMap(container, { crs: L.CRS.Simple });
+  map.setView([0, 0], 1);
+  return map;
+};
+
+describe("createSafeMap", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("ignores the zoom transition timer left pending by a removed map", () => {
+    vi.useFakeTimers();
+    const map = mountMap();
+    (map as L.Map & ZoomAnimation)._animateZoom(L.latLng(1, 1), 2, true);
+
+    map.remove();
+
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+  });
+
+  it("ignores an inertia pan deferred past a removed map", () => {
+    const map = mountMap();
+
+    map.remove();
+
+    expect(() => map.panBy([40, 40], { animate: true })).not.toThrow();
+  });
+
+  it("still runs the zoom transition on a live map", () => {
+    vi.useFakeTimers();
+    const map = mountMap();
+    const zoomEnd = vi.fn();
+    map.on("moveend", zoomEnd);
+
+    (map as L.Map & ZoomAnimation)._animateZoom(L.latLng(1, 1), 2, true);
+    vi.advanceTimersByTime(300);
+
+    expect(zoomEnd).toHaveBeenCalled();
+    expect(map.getZoom()).toBe(2);
+  });
+
+  it("still pans a live map", () => {
+    const map = mountMap();
+    const before = map.getCenter();
+
+    map.panBy([40, 40], { animate: false });
+
+    expect(map.getCenter()).not.toEqual(before);
+  });
+});

--- a/packages/web/src/components/GameMapCanvas/safeMap.ts
+++ b/packages/web/src/components/GameMapCanvas/safeMap.ts
@@ -1,0 +1,34 @@
+import L from "leaflet";
+
+type LiveMap = L.Map & { _mapPane?: HTMLElement };
+
+const onZoomTransitionEnd = (L.Map.prototype as L.Map & {
+  _onZoomTransitionEnd: () => void;
+})._onZoomTransitionEnd;
+
+// Leaflet schedules two pieces of deferred work without keeping a handle to
+// either, so Map.remove() has nothing to cancel: _animateZoom sets a 250ms
+// timeout backstopping a transitionend that webkit may never fire, and the drag
+// handler requests an animation frame at dragend to run the inertia pan. Both
+// callbacks dereference _mapPane, which remove() deletes on its way out, so a
+// map unmounted mid-zoom or mid-flick throws out of the leftover callback
+// ("_leaflet_pos" of undefined from the zoom timer, "classList" of undefined
+// from the pan frame). Skipping both entry points once the pane is gone leaves
+// the pending work harmless. The zoom timer binds the method when it schedules,
+// so the guard has to sit on the class rather than be applied at teardown.
+const SafeMap = L.Map.extend({
+  _onZoomTransitionEnd(this: LiveMap) {
+    if (!this._mapPane) return;
+    onZoomTransitionEnd.call(this);
+  },
+
+  panBy(this: LiveMap, offset: L.PointExpression, options?: L.PanOptions) {
+    if (!this._mapPane) return this;
+    return L.Map.prototype.panBy.call(this, offset, options);
+  },
+}) as unknown as new (container: HTMLElement, options?: L.MapOptions) => L.Map;
+
+export const createSafeMap = (
+  container: HTMLElement,
+  options: L.MapOptions
+): L.Map => new SafeMap(container, options);


### PR DESCRIPTION
## What this PR does

Stops the three Sentry crashes in #1169 (`DIPLICITY-REACT-9`, `-P`, `-10`) where a Leaflet callback runs after `GameMapCanvas` has unmounted and dereferences the deleted `_mapPane`.

`GameMapController.destroy()` already calls `map.remove()`, so the issue's first hypothesis is ruled out. The actual cause is that Leaflet schedules two pieces of deferred work **without keeping a handle to either**, so `Map.remove()` has nothing to cancel — verified against the bundled `leaflet@1.9.4` source:

| Sentry issue | Scheduled by | Crash |
|---|---|---|
| `-9` | `Map._animateZoom` → `setTimeout(bind(this._onZoomTransitionEnd, this), 250)` ([`leaflet-src.js:4827`](https://github.com/Leaflet/Leaflet/blob/v1.9.4/dist/leaflet-src.js#L4827)) — a bare timer backstopping a `transitionend` webkit may never fire | `_onZoomTransitionEnd` guards `_mapPane` for its `removeClass` but then calls `_move` unconditionally → `_getMapPanePos` → `getPosition(undefined)` → `_leaflet_pos` of undefined |
| `-P`, `-10` | `Map.Drag._onDragEnd` → `requestAnimFrame(function () { map.panBy(...) })` — a bare frame running the inertia pan, return value discarded | `panBy` → `addClass(this._mapPane, 'leaflet-pan-anim')` → `classList` of undefined |

`remove()` only cancels `_flyToFrame`, `_panAnim` and `_resizeRequest` (via `_stop()` and `_resizeRequest`), then `delete this._mapPane`. Neither of the above is reachable from outside, which is why the deferred callbacks survive teardown. This matches the issue's repro lead — pan or zoom the map, navigate to chat before it settles.

I reproduced both crashes in jsdom against unmodified Leaflet, and the messages match the Sentry reports verbatim:

```
Cannot read properties of undefined (reading '_leaflet_pos')
Cannot read properties of undefined (reading 'classList')
```

### The fix

New `safeMap.ts` constructs the map from an `L.Map` subclass that skips both entry points once `_mapPane` is gone, delegating to the original implementations otherwise. `GameMapController` calls `createSafeMap(...)` in place of `L.map(...)`; `destroy()` is unchanged.

The guard has to sit on the class rather than be applied at teardown: `_animateZoom` uses `bind(this._onZoomTransitionEnd, this)`, which captures the method reference **when it schedules**, so patching the instance inside `destroy()` is too late. I tried that first and the zoom test failed, which is what pinned it down.

`L.Map.extend` is the same idiom already used for `CanvasOverlay` in `GameMapController.ts`. I verified the subclass still receives the parent's init hooks — its handler set (`boxZoom`, `doubleClickZoom`, `dragging`, `keyboard`, `scrollWheelZoom`, `tapHold`, `touchZoom`) is identical to a plain `L.map`, and `dragging` is enabled — so panning and zooming are unaffected.

Only `GameMapController` constructs a Leaflet map, so this covers every map in the app.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — not run; the change is three files and ~35 lines, happy to run it if you'd like
- [x] Tests cover the change — `safeMap.test.ts` asserts both deferred callbacks are harmless after `remove()`, **and** that a live map still completes its zoom transition and still pans, so the guard can't pass by disabling the behaviour. Full frontend suite green (549 tests), `eslint` and `tsc -b --noEmit` clean
- [x] Screenshots embedded in the PR description for any visual changes — n/a, no visual change

> Heads up: this repo currently has 12 open PRs against the ≤ 5 target, so this one pushes further over rather than being the cause.

Fixes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ytCEYzggsjK13MCyJaHU4

---
_Generated by [Claude Code](https://claude.ai/code/session_016ytCEYzggsjK13MCyJaHU4)_