### PR TITLE
Point design playground docs at the live Netlify URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,8 +278,9 @@ npm run lint          # ESLint
 ## Design playground
 
 `packages/design-playground/` is a standalone app for prototyping screens before
-we build them. It deploys independently to `design.diplicity.com`, has no
-backend and no real data, and nothing in it ever ships to users.
+we build them. It deploys independently to
+`diplicity-design-playground.netlify.app`, has no backend and no real data, and
+nothing in it ever ships to users.
 
 **The rules in this file do not apply under `packages/design-playground/`.** That
 directory has its own `CLAUDE.md`, which overrides this one — most importantly it

--- a/packages/design-playground/CLAUDE.md
+++ b/packages/design-playground/CLAUDE.md
@@ -11,8 +11,9 @@ before applying any habit learned from the main app.
 ## What this is
 
 A standalone React app for prototyping screens before we build them. It builds
-and deploys independently to its own Netlify site at `design.diplicity.com`. It
-has no backend, no API client, no authentication and no real data.
+and deploys independently to its own Netlify site at
+`diplicity-design-playground.netlify.app`. It has no backend, no API client, no
+authentication and no real data.
 
 Nothing here ever ships to users. Prototype code exists to be argued about and
 then deleted.


### PR DESCRIPTION
## What this PR does

Both `CLAUDE.md` files described the design playground as deploying to `design.diplicity.com`. That custom domain isn't set up — the site is served from its default Netlify subdomain, `diplicity-design-playground.netlify.app`. This updates the two references so the guidance matches reality.

Verified against the live site:

```
$ curl -sI https://diplicity-design-playground.netlify.app/
HTTP/2 200
x-robots-tag: noindex, nofollow
```

Both occurrences are updated (root `CLAUDE.md`, and `packages/design-playground/CLAUDE.md`); `grep -rn "design\.diplicity\.com"` now returns nothing. Documentation only — no code, config, or behaviour changes.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, doc-only two-line change
- [x] Tests cover the change — n/a, documentation only
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_012BuDX6M3qw428Myv9XTVNT)_