### PR TITLE
Finalise every phase when a game ends and forbid duplicate active phases

### DIFF
--- a/service/conftest.py
+++ b/service/conftest.py
@@ -1250,7 +1250,7 @@ def retreat_phase(db):
             year=1901,
             type=PhaseType.RETREAT,
             status=PhaseStatus.ACTIVE,
-            ordinal=1,
+            ordinal=game.phases.count() + 1,
         )
         primary_member = game.members.first()
         phase.phase_states.create(member=primary_member)

--- a/service/draw_proposal/models.py
+++ b/service/draw_proposal/models.py
@@ -1,7 +1,6 @@
 from django.db import models, transaction
-from django.utils import timezone
 from common.models import BaseModel
-from common.constants import GameStatus, PhaseStatus
+from common.constants import GameStatus
 from draw_proposal.constants import DrawProposalStatus
 from emit import emit
 from victory.models import Victory
@@ -142,14 +141,7 @@ class DrawProposal(BaseModel):
                 member.drew = True
                 member.save()
 
-            self.game.status = GameStatus.COMPLETED
-            self.game.finished_at = timezone.now()
-            self.game.save()
-
-            self.phase.status = PhaseStatus.COMPLETED
-            self.phase.scheduled_resolution = None
-            self.phase.save()
-
+            self.game.finish(GameStatus.COMPLETED)
             self.game.emit_game_ended()
 
             return victory

--- a/service/draw_proposal/tests.py
+++ b/service/draw_proposal/tests.py
@@ -245,6 +245,30 @@ class TestDrawProposalProcessAcceptance:
         assert phase.status == PhaseStatus.COMPLETED
         assert phase.scheduled_resolution is None
 
+    def test_completes_every_phase_of_the_game(
+        self, game_factory, phase_factory, member_factory, draw_proposal_factory
+    ):
+        game = game_factory(variant__solo_victory_sc_count=18)
+        future = timezone.now() + timezone.timedelta(hours=20)
+        stale_phase = phase_factory(game=game, scheduled_resolution=future)
+        phase = phase_factory(game=game, ordinal=stale_phase.ordinal + 1, scheduled_resolution=future)
+        m1 = member_factory(game=game)
+        m2 = member_factory(game=game)
+
+        proposal = draw_proposal_factory(
+            game=game, created_by=m1, phase=phase,
+            included_member_ids=[m1.id, m2.id],
+        )
+        for vote in proposal.votes.all():
+            vote.accepted = True
+            vote.save()
+
+        assert proposal.process_acceptance() is not None
+
+        stale_phase.refresh_from_db()
+        assert stale_phase.status == PhaseStatus.COMPLETED
+        assert stale_phase.scheduled_resolution is None
+
     def test_cd_member_not_in_victory(
         self, game_factory, phase_factory, member_factory
     ):

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -90,13 +90,13 @@ class GameQuerySet(models.QuerySet):
         )
 
         current_phase_ids = (
-            Phase.objects.order_by("game_id", "-ordinal")
+            Phase.objects.order_by("game_id", "-ordinal", "-id")
             .distinct("game_id")
             .values("id")
         )
         latest_completed_phase_ids = (
             Phase.objects.filter(status=PhaseStatus.COMPLETED)
-            .order_by("game_id", "-ordinal")
+            .order_by("game_id", "-ordinal", "-id")
             .distinct("game_id")
             .values("id")
         )
@@ -155,13 +155,13 @@ class GameQuerySet(models.QuerySet):
         )
 
         current_phase_ids = (
-            Phase.objects.order_by("game_id", "-ordinal")
+            Phase.objects.order_by("game_id", "-ordinal", "-id")
             .distinct("game_id")
             .values("id")
         )
         latest_completed_phase_ids = (
             Phase.objects.filter(status=PhaseStatus.COMPLETED)
-            .order_by("game_id", "-ordinal")
+            .order_by("game_id", "-ordinal", "-id")
             .distinct("game_id")
             .values("id")
         )
@@ -500,7 +500,7 @@ class Game(BaseModel):
                 phases = list(self.phases.all())
                 return phases[-1] if phases else None
 
-            return self.phases.order_by("ordinal").last()
+            return self.phases.order_by("ordinal", "id").last()
 
     @property
     def movement_phase_duration_seconds(self):
