### PR TITLE
Allow the release workflows to be dispatched manually

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/web/**"
+  workflow_dispatch:
 
 concurrency:
   group: android-release

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/web/**"
+  workflow_dispatch:
 
 concurrency:
   group: ios-release


### PR DESCRIPTION
## What this PR does

Adds a `workflow_dispatch:` trigger to `.github/workflows/ios-release.yml` and `.github/workflows/android-release.yml`, alongside the existing `push` to `main` / `paths: packages/web/**` trigger.

Both workflows previously fired on `push` only. When GitHub Actions failed to create runs for the repo earlier today, the merge of #1172 (the 1.5.7 → 1.5.8 version bump) produced no iOS Release or Android Release run — and with no run created, there was nothing to re-run from the Actions UI. The only way to cut the build was another push touching `packages/web/**`, which for a version bump means bumping the version a second time even though 1.5.8 is already on `main`. `workflow_dispatch` makes the release re-triggerable from the Actions tab against any ref.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, two-line trigger-only diff, exempt as a trivial PR per CLAUDE.md
- [x] Tests cover the change — n/a, CI config change with no application code; both files verified to parse as YAML with `push` and `workflow_dispatch` both present
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvVUhEydVKbpzPurYFpT5v)_