### PR TITLE
Give API 404s their own not-found state

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -41,10 +41,13 @@
       padding: 0 !important;
     }
 
-    h1,
-    h2,
-    h3 {
-      text-align: left;
+    @layer base {
+
+      h1,
+      h2,
+      h3 {
+        text-align: left;
+      }
     }
 
     body {

--- a/packages/web/src/Router.tsx
+++ b/packages/web/src/Router.tsx
@@ -23,7 +23,7 @@ import { useIsMobile } from "./hooks/use-mobile";
 import { getVariantsListQueryOptions } from "./api/generated/endpoints";
 import * as Sentry from "@sentry/react";
 import { deepLinkStorage, useDeepLink } from "./deepLink";
-import { isNetworkError } from "./utils/network";
+import { isNetworkError, isNotFoundError } from "./utils/network";
 
 const RouteFallback: React.FC = () => (
   <div className="flex-1 flex items-center justify-center">
@@ -35,7 +35,7 @@ const RootErrorBoundary: React.FC = () => {
   const error = useRouteError() as Error;
 
   React.useEffect(() => {
-    if (error && !isNetworkError(error)) {
+    if (error && !isNetworkError(error) && !isNotFoundError(error)) {
       Sentry.captureException(error);
     }
   }, [error]);

--- a/packages/web/src/components/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary.tsx
@@ -4,8 +4,9 @@ import { DiplicityLogo } from "./DiplicityLogo";
 import { Button } from "@/components/ui/button";
 import { SafeAreaView } from "@/components/SafeAreaView";
 import { OfflineNotice } from "./OfflineNotice";
+import { NotFoundNotice } from "./NotFoundNotice";
 import { isStaleChunkError, reloadForStaleChunk } from "@/utils/staleChunk";
-import { isNetworkError } from "@/utils/network";
+import { isNetworkError, isNotFoundError } from "@/utils/network";
 
 const reloadApp = () => window.location.reload();
 
@@ -16,6 +17,10 @@ interface ErrorFallbackUIProps {
 export const ErrorFallbackUI: React.FC<ErrorFallbackUIProps> = ({ error }) => {
   if (isNetworkError(error)) {
     return <OfflineNotice fullScreen onRetry={reloadApp} />;
+  }
+
+  if (isNotFoundError(error)) {
+    return <NotFoundNotice fullScreen />;
   }
 
   return (

--- a/packages/web/src/components/NotFoundNotice.test.tsx
+++ b/packages/web/src/components/NotFoundNotice.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NotFoundNotice } from "./NotFoundNotice";
+
+describe("NotFoundNotice", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, href: "/game/some-game/phase/1" },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("navigates home when the user taps Go to my games", async () => {
+    render(<NotFoundNotice />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Go to my games" }));
+
+    expect(window.location.href).toBe("/");
+  });
+
+  it("does not offer a retry", () => {
+    render(<NotFoundNotice />);
+
+    expect(
+      screen.queryByRole("button", { name: "Try Again" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the full-screen variant heading", () => {
+    render(<NotFoundNotice fullScreen />);
+
+    expect(
+      screen.getByRole("heading", { name: "This game is no longer available" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/NotFoundNotice.tsx
+++ b/packages/web/src/components/NotFoundNotice.tsx
@@ -10,8 +10,7 @@ const goHome = () => {
 };
 
 const title = "This game is no longer available";
-const message =
-  "It may have been deleted, or this link may point to a phase that no longer exists.";
+const message = "It may have been deleted.";
 
 interface NotFoundNoticeProps {
   fullScreen?: boolean;
@@ -23,7 +22,7 @@ const NotFoundNotice: React.FC<NotFoundNoticeProps> = ({ fullScreen }) => {
       <div className="max-w-sm mx-auto">
         <SafeAreaView className="flex flex-col items-center justify-center min-h-screen text-center gap-6">
           <DiplicityLogo />
-          <h1 className="text-2xl font-bold">{title}</h1>
+          <h1 className="text-2xl font-bold text-center">{title}</h1>
           <p className="text-muted-foreground">{message}</p>
           <Button variant="outline" onClick={goHome}>
             Go to my games

--- a/packages/web/src/components/NotFoundNotice.tsx
+++ b/packages/web/src/components/NotFoundNotice.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { SearchX } from "lucide-react";
+import { DiplicityLogo } from "./DiplicityLogo";
+import { Button } from "@/components/ui/button";
+import { SafeAreaView } from "@/components/SafeAreaView";
+import { Notice } from "@/components/Notice";
+
+const goHome = () => {
+  window.location.href = "/";
+};
+
+const title = "This game is no longer available";
+const message =
+  "It may have been deleted, or this link may point to a phase that no longer exists.";
+
+interface NotFoundNoticeProps {
+  fullScreen?: boolean;
+}
+
+const NotFoundNotice: React.FC<NotFoundNoticeProps> = ({ fullScreen }) => {
+  if (fullScreen) {
+    return (
+      <div className="max-w-sm mx-auto">
+        <SafeAreaView className="flex flex-col items-center justify-center min-h-screen text-center gap-6">
+          <DiplicityLogo />
+          <h1 className="text-2xl font-bold">{title}</h1>
+          <p className="text-muted-foreground">{message}</p>
+          <Button variant="outline" onClick={goHome}>
+            Go to my games
+          </Button>
+        </SafeAreaView>
+      </div>
+    );
+  }
+
+  return (
+    <Notice
+      icon={SearchX}
+      title={title}
+      message={message}
+      actions={<Button onClick={goHome}>Go to my games</Button>}
+    />
+  );
+};
+
+export { NotFoundNotice };

--- a/packages/web/src/components/QueryErrorBoundary.test.tsx
+++ b/packages/web/src/components/QueryErrorBoundary.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AxiosError, AxiosHeaders } from "axios";
+import type { AxiosResponse } from "axios";
+import { ErrorBoundaryClass } from "./QueryErrorBoundary";
+
+const captureException = vi.fn();
+
+vi.mock("@sentry/react", () => ({
+  captureException: (error: unknown) => captureException(error),
+}));
+
+const responseError = (status: number) => {
+  const config = { headers: new AxiosHeaders() };
+  const response = {
+    status,
+    statusText: "",
+    data: null,
+    headers: {},
+    config,
+  } as AxiosResponse;
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    AxiosError.ERR_BAD_REQUEST,
+    config,
+    undefined,
+    response
+  );
+};
+
+const Thrower: React.FC<{ error: Error }> = ({ error }) => {
+  throw error;
+};
+
+const renderWithError = (error: Error) =>
+  render(
+    <ErrorBoundaryClass>
+      <Thrower error={error} />
+    </ErrorBoundaryClass>
+  );
+
+describe("QueryErrorBoundary", () => {
+  beforeEach(() => {
+    captureException.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("renders the not found notice for a 404 without reporting it", () => {
+    renderWithError(responseError(404));
+
+    expect(
+      screen.getByText("This game is no longer available")
+    ).toBeInTheDocument();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("renders the generic fallback for a 500 and reports it", () => {
+    const error = responseError(500);
+    renderWithError(error);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(captureException).toHaveBeenCalledWith(error);
+  });
+
+  it("renders the offline notice for a network error without reporting it", () => {
+    renderWithError(new AxiosError("Network Error", AxiosError.ERR_NETWORK));
+
+    expect(screen.getByText("No internet connection")).toBeInTheDocument();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/QueryErrorBoundary.tsx
+++ b/packages/web/src/components/QueryErrorBoundary.tsx
@@ -4,7 +4,8 @@ import * as Sentry from "@sentry/react";
 import { Button } from "@/components/ui/button";
 import { Notice } from "@/components/Notice";
 import { OfflineNotice } from "@/components/OfflineNotice";
-import { isNetworkError } from "@/utils/network";
+import { NotFoundNotice } from "@/components/NotFoundNotice";
+import { isNetworkError, isNotFoundError } from "@/utils/network";
 import { AlertCircle } from "lucide-react";
 
 interface QueryErrorFallbackProps {
@@ -20,6 +21,14 @@ const QueryErrorFallback: React.FC<QueryErrorFallbackProps> = ({
     return (
       <div className="flex flex-col items-center justify-center p-8">
         <OfflineNotice onRetry={onReset} />
+      </div>
+    );
+  }
+
+  if (isNotFoundError(error)) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8">
+        <NotFoundNotice />
       </div>
     );
   }
@@ -65,7 +74,7 @@ class ErrorBoundaryClass extends Component<
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryClassState {
-    if (!isNetworkError(error)) {
+    if (!isNetworkError(error) && !isNotFoundError(error)) {
       Sentry.captureException(error);
     }
     return { hasError: true, error };

--- a/packages/web/src/utils/network.test.ts
+++ b/packages/web/src/utils/network.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { AxiosError } from "axios";
-import { isNetworkError } from "./network";
+import { AxiosError, AxiosHeaders } from "axios";
+import type { AxiosResponse } from "axios";
+import { isNetworkError, isNotFoundError } from "./network";
+
+const responseError = (status: number) => {
+  const config = { headers: new AxiosHeaders() };
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    AxiosError.ERR_BAD_REQUEST,
+    config,
+    undefined,
+    { status, statusText: "", data: null, headers: {}, config } as AxiosResponse
+  );
+};
 
 describe("isNetworkError", () => {
   it("returns true for an axios network error", () => {
@@ -21,5 +33,25 @@ describe("isNetworkError", () => {
 
   it("returns false for a non-error value", () => {
     expect(isNetworkError("offline")).toBe(false);
+  });
+});
+
+describe("isNotFoundError", () => {
+  it("returns true for an axios error with a 404 response", () => {
+    expect(isNotFoundError(responseError(404))).toBe(true);
+  });
+
+  it("returns false for an axios error with a 500 response", () => {
+    expect(isNotFoundError(responseError(500))).toBe(false);
+  });
+
+  it("returns false for an axios network error", () => {
+    expect(
+      isNotFoundError(new AxiosError("Network Error", AxiosError.ERR_NETWORK))
+    ).toBe(false);
+  });
+
+  it("returns false for a non-axios error", () => {
+    expect(isNotFoundError(new Error("Not Found"))).toBe(false);
   });
 });

--- a/packages/web/src/utils/network.ts
+++ b/packages/web/src/utils/network.ts
@@ -2,3 +2,6 @@ import { AxiosError } from "axios";
 
 export const isNetworkError = (error: unknown): boolean =>
   error instanceof AxiosError && error.code === AxiosError.ERR_NETWORK;
+
+export const isNotFoundError = (error: unknown): boolean =>
+  error instanceof AxiosError && error.response?.status === 404;


### PR DESCRIPTION
## What this PR does

Fixes #1171. A 404 from the API took the generic "Something went wrong" branch in both error fallbacks — an error card with a Try Again button that can never succeed — and was captured as a Sentry exception. `DIPLICITY-REACT-A` is 71 events since 2026-06-30 and the noisiest frontend issue open.

**What is actually 404ing.** The issue asked to confirm this from the replays; the span data answers it directly. `span.op:http.client span.status_code:404` over 30d is almost entirely sandbox games, and the shape is the phase-scoped pair 404ing *while the game slug still resolves*:

```
GET .../game/intro-to-diplomacy-sandbox/phase/66097/        6
GET .../game/intro-to-diplomacy-sandbox/orders/66097        6
GET .../game/chaos-3-electric-boogalee-sandbox/phase/65348/ 4
GET .../game/chaos-3-electric-boogalee-sandbox/orders/65348 4
GET .../game/intro-to-diplomacy-sandbox-864d25d7/           2
```

The mechanism is in the code. `GameCloneToSandboxSerializer.create` hard-deletes the user's oldest sandbox once they hit three (`service/game/serializers.py:633`), so its phases cascade away. `Game._generate_id` (`service/game/models.py:483`) derives the id from the game name and only appends a uuid suffix if the bare slug is taken — so the next "X (Sandbox)" clone reclaims the freed slug. `resolve_phase` filters on both id and game (`service/common/views.py:32`), so the reclaimed game returns 200 while the old phase ids return 404. The user story is a bookmark, an open tab or a back button pointing at a sandbox phase that was auto-deleted out from under them.

**The change.** `isNotFoundError` sits next to `isNetworkError` in `utils/network.ts`, following that precedent so the classification lives in one place and both the fallback and the Sentry decision read from it. A new `NotFoundNotice` mirrors `OfflineNotice` (including its `fullScreen` variant) and offers navigation home instead of a retry.

**Scope beyond the issue's file list.** The issue points only at `QueryErrorBoundary.tsx`, but 5 of the 23 events are transactions with no phase segment (`/game/the-flight-of-the-bilious-history`, `/game/simen-test`) — those are `GamePhaseRedirect`, which has a `Suspense` but no `QueryErrorBoundary`, so its 404 bubbles to the router `errorElement` → `RootErrorBoundary` → `ErrorFallbackUI`. Fixing only the query boundary would leave that path reporting and still showing "Something went wrong", so `ErrorBoundary.tsx` and `Router.tsx` get the same two changes.

Genuine 5xx keeps the current fallback and keeps reporting.

**One-line CSS fix in `index.html`.** The new title is the first heading in the app long enough to wrap, which exposed that it would not centre. `index.html` carries an unlayered `h1, h2, h3 { text-align: left }` from the Vite template era; Tailwind v4 emits its utilities inside cascade layers, and **unlayered rules beat layered ones regardless of specificity**, so that rule silently defeats `text-center` on every heading in the app. Moving it into `@layer base` keeps it as the default it was meant to be while letting an explicit utility win. Verified with computed styles: no other heading in the app carries an alignment utility, so the Login hero, auth cards and every other heading render exactly as before.

### Worth a reviewer's attention

- **This silences a real bug.** `GET /variants/1139-youngstown-redux/` 404s 6 times in 30d — a variant that should exist, not a deleted game. It goes quiet under this change. Worth its own issue; I did not fold a fix in here.
- **Slug reuse after deletion is the root cause** of the sandbox bucket, not just a 404-handling problem. A deleted game's id being reclaimed is what turns "game gone" into the more confusing "game fine, phase gone". Also worth its own issue — plausibly `_generate_id` should always suffix, or deleted ids should be tombstoned.
- **The copy covers both cases with one message** ("It may have been deleted") rather than distinguishing game-404 from phase-404. Telling them apart means sniffing `error.config.url` in the fallback, which is fragile. A reviewer who wants the phase-stale case to redirect to the game's current phase instead of showing a dead end — the game does load fine — should say so; it is a real UX improvement but needs that distinction.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in — the `index.html` cascade-layer fix is included because this PR's own screen cannot render correctly without it, not as a drive-by
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, this is a 6-file change; lint, typecheck and the full suite were run instead
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — taken, but not uploadable from this session; see below

Frontend: 559 passed, `npm run lint` and `npx tsc -b --noEmit` clean.

`network.test.ts` covers `isNotFoundError` (404 true, 500 false, `ERR_NETWORK` false, non-axios false). A new `QueryErrorBoundary.test.tsx` asserts the thing the issue is actually about — Sentry is not called for a 404 and is called for a 500 — which nothing covered before. `NotFoundNotice.test.tsx` mirrors `OfflineNotice.test.tsx` and asserts no retry button is offered.

## Screenshots

Taken against `npm run dev:mocks` but **could not be uploaded** — GitHub has no attachment-upload API and this session has no browser for the web uploader. The files were sent into the Claude Code conversation and need dragging into this description before merge:

- `before-mobile.png` / `not-found-mobile.png` — the inline state at 390x844, the viewport most of these events come from (Chrome Mobile / Android)
- `before-fullscreen.png` / `not-found-fullscreen.png` — the full-screen state on the `/game/:gameId` redirect path
- `not-found-inline.png` — the inline state at 1280x800

To reproduce: `cd packages/web && npm run dev:mocks`, then visit `/game/deleted-sandbox/phase/999/orders` (inline) and `/game/deleted-sandbox` (full screen). The mock handlers already 404 an unknown game id via `gameOr404`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4299AHRRiQ8QkNHhGv91D