### PR TITLE
Serialise seat claims so a game can't be joined twice

### DIFF
--- a/service/bot_profile/serializers.py
+++ b/service/bot_profile/serializers.py
@@ -17,21 +17,25 @@ class AvailableBotSerializer(serializers.Serializer):
 class BotMemberCreateSerializer(serializers.Serializer):
     user_id = serializers.IntegerField(write_only=True)
 
-    def validate_user_id(self, value):
+    def _resolve_available_bot(self, user_id):
         game = self.context["game"]
         bot_profile = (
-            BotProfile.objects.available_for_game(game).filter(user_id=value).first()
+            BotProfile.objects.available_for_game(game).filter(user_id=user_id).first()
         )
         if bot_profile is None:
             raise serializers.ValidationError(
                 "This bot is not available to add to this game."
             )
-        self._bot_user = bot_profile.user
+        return bot_profile
+
+    def validate_user_id(self, value):
+        self._resolve_available_bot(value)
         return value
 
     def create(self, validated_data):
         game = self.context["game"]
-        member = game.members.create(user=self._bot_user)
+        bot_profile = self._resolve_available_bot(validated_data["user_id"])
+        member = game.members.create(user=bot_profile.user)
         public_channels = game.channels.filter(private=False)
         ChannelMember.objects.bulk_create(
             [ChannelMember(member=member, channel=ch) for ch in public_channels]

--- a/service/bot_profile/tests.py
+++ b/service/bot_profile/tests.py
@@ -1,10 +1,12 @@
 import pytest
+from unittest.mock import patch
 from django.urls import reverse
 from rest_framework import status
 
 from bot_profile.constants import BotKind
 from bot_profile.models import BotProfile
 from bot_profile.utils import get_bot_user
+from bot_profile.views import BotMemberCreateView
 from common.constants import GameStatus, PhaseStatus
 from game.models import Game
 
@@ -271,3 +273,47 @@ class TestAddBot:
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_rejects_request_whose_bot_is_seated_after_its_checks(
+        self, authenticated_client, classical_variant, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        game = _create_game_via_api(authenticated_client, classical_variant.id)
+        bot_user = _first_roster_bot_user()
+
+        original_perform_create = BotMemberCreateView.perform_create
+
+        def perform_create_after_competing_add(view, serializer):
+            game.members.create(user=bot_user)
+            return original_perform_create(view, serializer)
+
+        with patch.object(BotMemberCreateView, "perform_create", perform_create_after_competing_add):
+            response = authenticated_client.post(
+                reverse(add_bot_viewname, args=[game.id]), {"user_id": bot_user.id}, format="json"
+            )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert game.members.filter(user=bot_user).count() == 1
+
+    @pytest.mark.django_db
+    def test_rejects_request_whose_last_seat_is_taken_after_its_checks(
+        self, authenticated_client, italy_vs_germany_variant, secondary_user, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        game = _create_game_via_api(authenticated_client, italy_vs_germany_variant.id)
+        bot_user = _first_roster_bot_user()
+
+        original_perform_create = BotMemberCreateView.perform_create
+
+        def perform_create_after_competing_join(view, serializer):
+            game.members.create(user=secondary_user)
+            return original_perform_create(view, serializer)
+
+        with patch.object(BotMemberCreateView, "perform_create", perform_create_after_competing_join):
+            response = authenticated_client.post(
+                reverse(add_bot_viewname, args=[game.id]), {"user_id": bot_user.id}, format="json"
+            )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert game.members.count() == 2

--- a/service/bot_profile/views.py
+++ b/service/bot_profile/views.py
@@ -4,7 +4,7 @@ from rest_framework import generics, permissions
 from bot_profile.models import BotProfile
 from bot_profile.serializers import AvailableBotSerializer, BotMemberCreateSerializer
 from common.permissions import CanUseBotOpponent, IsGameManager, IsPendingGame, IsSpaceAvailable
-from common.views import SelectedGameMixin
+from common.views import SeatClaimMixin, SelectedGameMixin
 from member.serializers import MemberSerializer
 
 
@@ -17,10 +17,6 @@ class AvailableBotListView(SelectedGameMixin, generics.ListAPIView):
 
 
 @extend_schema(responses={201: MemberSerializer})
-class BotMemberCreateView(SelectedGameMixin, generics.CreateAPIView):
+class BotMemberCreateView(SeatClaimMixin, generics.CreateAPIView):
     serializer_class = BotMemberCreateSerializer
     permission_classes = [permissions.IsAuthenticated, IsPendingGame, IsGameManager, IsSpaceAvailable, CanUseBotOpponent]
-
-    def perform_create(self, serializer):
-        member = serializer.save()
-        member.game.start_if_full()

--- a/service/common/views.py
+++ b/service/common/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.apps import apps
 
@@ -6,17 +7,23 @@ Game = apps.get_model("game", "Game")
 Channel = apps.get_model("channel", "Channel")
 
 
-def resolve_game(request, game_id):
+def resolve_game(request, game_id, lock=False):
     """Fetch the Game once per request, regardless of how many permission
     classes and mixins ask for it. Several views combine 2-3 permission
     checks + a mixin (e.g. orders create chains IsActiveGame +
     IsActiveGameMember + CurrentPhaseMixin), each of which would otherwise
-    issue an independent SELECT against game_game."""
+    issue an independent SELECT against game_game.
+
+    Pass lock=True to re-fetch the row FOR UPDATE and replace what the cache
+    holds, so checks that re-run after it see committed state rather than the
+    snapshot the request started from."""
     cache = getattr(request, "_game_cache", None)
     if cache is None:
         cache = {}
         request._game_cache = cache
-    if game_id not in cache:
+    if lock:
+        cache[game_id] = get_object_or_404(Game.objects.select_for_update(), id=game_id)
+    elif game_id not in cache:
         cache[game_id] = get_object_or_404(Game, id=game_id)
     return cache[game_id]
 
@@ -47,6 +54,16 @@ class SelectedGameMixin:
         context = super().get_serializer_context()
         context["game"] = self.get_game()
         return context
+
+
+class SeatClaimMixin(SelectedGameMixin):
+
+    def perform_create(self, serializer):
+        with transaction.atomic():
+            game = resolve_game(self.request, self.kwargs.get("game_id"), lock=True)
+            self.check_permissions(self.request)
+            serializer.save()
+            game.start_if_full()
 
 
 class SelectedPhaseMixin:

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -8,6 +8,7 @@ from agent.constants import AgentTaskKind, AgentTaskStatus
 from agent.models import AgentTask
 from bot_profile.models import BotProfile
 from game.models import Game
+from member.views import MemberCreateView
 from notification.models import Notification
 from phase.models import Phase
 from user_profile.models import UserProfile
@@ -185,6 +186,50 @@ def test_join_game_max_players(
     url = reverse(join_viewname, args=[game.id])
     response = authenticated_client.post(url)
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_join_game_rejects_request_whose_seat_is_taken_by_the_same_user_after_its_checks(
+    authenticated_client, pending_game_created_by_secondary_user, italy_vs_germany_variant, primary_user
+):
+    game = pending_game_created_by_secondary_user
+    game.variant = italy_vs_germany_variant
+    game.save()
+
+    original_perform_create = MemberCreateView.perform_create
+
+    def perform_create_after_competing_join(view, serializer):
+        game.members.create(user=primary_user)
+        return original_perform_create(view, serializer)
+
+    url = reverse(join_viewname, args=[game.id])
+    with patch.object(MemberCreateView, "perform_create", perform_create_after_competing_join):
+        response = authenticated_client.post(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert game.members.filter(user=primary_user).count() == 1
+
+
+@pytest.mark.django_db
+def test_join_game_rejects_request_whose_last_seat_is_taken_after_its_checks(
+    authenticated_client, pending_game_created_by_secondary_user, italy_vs_germany_variant, tertiary_user
+):
+    game = pending_game_created_by_secondary_user
+    game.variant = italy_vs_germany_variant
+    game.save()
+
+    original_perform_create = MemberCreateView.perform_create
+
+    def perform_create_after_competing_join(view, serializer):
+        game.members.create(user=tertiary_user)
+        return original_perform_create(view, serializer)
+
+    url = reverse(join_viewname, args=[game.id])
+    with patch.object(MemberCreateView, "perform_create", perform_create_after_competing_join):
+        response = authenticated_client.post(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert game.members.count() == 2
 
 
 # Leave/Delete Member Tests

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -8,21 +8,17 @@ from .models import Member
 from .serializers import MemberSerializer
 from common.serializers import EmptySerializer
 from common.permissions import IsActiveGame, IsGameMember, IsGameManager, IsInCivilDisorder, IsNotKickedGameMember, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsCommitmentRequirement
-from common.views import SelectedGameMixin
+from common.views import SeatClaimMixin, SelectedGameMixin
 from emit import emit
 
 
-class MemberCreateView(SelectedGameMixin, generics.CreateAPIView):
+class MemberCreateView(SeatClaimMixin, generics.CreateAPIView):
     serializer_class = MemberSerializer
     permission_classes = [permissions.IsAuthenticated, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsCommitmentRequirement]
 
     @extend_schema(request=EmptySerializer)
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
-
-    def perform_create(self, serializer):
-        member = serializer.save()
-        member.game.start_if_full()
 
 
 class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):


### PR DESCRIPTION
## What this PR does

A player reported that "The Scrimmage of the Sartorial Sail" (a 1v1 `italy-vs-germany` game) was buggy because they had joined it twice. Production confirms it — two `member_member` rows for the same user, inserted 11ms apart:

| id | user_id | created_at |
|---|---|---|
| 57608 | 3830 | 2026-08-04T11:08:26.237500Z |
| 57609 | 3830 | 2026-08-04T11:08:26.248886Z |

`MemberCreateView` decides whether a seat is free entirely in permission classes (`IsNotGameMember`, `IsSpaceAvailable`, …), which read the game before anything is written. Two overlapping requests — a double-tapped join — both pass and both insert. The variant has two playable nations, so the game ended up with three members: `start_if_full` compares `members.count()` against the playable nation count with `!=`, never matched, and the game has been stuck in `pending` ever since, with `IsSpaceAvailable` now refusing anyone else. `BotMemberCreateView` claims a seat exactly the same way and has the same race.

This adds `SeatClaimMixin`, which re-fetches the game `FOR UPDATE` inside the write transaction and re-runs the view's permission checks against it, so the losing request is rejected with the response it would have got had the two requests not overlapped. `resolve_game` grows a `lock=True` argument that also replaces the cached instance with the locked one, so re-run checks read the game's committed column values rather than the snapshot the request started from — that matters for `IsPendingGame`, which reads `status` off the instance. (The other checks re-query and would reject the loser regardless, so the refresh changes which message it gets, not whether it is rejected.) Whether the requested bot is still available is a serializer check rather than a permission, so `BotMemberCreateSerializer` re-resolves it in `create()`, which now runs under the same lock.

This follows the same shape as the phase lock in #1147 (lock the row inside the write transaction, re-check the precondition), reusing `check_permissions` rather than a bespoke re-check because a seat claim is guarded by five permission classes rather than one condition.

One intended behaviour change: `start_if_full()` now runs inside the same transaction as the member insert, so a game that fails to start no longer leaves the joining member stranded in a full-but-pending game.

Two things I deliberately did not do:

- The mixin carries no docstring. drf-spectacular resolves view descriptions through the MRO, so a docstring there becomes the public OpenAPI description of `POST /game/{id}/join/`. I verified `manage.py spectacular` output is byte-identical before and after this branch, so no codegen is needed.
- No unique constraint on `(game, user)`. Sandbox games legitimately seat the same user in every nation (`Game.objects.create_sandbox`), so the database cannot express this as a uniqueness rule.

The affected production game still needs deleting by hand — pgweb is read-only and `railway run` resolves the internal database host, so I could not do it from this session.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings

  The `/review-pr` harness could not run in this session — it shells out to `gh pr view`/`gh pr diff`, and GraphQL is disabled for the session's token. I worked through its review checklist manually against the diff instead and found nothing to flag. It did catch one inaccuracy in an earlier draft of this description, which is corrected above.
- [x] Tests cover the change

  Four tests, one per seat-claiming path and failure mode. Each wraps `perform_create` so a competing member lands after the request's permission checks but before its write — the exact interleaving the production rows show. All four fail on `main` with `201` and a duplicated or over-allocated seat:

  - `test_join_game_rejects_request_whose_seat_is_taken_by_the_same_user_after_its_checks` — the reported bug
  - `test_join_game_rejects_request_whose_last_seat_is_taken_after_its_checks`
  - `TestAddBot::test_rejects_request_whose_bot_is_seated_after_its_checks`
  - `TestAddBot::test_rejects_request_whose_last_seat_is_taken_after_its_checks`

  Full backend suite green: 2105 passed, 8 skipped.
- [ ] Screenshots embedded in the PR description for any visual changes — n/a, backend only