@@ -733,6 +733,17 @@ class Game(BaseModel):
 
             emit("game_start", game=self)
             emit("phase_started", phase=current_phase)
+
+    def finish(self, status):
+        with transaction.atomic():
+            self.status = status
+            self.finished_at = timezone.now()
+            self.save()
+
+            for phase in self.phases.exclude(status=PhaseStatus.COMPLETED):
+                phase.status = PhaseStatus.COMPLETED
+                phase.scheduled_resolution = None
+                phase.save()
 
     def emit_game_ended(self):
         try:

--- a/service/phase/migrations/0018_complete_phases_of_finished_games.py
+++ b/service/phase/migrations/0018_complete_phases_of_finished_games.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+
+def complete_phases_of_finished_games(apps, schema_editor):
+    schema_editor.execute("""
+        UPDATE phase_phase
+        SET status = 'completed',
+            scheduled_resolution = NULL,
+            resolution_job_id = NULL
+        FROM game_game
+        WHERE phase_phase.game_id = game_game.id
+          AND game_game.status IN ('completed', 'abandoned')
+          AND phase_phase.status <> 'completed'
+    """)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("phase", "0017_phase_processing_started_at_alter_phase_status"),
+        ("game", "0023_backfill_commitment_requirement"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            complete_phases_of_finished_games,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/service/phase/migrations/0019_unique_live_phase_ordinal_per_game.py
+++ b/service/phase/migrations/0019_unique_live_phase_ordinal_per_game.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("phase", "0018_complete_phases_of_finished_games"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="phase",
+            options={"ordering": ["ordinal", "id"]},
+        ),
+        migrations.AddConstraint(
+            model_name="phase",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("status", "completed"), _negated=True),
+                fields=("game", "ordinal"),
+                name="unique_live_phase_ordinal_per_game",
+            ),
+        ),
+    ]

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -627,23 +627,12 @@ class PhaseManager(models.Manager):
                         victory = Victory.objects.try_create_victory(new_phase)
 
                         if victory:
-                            new_phase.game.status = GameStatus.COMPLETED
-                            new_phase.game.finished_at = timezone.now()
-                            new_phase.game.save()
-
-                            new_phase.status = PhaseStatus.COMPLETED
-                            new_phase.scheduled_resolution = None
-                            new_phase.save()
-
+                            new_phase.game.finish(GameStatus.COMPLETED)
                             new_phase.game.emit_game_ended()
                         elif self._check_abandonment(new_phase.game):
-                            new_phase.game.status = GameStatus.ABANDONED
-                            new_phase.game.finished_at = timezone.now()
-                            new_phase.game.save()
+                            new_phase.game.finish(GameStatus.ABANDONED)
 
-                            new_phase.status = PhaseStatus.COMPLETED
-                            new_phase.scheduled_resolution = None
-                            new_phase.save()
+                        new_phase.refresh_from_db()
 
                         if new_phase.status == PhaseStatus.ACTIVE:
                             emit("phase_started", phase=new_phase)
@@ -945,7 +934,14 @@ class Phase(BaseModel):
     options = models.JSONField(default=dict)
 
     class Meta:
-        ordering = ["ordinal"]
+        ordering = ["ordinal", "id"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["game", "ordinal"],
+                condition=~Q(status=PhaseStatus.COMPLETED),
+                name="unique_live_phase_ordinal_per_game",
+            )
+        ]
 
     def __str__(self):
         return f"{self.name} ({self.game.name if self.game else '-'})"

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -2081,6 +2081,123 @@ class TestResolveTransactionSafety:
         assert active_phases.first().id == phase.id
 
 
