### PR TITLE
[1 file change] Match Play Store badge sizing and border to App Store badge

### DIFF
--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -273,7 +273,7 @@ const Login: React.FC = () => {
                   <img
                     src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                     alt="Get it on Google Play"
-                    className="absolute"
+                    className="absolute max-w-none"
                     style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
                   />
                 </a>
@@ -430,7 +430,7 @@ const Login: React.FC = () => {
                 <img
                   src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                   alt="Get it on Google Play"
-                  className="absolute"
+                  className="absolute max-w-none"
                   style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
                 />
               </a>

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -73,6 +73,24 @@ const loginSchema = z.object({
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
+const PlayStoreBadge: React.FC = () => (
+  <a
+    href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
+    target="_blank"
+    rel="noreferrer"
+    className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
+    style={{ width: 134, height: 40 }}
+  >
+    {/* Google's badge asset bakes in padding and a soft, over-thick border unlike Apple's crisp SVG; crop past both and redraw a matching 1px #a6a6a6 border so the two badges read the same */}
+    <img
+      src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+      alt="Get it on Google Play"
+      className="absolute max-w-none"
+      style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
+    />
+  </a>
+);
+
 const Login: React.FC = () => {
   const { login } = useAuth();
   const appleLoginMutation = useAuthAppleLoginCreate();
@@ -261,23 +279,7 @@ const Login: React.FC = () => {
                   className="h-10"
                 />
               </a>
-              {!isNativePlatform() && (
-                <a
-                  href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
-                  style={{ width: 134, height: 40 }}
-                >
-                  {/* Google's badge asset bakes in padding and a soft, over-thick border unlike Apple's crisp SVG; crop past both and redraw a matching 1px #a6a6a6 border so the two badges read the same */}
-                  <img
-                    src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
-                    alt="Get it on Google Play"
-                    className="absolute max-w-none"
-                    style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
-                  />
-                </a>
-              )}
+              {!isNativePlatform() && <PlayStoreBadge />}
             </div>
           )}
         </div>
@@ -418,23 +420,7 @@ const Login: React.FC = () => {
                 className="h-10"
               />
             </a>
-            {!isNativePlatform() && (
-              <a
-                href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
-                target="_blank"
-                rel="noreferrer"
-                className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
-                style={{ width: 134, height: 40 }}
-              >
-                {/* Google's badge asset bakes in padding and a soft, over-thick border unlike Apple's crisp SVG; crop past both and redraw a matching 1px #a6a6a6 border so the two badges read the same */}
-                <img
-                  src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
-                  alt="Get it on Google Play"
-                  className="absolute max-w-none"
-                  style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
-                />
-              </a>
-            )}
+            {!isNativePlatform() && <PlayStoreBadge />}
           </div>
         )}
 

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -266,11 +266,13 @@ const Login: React.FC = () => {
                   href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
                   target="_blank"
                   rel="noreferrer"
+                  className="inline-flex h-10 overflow-hidden"
                 >
+                  {/* Google's badge asset has ~16% built-in vertical padding, unlike Apple's; scale up and crop to match its visible height */}
                   <img
                     src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                     alt="Get it on Google Play"
-                    className="h-10"
+                    className="h-[59.5px] -mt-[9.8px]"
                   />
                 </a>
               )}
@@ -419,11 +421,13 @@ const Login: React.FC = () => {
                 href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
                 target="_blank"
                 rel="noreferrer"
+                className="inline-flex h-10 overflow-hidden"
               >
+                {/* Google's badge asset has ~16% built-in vertical padding, unlike Apple's; scale up and crop to match its visible height */}
                 <img
                   src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                   alt="Get it on Google Play"
-                  className="h-10"
+                  className="h-[59.5px] -mt-[9.8px]"
                 />
               </a>
             )}

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -266,13 +266,15 @@ const Login: React.FC = () => {
                   href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex h-10 overflow-hidden"
+                  className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
+                  style={{ width: 134, height: 40 }}
                 >
-                  {/* Google's badge asset has ~16% built-in vertical padding, unlike Apple's; scale up and crop to match its visible height */}
+                  {/* Google's badge asset bakes in padding and a soft, over-thick border unlike Apple's crisp SVG; crop past both and redraw a matching 1px #a6a6a6 border so the two badges read the same */}
                   <img
                     src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                     alt="Get it on Google Play"
-                    className="h-[59.5px] -mt-[9.8px]"
+                    className="absolute"
+                    style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
                   />
                 </a>
               )}
@@ -421,13 +423,15 @@ const Login: React.FC = () => {
                 href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex h-10 overflow-hidden"
+                className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
+                style={{ width: 134, height: 40 }}
               >
-                {/* Google's badge asset has ~16% built-in vertical padding, unlike Apple's; scale up and crop to match its visible height */}
+                {/* Google's badge asset bakes in padding and a soft, over-thick border unlike Apple's crisp SVG; crop past both and redraw a matching 1px #a6a6a6 border so the two badges read the same */}
                 <img
                   src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                   alt="Get it on Google Play"
-                  className="h-[59.5px] -mt-[9.8px]"
+                  className="absolute"
+                  style={{ width: 154, height: 59.8, top: -10.8, left: -11 }}
                 />
               </a>
             )}


### PR DESCRIPTION
## What this PR does

The "Get it on Google Play" badge on the login page rendered visibly smaller than the "Download on the App Store" badge, and had a mismatched border once heights were aligned. Both badges now read as the same size and border weight.

Root causes, fixed incrementally:
1. Google's badge PNG bakes in ~16% transparent padding around the pill, unlike Apple's SVG which fills its canvas — setting both to the same `h-10` left Google's visibly smaller. Fixed by scaling the image up and cropping the padding.
2. Google's built-in border scaled into a soft/thick line next to Apple's crisp one. Fixed by cropping past Google's own border and redrawing a matching 1px `#a6a6a6` CSS border.
3. Tailwind's preflight applies `max-width: 100%` to all `<img>` elements, which silently clamped the crop's explicit width back down to the container size, leaving a sliver of Google's original border visible next to the new CSS border (a "double border"). Fixed with `max-w-none`.

A self-review via `/review-pr` flagged that the crop/border markup was duplicated verbatim between the desktop and mobile hero blocks; extracted into a local `PlayStoreBadge` component so the two copies can't drift out of sync.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — n/a, purely visual sizing/border fix on static badge assets; verified visually (see below)
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

## Screenshots

I don't have a working image-attachment upload path in this session (no `gh` CLI, and the GitHub MCP tools here don't expose attachment upload), so screenshots aren't embedded above. I verified the fix visually — full-page desktop/mobile renders and pixel-level before/after comparisons of the badges — and shared them directly with the requester in the session.