### PR TITLE
Match If-None-Match using the RFC 9110 weak comparison

### DIFF
--- a/service/common/etag.py
+++ b/service/common/etag.py
@@ -1,0 +1,26 @@
+from django.utils.http import parse_etags
+
+# Railway's edge proxy gzips our JSON responses, and a proxy that re-encodes a
+# body must downgrade the ETag it forwards to a weak validator. Clients
+# therefore replay `If-None-Match: W/"abc"` against an ETag we issued as
+# `"abc"`, and a plain `==` never matches — so every conditional request falls
+# through to a full 200. RFC 9110 13.1.2 requires If-None-Match to use the weak
+# comparison function, which ignores the `W/` prefix on either side.
+_WEAK_PREFIX = "W/"
+
+
+def _strip_weak(etag):
+    if etag.startswith(_WEAK_PREFIX):
+        return etag[len(_WEAK_PREFIX):]
+    return etag
+
+
+def if_none_match(request, etag):
+    header = request.headers.get("If-None-Match")
+    if not header:
+        return False
+    candidates = parse_etags(header)
+    if candidates == ["*"]:
+        return True
+    target = _strip_weak(etag)
+    return any(_strip_weak(candidate) == target for candidate in candidates)

--- a/service/common/tests.py
+++ b/service/common/tests.py
@@ -1,0 +1,39 @@
+import pytest
+from django.test import RequestFactory
+
+from common.etag import if_none_match
+
+
+def _request(header=None):
+    factory = RequestFactory()
+    if header is None:
+        return factory.get("/")
+    return factory.get("/", HTTP_IF_NONE_MATCH=header)
+
+
+class TestIfNoneMatch:
+
+    def test_no_header_does_not_match(self):
+        assert if_none_match(_request(), '"abc"') is False
+
+    def test_strong_header_matches_strong_etag(self):
+        assert if_none_match(_request('"abc"'), '"abc"') is True
+
+    def test_weak_header_matches_strong_etag(self):
+        assert if_none_match(_request('W/"abc"'), '"abc"') is True
+
+    def test_weak_header_matches_weak_etag(self):
+        assert if_none_match(_request('W/"abc"'), 'W/"abc"') is True
+
+    def test_different_etag_does_not_match(self):
+        assert if_none_match(_request('W/"abc"'), '"def"') is False
+
+    def test_matches_any_entry_in_a_list(self):
+        assert if_none_match(_request('W/"abc", "def"'), '"def"') is True
+
+    def test_wildcard_matches(self):
+        assert if_none_match(_request("*"), '"abc"') is True
+
+    @pytest.mark.parametrize("header", ["", "not-an-etag"])
+    def test_unparseable_header_does_not_match(self, header):
+        assert if_none_match(_request(header), '"abc"') is False

--- a/service/order/tests.py
+++ b/service/order/tests.py
@@ -260,6 +260,20 @@ class TestOrderListViewCompletedPhaseCaching:
         assert response.status_code == status.HTTP_200_OK
         assert response["ETag"] != '"stale"'
 
+    @pytest.mark.django_db
+    def test_completed_phase_weakened_etag_returns_304(self, authenticated_client, order_active_game):
+        game = order_active_game
+        phase = game.current_phase
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+        url = reverse("order-list", args=[game.id, phase.id])
+
+        etag = authenticated_client.get(url)["ETag"]
+
+        response = authenticated_client.get(url, HTTP_IF_NONE_MATCH=f"W/{etag}")
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+
 
 class TestOrderCreateView:
 

--- a/service/order/views.py
+++ b/service/order/views.py
@@ -10,6 +10,7 @@ from .models import Order
 from .serializers import OrderSerializer, OrderOptionsResponseSerializer
 from .utils import flatten_options, build_move_coast_lookup, FIELD_ORDER
 from common.constants import PhaseStatus
+from common.etag import if_none_match
 from common.permissions import IsActiveGame, IsActiveGameMember, IsCurrentPhaseActive
 from common.views import SelectedPhaseMixin, CurrentPhaseMixin
 from common.serializers import EmptySerializer
@@ -37,7 +38,7 @@ class OrderListView(SelectedPhaseMixin, generics.ListAPIView):
         phase = self.get_phase()
         if phase.status == PhaseStatus.COMPLETED:
             etag = _completed_phase_orders_etag(phase)
-            if request.headers.get("If-None-Match") == etag:
+            if if_none_match(request, etag):
                 response = Response(status=status.HTTP_304_NOT_MODIFIED)
             else:
                 response = self._build_orders_response()

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -86,6 +86,33 @@ def test_list_variants_returns_304_when_etag_matches(authenticated_client):
 
 
 @pytest.mark.django_db