+class TestUniqueLivePhaseOrdinal:
+
+    def _duplicate(self, phase, status):
+        return Phase.objects.create(
+            game=phase.game,
+            variant=phase.variant,
+            season=phase.season,
+            year=phase.year,
+            type=phase.type,
+            ordinal=phase.ordinal,
+            status=status,
+        )
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("status", [PhaseStatus.ACTIVE, PhaseStatus.PROCESSING, PhaseStatus.PENDING])
+    def test_second_live_phase_at_same_ordinal_is_rejected(self, italy_vs_germany_phase_with_orders, status):
+        phase = italy_vs_germany_phase_with_orders
+
+        with pytest.raises(IntegrityError):
+            with transaction.atomic():
+                self._duplicate(phase, status)
+
+    @pytest.mark.django_db
+    def test_completed_phase_at_same_ordinal_is_allowed(self, italy_vs_germany_phase_with_orders):
+        phase = italy_vs_germany_phase_with_orders
+
+        duplicate = self._duplicate(phase, PhaseStatus.COMPLETED)
+
+        assert Phase.objects.filter(game=phase.game, ordinal=phase.ordinal).count() == 2
+        assert phase.game.current_phase.id == max(phase.id, duplicate.id)
+
+
+class TestGameEndingFinalisesPhases:
+
+    def _stale_active_phase(self, game, ordinal):
+        return Phase.objects.create(
+            game=game,
+            variant=game.variant,
+            season="Fall",
+            year=1901,
+            type=PhaseType.MOVEMENT,
+            ordinal=ordinal,
+            status=PhaseStatus.ACTIVE,
+            scheduled_resolution=timezone.now() + timedelta(days=1),
+        )
+
+    @pytest.mark.django_db
+    def test_victory_completes_every_phase(
+        self,
+        italy_vs_germany_phase_with_orders,
+        mock_adjudication_data_basic,
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        game = phase.game
+        stale_phase = self._stale_active_phase(game, ordinal=phase.ordinal + 2)
+
+        with patch("phase.models.resolve", return_value=mock_adjudication_data_basic):
+            with patch("phase.models.Victory.objects.try_create_victory", return_value=Mock()):
+                Phase.objects.resolve(phase)
+
+        game.refresh_from_db()
+        assert game.status == GameStatus.COMPLETED
+        assert not game.phases.exclude(status=PhaseStatus.COMPLETED).exists()
+
+        stale_phase.refresh_from_db()
+        assert stale_phase.status == PhaseStatus.COMPLETED
+        assert stale_phase.scheduled_resolution is None
+
+    @pytest.mark.django_db
+    def test_abandonment_completes_every_phase(
+        self,
+        italy_vs_germany_phase_with_orders,
+        mock_adjudication_data_basic,
+    ):
+        phase = italy_vs_germany_phase_with_orders
+        game = phase.game
+        stale_phase = self._stale_active_phase(game, ordinal=phase.ordinal + 2)
+
+        for member in game.members.all():
+            member.civil_disorder = True
+            member.save()
+
+        with patch("phase.models.resolve", return_value=mock_adjudication_data_basic):
+            with patch("phase.models.Victory.objects.try_create_victory", return_value=None):
+                Phase.objects.resolve(phase)
+
+        game.refresh_from_db()
+        assert game.status == GameStatus.ABANDONED
+        assert not game.phases.exclude(status=PhaseStatus.COMPLETED).exists()
+
+        stale_phase.refresh_from_db()
+        assert stale_phase.status == PhaseStatus.COMPLETED
+        assert stale_phase.scheduled_resolution is None
+
+    @pytest.mark.django_db
+    def test_finish_cancels_armed_resolution_job(
+        self, phase_factory, in_memory_procrastinate, classical_england_nation
+    ):
+        phase = phase_factory(
+            scheduled_resolution=timezone.now() + timedelta(hours=24),
+            phase_states_config=[
+                {"nation": classical_england_nation, "has_possible_orders": True, "orders_confirmed": False},
+            ],
+        )
+        phase.refresh_from_db()
+        job_id = phase.resolution_job_id
+
+        phase.game.finish(GameStatus.COMPLETED)
+
+        assert in_memory_procrastinate.jobs[job_id]["status"] == "cancelled"
+
+        phase.refresh_from_db()
+        assert phase.status == PhaseStatus.COMPLETED
+        assert phase.scheduled_resolution is None
+        assert phase.resolution_job_id is None
+
+
 class TestFilterDuePhasesBasicFiltering:
 
     @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does

Fixes #1181. A finished game could keep a phase that was still `active` with a live `scheduled_resolution` and an armed `phase.resolve_phase` job, because the game-ending branches only finalised the phase they had in hand. Ending a game now finalises *every* phase of that game, and a unique constraint stops a second live phase from being created at an ordinal a game already has.

### Changes

- **`Game.finish(status)`** (`service/game/models.py`) sets the status and `finished_at`, then completes every phase that is not already completed, clearing `scheduled_resolution` — which makes the existing `arm_deadline_resolution` post_save signal cancel the armed resolution job. Both game-ending branches of `PhaseManager.resolve` (victory, abandonment) and `DrawProposal.process_acceptance` now go through it, replacing three copies of the same six lines.
- **Unique constraint** `unique_live_phase_ordinal_per_game` on `(game, ordinal)` for every phase that is not `completed`. In both production incidents the duplicate was inserted while its twin was still live, so this is the insert that gets rejected.
- **Deterministic current phase**: `Phase.Meta.ordering` is now `["ordinal", "id"]`, `Game.current_phase` orders by `("ordinal", "id")`, and the two `DISTINCT ON (game_id)` subqueries that pick the current/latest-completed phase per game break their tie on `-id`. Legacy duplicates no longer make `current_phase` arbitrary.
- **Data migration** `0018_complete_phases_of_finished_games` completes the phases of games that are already `completed`/`abandoned` and clears their deadlines, so the constraint in `0019` applies cleanly.

### Why the constraint is scoped to live phases

The issue asks for uniqueness on `(game, ordinal)` outright. I checked production before writing the migration: five duplicate groups match the pattern in the issue (one live stale row, one completed row the game actually followed), but a sixth game — `the-battle-of-the-execrable-experience`, from October 2025 — carries **27 duplicate pairs where both rows are `completed`**, two interleaved chains of real phases with units, supply centres and phase states on both sides. Which chain the game followed cannot be determined automatically (the low-id chain holds the final phase the game ended on; the high-id chain holds the fuller board), so an unconditional constraint would need a migration that deletes 27 phases of a real 7-player game on a guess. That is a call for a human, not for a data migration.

Excluding completed rows keeps the invariant that actually bites — a game cannot gain a second live phase at an ordinal it already has — with no destructive migration. I confirmed no `(game, ordinal)` group in production currently holds two non-completed rows, so `0019` applies cleanly. If you want full `(game, ordinal)` uniqueness, say which chain of that 2025 game to keep and I will follow up with the dedupe.

### Two things I deliberately did not do

- **The five armed jobs in production are left to expire** rather than cancelled by the migration. Cancelling from a migration means reaching into `procrastinate_jobs` and depending on a third-party app's migration graph; the jobs are already no-ops, since `resolve_if_due` re-checks `filter_due_phases`, which now sees a completed phase in a finished game. Going forward the signal cancels them properly.
- **I did not find the root-cause race.** `resolve_if_due` takes `SELECT ... FOR UPDATE` on the phase and re-checks `filter_due_phases` inside the transaction, and every deferral shares a `resolve-game-<id>` procrastinate lock, so the double resolution should not be reachable from the code on `main`. The constraint turns whatever the path is into a loud `IntegrityError` that rolls the second resolution back (and procrastinate's retry will then skip it), rather than silent corruption.

### Rebased on #1176

`main` picked up the `processing` phase status while this was open, which conflicted in `PhaseManager.resolve`. Merge resolved in favour of `Game.finish(...)` inside `_resolve_claimed`'s try block, and the constraint condition widened from "active" to "not completed" so the new `processing` status cannot host a second live phase either. `claim_for_processing`'s compare-and-swap and this constraint are complementary: that one stops a second resolution starting, this one stops a second phase row landing whatever the path.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only

### Tests

`service/phase/tests.py`
- a second `active`/`processing`/`pending` phase at an ordinal the game already has is rejected; a completed one is allowed (documents the scope) and `current_phase` resolves deterministically
- resolving into a victory, and into abandonment, leaves every phase of the game completed with no `scheduled_resolution`, including a leftover live phase at another ordinal
- `Game.finish` cancels the armed resolution job and clears `resolution_job_id`

`service/draw_proposal/tests.py`
- accepting a draw completes a leftover live phase, not just the proposal's phase

`service/conftest.py` — the `retreat_phase` fixture hardcoded `ordinal=1` on games that already had a live phase at ordinal 1, which is the state the constraint forbids; it now appends at the next ordinal.

Full backend suite: 2126 passed, 8 skipped.