### PR TITLE
Skip design playground Netlify builds when nothing under it changed

### DIFF
--- a/packages/design-playground/netlify.toml
+++ b/packages/design-playground/netlify.toml
@@ -2,6 +2,7 @@
   base = "packages/design-playground"
   command = "npm run build"
   publish = "dist"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ."
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## What this PR does

The Netlify site for the design playground was building on every pull request, including ones that touch nothing under `packages/design-playground/`. Deploy `6a79aa4d` (branch `claude/github-issue-1181-a1xtgm`, a service-only change) built and failed with `Build script returned non-zero exit code: 2` — wasted build minutes and a red deploy status on a PR that has nothing to do with the playground.

This adds an `ignore` command to `packages/design-playground/netlify.toml` so Netlify skips the build unless the diff touches that package:

```toml
ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ."
```

Netlify runs the ignore command from the site's base directory (`packages/design-playground`), so the `.` pathspec resolves to that package. Exit 0 (no changes) skips the build; any non-zero exit proceeds with it.

Verified the exit codes against real commits in this repo, run from `packages/design-playground`:

| Range | Touches playground | Exit | Result |
|---|---|---|---|
| `b1b6475..175b605` | yes | 1 | build |
| `7820ef0..b1b6475` | no | 0 | skip |
| empty `CACHED_COMMIT_REF` | n/a | 128 | build |

The last row is the important failure mode: on a first build for a context there is no cached commit, `git diff` errors, and the non-zero exit means Netlify builds rather than silently skipping. The command fails open.

`npm ci && npm run build` in `packages/design-playground` succeeds on this branch (vite build, 1812 modules, `dist/` emitted).

No visual changes — this is build configuration only. `packages/web` is untouched.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — n/a; `packages/design-playground` is exempt from tests by its own `CLAUDE.md`, and the ignore command's behaviour is verified by the exit-code table above
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_012BuDX6M3qw428Myv9XTVNT)_