+def test_list_variants_returns_304_when_weakened_etag_matches(authenticated_client):
+    response1 = authenticated_client.get(reverse(viewname))
+    etag = response1["ETag"]
+
+    response2 = authenticated_client.get(reverse(viewname), HTTP_IF_NONE_MATCH=f"W/{etag}")
+
+    assert response2.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+@pytest.mark.django_db
+def test_list_variants_returns_200_when_weakened_etag_is_stale(authenticated_client):
+    response = authenticated_client.get(reverse(viewname), HTTP_IF_NONE_MATCH='W/"stale"')
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_retrieve_variant_returns_304_when_weakened_etag_matches(authenticated_client):
+    url = reverse("variant-detail", args=["classical"])
+    etag = authenticated_client.get(url)["ETag"]
+
+    response = authenticated_client.get(url, HTTP_IF_NONE_MATCH=f"W/{etag}")
+
+    assert response.status_code == status.HTTP_304_NOT_MODIFIED
+
+
+@pytest.mark.django_db
 def test_list_variants_includes_svg_url(authenticated_client):
     response = authenticated_client.get(reverse(viewname))
 

--- a/service/variant/views.py
+++ b/service/variant/views.py
@@ -13,6 +13,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from common.constants import VariantStatus
+from common.etag import if_none_match
 from nation.models import NationFlag
 from province.models import Province
 from .models import Variant, VariantSvg
@@ -79,7 +80,7 @@ class VariantListCreateView(generics.ListCreateAPIView):
     def list(self, request, *args, **kwargs):
         variant_max, flag_max = _variants_list_cache_inputs()
         etag = _variants_list_etag(variant_max, flag_max)
-        if request.headers.get("If-None-Match") == etag:
+        if if_none_match(request, etag):
             response = Response(status=status.HTTP_304_NOT_MODIFIED)
         else:
             response = Response(self._published_variants_data(variant_max, flag_max))
@@ -124,7 +125,7 @@ class VariantDetailView(generics.RetrieveUpdateDestroyAPIView):
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         etag = _variant_detail_etag(instance, request.user)
-        if request.headers.get("If-None-Match") == etag:
+        if if_none_match(request, etag):
             response = Response(status=status.HTTP_304_NOT_MODIFIED)
         else:
             response = Response(self.get_serializer(instance).data)


### PR DESCRIPTION
## What this PR does

Our three conditional-GET views compared the `If-None-Match` header to the ETag with `==`. Railway's edge proxy gzips our JSON responses and — per RFC 9110, which requires a proxy that re-encodes a body to downgrade the validator it forwards — rewrites the ETag to its weak form. Real clients therefore replay `If-None-Match: W/"abc"` against an ETag the view issued as `"abc"`, the strict comparison fails, and **every conditional request falls through to a full 200**. RFC 9110 §13.1.2 specifies that `If-None-Match` uses the *weak* comparison function, which ignores the `W/` prefix on either side.

Reproduced against production, taking the ETag exactly as a browser receives it:

```
$ curl -sD- -o/dev/null $API/variants/ -H 'Accept-Encoding: gzip' | grep -i etag
etag: W/"2b8cee2c6cf34540217f0774565d8ccb"      # what the client caches
$ curl -sD- -o/dev/null $API/variants/ -H 'Accept-Encoding: identity' | grep -i etag
etag: "2b8cee2c6cf34540217f0774565d8ccb"        # what the view issued

# replay the weak form — i.e. what every real client actually sends:
$ curl -o/dev/null -w '%{http_code} %{size_download}\n' $API/variants/ \
    -H 'Accept-Encoding: gzip' -H 'If-None-Match: W/"2b8cee…"'
200 54538

# replay the unweakened form:
$ curl -o/dev/null -w '%{http_code} %{size_download}\n' $API/variants/ \
    -H 'Accept-Encoding: gzip' -H 'If-None-Match: "2b8cee…"'
304 0
```

The three affected views are `VariantListCreateView.list`, `VariantDetailView.retrieve` and `OrderListView.list` (completed phases). `GET /variants/` is the one that matters for cost: it is a **486 KB** uncompressed body (83% of it province adjacency graphs for all 18 published variants) that a working 304 turns into zero bytes. At ~3,550 requests/day that is on the order of **50 GB/month of Railway egress**, roughly 19% of the service's current 269.77 GB bill.

The shared helper lives in `common/etag.py` rather than being repeated at each call site, and uses Django's public `parse_etags` so a multi-value header and `*` are handled correctly too.

This is the first of several egress reductions; the larger contributor (`GET /games/<id>/channels/`, 125 KB per response polled every 5s) needs a payload-shape decision and is filed separately.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, single-function change; verified instead by confirming the three new tests fail on the unfixed views and pass with the fix
- [x] Tests cover the change — 9 unit tests for `if_none_match` in `common/tests.py`, plus one weak-ETag round-trip test per affected view. Reverting only the view changes fails exactly those three round-trip tests. Full suite: 2131 passed, 8 skipped.
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no user-visible change

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YdhBc8KPDJmArbpdU66U)_