### PR TITLE
Report order outcome codes from the adjudicator

### DIFF
--- a/service/adjudication/service.py
+++ b/service/adjudication/service.py
@@ -32,18 +32,6 @@ logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
-# Map the Python engine's resolution statuses back to godip's wire-format
-# strings. Downstream OrderResolution.status is a CharField with choices
-# defined as the godip codes (see common.constants.OrderResolutionStatus),
-# and `get_status_display` is what the frontend renders.
-_STATUS_TO_GODIP = {
-    "OK": "OK",
-    "BOUNCE": "ErrBounce",
-    "CUT": "ErrSupportBroken",
-    "ILLEGAL": "ErrIllegalMove",
-}
-
-
 def start(phase) -> Dict[str, Any]:
     logger.info(f"Starting adjudication for phase {phase.id} of game {phase.game.id}")
     with tracer.start_as_current_span("adjudication.start") as span:
@@ -235,6 +223,10 @@ def _build_resolutions(orders, resolutions, variant: Variant) -> List[Dict[str, 
     # parent province (named coasts get collapsed at order creation), so
     # the resolution province must be the parent too.
     #
+    # The engine reports each order's outcome code directly, so "result"
+    # is a copy rather than a translation: ResolutionCode and
+    # OrderResolutionStatus are the same vocabulary.
+    #
     # For BOUNCE/CUT statuses we also populate the "by" province — godip
     # encoded it as `ErrBounce:par` / `ErrSupportBroken:mar`. The engine
     # doesn't carry that on the Resolution, so we reconstruct it from the
@@ -252,7 +244,6 @@ def _build_resolutions(orders, resolutions, variant: Variant) -> List[Dict[str, 
     resolutions_out: List[Dict[str, Any]] = []
     for resolution in resolutions or []:
         province_parent = variant.parent_of(resolution.province)
-        godip_status = _STATUS_TO_GODIP.get(resolution.resolution, "ErrIllegalMove")
         by = _find_by_province(
             resolution.resolution,
             province_parent,
@@ -263,7 +254,7 @@ def _build_resolutions(orders, resolutions, variant: Variant) -> List[Dict[str, 
         resolutions_out.append(
             {
                 "province": province_parent,
-                "result": godip_status,
+                "result": resolution.code,
                 "by": by,
             }
         )

--- a/service/adjudicator/domain.py
+++ b/service/adjudicator/domain.py
@@ -247,6 +247,7 @@ class SupplyCenter:
 class Resolution:
     province: str
     resolution: str
+    code: Optional[str] = None
     reason: Optional[str] = None
 
 

--- a/service/adjudicator/engine.py
+++ b/service/adjudicator/engine.py
@@ -29,6 +29,7 @@ from .types import (
     Order,
     OrderResolution,
     OrderType,
+    ResolutionCode,
     RetreatOrder,
     StateView,
     Status,
@@ -438,9 +439,10 @@ class ParseAdjustmentOrdersReducer(Reducer):
 class ApplyLegalityChecksReducer(Reducer):
     """Walk parsed_orders in index order and apply each order's
     LEGALITY_CHECKS against the input state. The first failing check's
-    MESSAGE becomes the order's failure_reason; its status becomes
-    ILLEGAL. Checks are pure predicates over the input state and do not
-    see the resolutions of other orders in this phase."""
+    MESSAGE becomes the order's failure_reason and its CODE the order's
+    code; its status becomes ILLEGAL. Checks are pure predicates over the
+    input state and do not see the resolutions of other orders in this
+    phase."""
 
     ACTION = Actions.ApplyLegalityChecks
 
@@ -455,6 +457,7 @@ class ApplyLegalityChecksReducer(Reducer):
                     resolutions[i] = replace(
                         resolutions[i],
                         status=Status.ILLEGAL,
+                        code=check_cls.CODE,
                         failure_reason=check_cls.MESSAGE,
                     )
                     break
@@ -494,6 +497,7 @@ class MarkRedundantConvoysIllegalReducer(Reducer):
                     resolutions[k] = replace(
                         resolutions[k],
                         status=Status.ILLEGAL,
+                        code=ResolutionCode.ILLEGAL_MOVE,
                         failure_reason="Convoy fleet is not necessary for any convoy route.",
                     )
         return state.replace(resolutions=tuple(resolutions))
@@ -550,7 +554,7 @@ class MarkConvoyedMovesReachableReducer(Reducer):
                 ):
                     continue
                 resolutions[i] = replace(
-                    r, status=None, failure_reason=None, via_convoy=True
+                    r, status=None, code=None, failure_reason=None, via_convoy=True
                 )
                 continue
             if r.status is not None:
@@ -597,6 +601,7 @@ class EnforceUniqueAdjustmentTargetsReducer(Reducer):
                     resolutions[i] = replace(
                         resolutions[i],
                         status=Status.ILLEGAL,
+                        code=ResolutionCode.ILLEGAL_MOVE,
                         failure_reason="Another build for this province has already been ordered.",
                     )
                 else:
@@ -607,6 +612,7 @@ class EnforceUniqueAdjustmentTargetsReducer(Reducer):
                     resolutions[i] = replace(
                         resolutions[i],
                         status=Status.ILLEGAL,
+                        code=ResolutionCode.ILLEGAL_MOVE,
                         failure_reason="This unit has already been ordered to disband.",
                     )
                 else:
@@ -748,6 +754,7 @@ class ResolveRetreatBouncesReducer(Reducer):
                 resolutions[i] = replace(
                     resolutions[i],
                     status=Status.BOUNCE,
+                    code=ResolutionCode.BOUNCED,
                     failure_reason="Multiple units retreat to the same province; all disband.",
                 )
         return state.replace(resolutions=tuple(resolutions))
@@ -777,6 +784,7 @@ class EnforceBuildLimitsReducer(Reducer):
                 resolutions[i] = replace(
                     resolutions[i],
                     status=Status.ILLEGAL,
+                    code=ResolutionCode.ILLEGAL_MOVE,
                     failure_reason="Nation has already built its allowed number of units.",
                 )
             else:
@@ -808,6 +816,7 @@ class EnforceDisbandLimitsReducer(Reducer):
                 resolutions[i] = replace(
                     resolutions[i],
                     status=Status.ILLEGAL,
+                    code=ResolutionCode.ILLEGAL_MOVE,
                     failure_reason="Nation has already disbanded its required number of units.",
                 )
             else:
@@ -888,13 +897,18 @@ class FinalizeStatusesReducer(Reducer):
                 continue
             if isinstance(order, (SupportHoldOrder, SupportMoveOrder)):
                 if r.support_cut == Status.CUT:
-                    resolutions[i] = replace(r, status=Status.CUT)
+                    resolutions[i] = replace(
+                        r, status=Status.CUT, code=ResolutionCode.SUPPORT_BROKEN
+                    )
                 elif r.support_matched:
-                    resolutions[i] = replace(r, status=Status.OK)
+                    resolutions[i] = replace(
+                        r, status=Status.OK, code=ResolutionCode.SUCCEEDED
+                    )
                 else:
                     resolutions[i] = replace(
                         r,
                         status=Status.ILLEGAL,
+                        code=ResolutionCode.ILLEGAL_MOVE,
                         failure_reason="The supported unit was not ordered to perform the supported action.",
                     )
                 continue
@@ -904,10 +918,13 @@ class FinalizeStatusesReducer(Reducer):
                 resolutions[i] = replace(
                     r,
                     status=Status.BOUNCE,
+                    code=ResolutionCode.BOUNCED,
                     failure_reason="The convoying fleet was dislodged.",
                 )
                 continue
-            resolutions[i] = replace(r, status=Status.OK)
+            resolutions[i] = replace(
+                r, status=Status.OK, code=ResolutionCode.SUCCEEDED
+            )
         return state.replace(resolutions=tuple(resolutions))
 
     @classmethod
@@ -1475,6 +1492,7 @@ class Engine:
                 Resolution(
                     province=order.source_province(),
                     resolution=resolution.status or Status.OK,
+                    code=resolution.code or ResolutionCode.SUCCEEDED,
                     reason=resolution.failure_reason,
                 )
             )
@@ -1483,6 +1501,7 @@ class Engine:
                 Resolution(
                     province=location,
                     resolution=Status.OK,
+                    code=ResolutionCode.SUCCEEDED,
                     reason="Disbanded due to civil disorder.",
                 )
             )

--- a/service/adjudicator/resolution.py
+++ b/service/adjudicator/resolution.py
@@ -87,6 +87,7 @@ from .types import (
     MoveOrder,
     Order,
     OrderResolution,
+    ResolutionCode,
     Status,
     StateView,
     SupportHoldOrder,
@@ -119,7 +120,7 @@ class _Decision:
     `parsed_orders` index the decision is about. `value` is `None` while
     unresolved; once decided, it holds the per-kind answer (a `Status`
     string for `support_cut`, an `int` for the strength kinds, or a
-    `(status, failure_reason)` tuple for `move_status`). `dependencies`
+    `(status, code, failure_reason)` tuple for `move_status`). `dependencies`
     is the set of other decision keys this one reads from — computed
     statically when the decision is enumerated.
     """
@@ -654,7 +655,7 @@ class _Solver:
 
     def _compute_move_status(
         self, i: int
-    ) -> Optional[Tuple[str, Optional[str]]]:
+    ) -> Optional[Tuple[str, str, Optional[str]]]:
         parsed = self._parsed
         variant = self._variant
         resolutions = self._initial_resolutions
@@ -670,6 +671,7 @@ class _Solver:
             if not intact:
                 return (
                     Status.BOUNCE,
+                    ResolutionCode.BOUNCED,
                     "The convoy was disrupted.",
                 )
         target_parent = variant.parent_of(order.target)
@@ -691,6 +693,7 @@ class _Solver:
         if attack <= max_prevent:
             return (
                 Status.BOUNCE,
+                ResolutionCode.BOUNCED,
                 "The attack was prevented by a competing move of equal or greater strength.",
             )
         h2h_index = _head_to_head_opponent_index(self._state, i)
@@ -701,6 +704,7 @@ class _Solver:
             if attack <= opp_defense:
                 return (
                     Status.BOUNCE,
+                    ResolutionCode.BOUNCED,
                     "The head-to-head attack failed to overpower the opposing unit.",
                 )
             opponent = parsed[h2h_index]
@@ -708,12 +712,13 @@ class _Solver:
             if opponent.nation == order.nation:
                 return (
                     Status.BOUNCE,
+                    ResolutionCode.BOUNCED,
                     "A unit cannot dislodge a unit of its own nation.",
                 )
-            return (Status.OK, None)
+            return (Status.OK, ResolutionCode.SUCCEEDED, None)
         defender_idx = _defender_order_index(self._state, i)
         if defender_idx is None:
-            return (Status.OK, None)
+            return (Status.OK, ResolutionCode.SUCCEEDED, None)
         defender_order = parsed[defender_idx]
         defender_initial_status = resolutions[defender_idx].status
         if (
@@ -727,21 +732,23 @@ class _Solver:
         else:
             defender_status = defender_initial_status
         if isinstance(defender_order, MoveOrder) and defender_status == Status.OK:
-            return (Status.OK, None)
+            return (Status.OK, ResolutionCode.SUCCEEDED, None)
         hold = self._dec_value((_HOLD_STRENGTH, defender_idx))
         if hold is None:
             return None
         if attack <= hold:
             return (
                 Status.BOUNCE,
+                ResolutionCode.BOUNCED,
                 "The attack was not strong enough to dislodge the defender.",
             )
         if defender_order.nation == order.nation:
             return (
                 Status.BOUNCE,
+                ResolutionCode.BOUNCED,
                 "A unit cannot dislodge a unit of its own nation.",
             )
-        return (Status.OK, None)
+        return (Status.OK, ResolutionCode.SUCCEEDED, None)
 
     def _compute_convoy_path_intact(self, i: int) -> Optional[bool]:
         """Three-valued convoy path: True if a chain through known-alive
@@ -888,7 +895,8 @@ class _Solver:
             for j in cycle:
                 key = (_MOVE_STATUS, j)
                 self._decisions[key] = replace(
-                    self._decisions[key], value=(Status.OK, None)
+                    self._decisions[key],
+                    value=(Status.OK, ResolutionCode.SUCCEEDED, None),
                 )
                 seen_in_resolved_cycle.add(j)
                 self._enqueue_dependents(key)
@@ -1185,7 +1193,7 @@ class _Solver:
             if forced_reason is None:
                 continue
             self._decisions[key] = replace(
-                decision, value=(Status.BOUNCE, forced_reason)
+                decision, value=(Status.BOUNCE, ResolutionCode.BOUNCED, forced_reason)
             )
             self._enqueue_dependents(key)
             changed = True
@@ -1230,8 +1238,8 @@ class _Solver:
             elif kind == _HOLD_STRENGTH:
                 r = replace(r, hold_strength=value)
             elif kind == _MOVE_STATUS:
-                status, reason = value
-                r = replace(r, status=status, failure_reason=reason)
+                status, code, reason = value
+                r = replace(r, status=status, code=code, failure_reason=reason)
             elif kind == _CONVOY_PATH_INTACT:
                 r = replace(r, convoy_path_intact=value)
             resolutions[idx] = r

--- a/service/adjudicator/serializers.py
+++ b/service/adjudicator/serializers.py
@@ -308,6 +308,7 @@ def deserialize_game_state(data: Dict[str, Any], variant: Variant) -> State:
             Resolution(
                 province=r["province"],
                 resolution=r["resolution"],
+                code=r.get("code"),
                 reason=r.get("reason"),
             )
             for r in resolutions_raw
@@ -381,6 +382,7 @@ def serialize_game_state(state: State) -> Dict[str, Any]:
                 {
                     "province": r.province,
                     "resolution": r.resolution,
+                    "code": r.code,
                     "reason": r.reason,
                 }
                 for r in state.resolutions

--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -54,9 +54,11 @@ from .types import (
     ConvoyOrder,
     HoldOrder,
     MoveOrder,
+    MoveTargetIsReachableCheck,
     Order,
     OrderResolution,
     OrderType,
+    ResolutionCode,
     StateView,
     SupportHoldOrder,
     SupportMoveOrder,
@@ -7656,6 +7658,13 @@ def _c2_failure_reason(states: List[State], province: str) -> Optional[str]:
     return None
 
 
+def _c2_code(states: List[State], province: str) -> Optional[str]:
+    for r in states[0].resolutions or []:
+        if r.province == province:
+            return r.code
+    return None
+
+
 def _c2_unit_at(states: List[State], location: str) -> Optional[Unit]:
     for u in states[0].units:
         if u.location == location and not u.dislodged:
@@ -7682,6 +7691,84 @@ def _c2_convoy_matched_at(adj: AdjudicationState, source: str) -> Optional[bool]
         if isinstance(order, ConvoyOrder) and order.source == source:
             return res.convoy_matched
     return None
+
+
+# === Outcome codes ===
+
+
+def test_successful_order_reports_succeeded_code():
+    """An uncontested move carries the success code, not an absent one."""
+    state = _c2_movement_state(
+        units=[Unit(nation=NORTH, type=Unit.ARMY, location="lhs")],
+        orders=[
+            RawOrder(nation=NORTH, source="lhs", order_type="Move", target="mid"),
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _c2_resolution(result, "lhs") == Status.OK
+    assert _c2_code(result, "lhs") == ResolutionCode.SUCCEEDED
+
+
+def test_illegal_order_reports_the_code_declared_by_the_check_that_rejected_it():
+    """The code travels from the failing Check's CODE attribute through
+    to the external Resolution — nothing downstream re-derives it from
+    the status."""
+    state = _c2_movement_state(
+        units=[Unit(nation=NORTH, type=Unit.ARMY, location="lhs")],
+        orders=[
+            RawOrder(nation=NORTH, source="lhs", order_type="Move", target="far"),
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _c2_resolution(result, "lhs") == Status.ILLEGAL
+    assert _c2_code(result, "lhs") == MoveTargetIsReachableCheck.CODE
+
+
+def test_bounced_move_reports_bounced_code():
+    """Two armies contest mid; both bounce and both carry the bounce
+    code, which is distinct from the illegal-order code."""
+    state = _c2_movement_state(
+        units=[
+            Unit(nation=NORTH, type=Unit.ARMY, location="lhs"),
+            Unit(nation=SOUTH, type=Unit.ARMY, location="rhs"),
+        ],
+        orders=[
+            RawOrder(nation=NORTH, source="lhs", order_type="Move", target="mid"),
+            RawOrder(nation=SOUTH, source="rhs", order_type="Move", target="mid"),
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _c2_resolution(result, "lhs") == Status.BOUNCE
+    assert _c2_code(result, "lhs") == ResolutionCode.BOUNCED
+    assert _c2_code(result, "rhs") == ResolutionCode.BOUNCED
+
+
+def test_cut_support_reports_support_broken_code():
+    """A support cut by an attack on the supporter reports the
+    support-broken code rather than the generic bounce code."""
+    state = _c2_movement_state(
+        units=[
+            Unit(nation=NORTH, type=Unit.ARMY, location="lhs"),
+            Unit(nation=NORTH, type=Unit.ARMY, location="mid"),
+            Unit(nation=SOUTH, type=Unit.ARMY, location="rhs"),
+        ],
+        orders=[
+            RawOrder(nation=NORTH, source="lhs", order_type="Hold"),
+            RawOrder(nation=NORTH, source="mid", order_type="Support", aux="lhs"),
+            RawOrder(nation=SOUTH, source="rhs", order_type="Move", target="mid"),
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _c2_resolution(result, "mid") == Status.CUT
+    assert _c2_code(result, "mid") == ResolutionCode.SUPPORT_BROKEN
 
 
 # === Custom chain variant for multi-sea path tests ===

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -43,6 +43,34 @@ class Status:
     CUT: ClassVar[str] = "CUT"
 
 
+class ResolutionCode:
+    """Outcome codes written into OrderResolution.code and propagated
+    verbatim to the external Resolution records, which persist them as
+    OrderResolution.status (see common.constants.OrderResolutionStatus,
+    which takes its values from here).
+
+    Distinct from `Status`: `Status` is the solver's control-flow value
+    and stays deliberately coarse, while these codes are the reporting
+    vocabulary and may name any number of distinct failures per status.
+    Every site that assigns a final status assigns a code alongside it,
+    so nothing downstream has to infer one from the other.
+
+    The values are godip's wire-format strings. godip is gone, but its
+    codes are what every stored OrderResolution row already holds and
+    what the recorded games in `integration/fixtures` assert against."""
+
+    SUCCEEDED: ClassVar[str] = "OK"
+    ILLEGAL_MOVE: ClassVar[str] = "ErrIllegalMove"
+    ILLEGAL_DESTINATION: ClassVar[str] = "ErrIllegalDestination"
+    BOUNCED: ClassVar[str] = "ErrBounce"
+    INVALID_SUPPORT_ORDER: ClassVar[str] = "ErrInvalidSupporteeOrder"
+    ILLEGAL_SUPPORT_DESTINATION: ClassVar[str] = "ErrIllegalSupportDestination"
+    INVALID_DESTINATION: ClassVar[str] = "ErrInvalidDestination"
+    MISSING_SUPPORT_UNIT: ClassVar[str] = "ErrMissingSupportUnit"
+    MISSING_UNIT: ClassVar[str] = "ErrMissingUnit"
+    SUPPORT_BROKEN: ClassVar[str] = "ErrSupportBroken"
+
+
 class OrderType:
     """Wire-format order-type ids accepted in the prototype slice. Any
     raw order whose `order_type` is not one of these raises
@@ -94,8 +122,9 @@ class Action:
 
 class Check:
     """Stateless predicate over (StateView, Order). Subclasses declare
-    the MESSAGE shown to players when the check fails and a classmethod
-    `check` returning True iff the order satisfies the rule.
+    the MESSAGE shown to players when the check fails, the CODE reported
+    for that failure, and a classmethod `check` returning True iff the
+    order satisfies the rule.
 
     Composed into Order subclasses via the LEGALITY_CHECKS class attribute
     and applied by the `ApplyLegalityChecks` reducer. Checks are pure
@@ -107,6 +136,11 @@ class Check:
     """
 
     MESSAGE: ClassVar[str] = ""
+    CODE: ClassVar[str] = ResolutionCode.ILLEGAL_MOVE
+    """Outcome code reported when this check rejects an order. Most
+    rejections are indistinguishable to a player, so the base supplies
+    the generic code and a subclass overrides it only where the
+    reporting vocabulary names its rule specifically."""
 
     @classmethod
     def check(cls, state: "StateView", order: Order) -> bool:
@@ -843,6 +877,12 @@ class OrderResolution:
     are Status.OK / ILLEGAL / BOUNCE / CUT. Populated incrementally by
     legality checks, retreat bounces, build/disband limits, the strength
     resolver, and FinalizeStatuses."""
+
+    code: Optional[str] = None
+    """Per-order outcome code from ResolutionCode — the reported form of
+    `status`, finer-grained than the four control-flow values. Assigned
+    by whichever step assigns `status`, and cleared with it. After
+    FinalizeStatuses it is guaranteed non-None."""
 
     failure_reason: Optional[str] = None
     """Per-order failure message. Populated alongside ILLEGAL / BOUNCE

--- a/service/common/constants.py
+++ b/service/common/constants.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from adjudicator.types import ResolutionCode
+
 
 class GameStatus:
     PENDING = "pending"
@@ -251,16 +253,16 @@ class ProvinceType:
 
 
 class OrderResolutionStatus:
-    SUCCEEDED = "OK"
-    ILLEGAL_MOVE = "ErrIllegalMove"
-    ILLEGAL_DESTINATION = "ErrIllegalDestination"
-    BOUNCED = "ErrBounce"
-    INVALID_SUPPORT_ORDER = "ErrInvalidSupporteeOrder"
-    ILLEGAL_SUPPORT_DESTINATION = "ErrIllegalSupportDestination"
-    INVALID_DESTINATION = "ErrInvalidDestination"
-    MISSING_SUPPORT_UNIT = "ErrMissingSupportUnit"
-    MISSING_UNIT = "ErrMissingUnit"
-    SUPPORT_BROKEN = "ErrSupportBroken"
+    SUCCEEDED = ResolutionCode.SUCCEEDED
+    ILLEGAL_MOVE = ResolutionCode.ILLEGAL_MOVE
+    ILLEGAL_DESTINATION = ResolutionCode.ILLEGAL_DESTINATION
+    BOUNCED = ResolutionCode.BOUNCED
+    INVALID_SUPPORT_ORDER = ResolutionCode.INVALID_SUPPORT_ORDER
+    ILLEGAL_SUPPORT_DESTINATION = ResolutionCode.ILLEGAL_SUPPORT_DESTINATION
+    INVALID_DESTINATION = ResolutionCode.INVALID_DESTINATION
+    MISSING_SUPPORT_UNIT = ResolutionCode.MISSING_SUPPORT_UNIT
+    MISSING_UNIT = ResolutionCode.MISSING_UNIT
+    SUPPORT_BROKEN = ResolutionCode.SUPPORT_BROKEN
 
     STATUS_CHOICES = (
         (SUCCEEDED, "Succeeded"),


### PR DESCRIPTION
## What this PR does

Gives the adjudicator a first-class outcome code so `adjudication.service` can report it directly instead of inferring one from the engine's control-flow status. Pure mechanism — no reported code changes. It exists to make #1134 (specific convoy/support failure codes) a set of one-line declarations rather than a second mapping table keyed on player-facing prose.

### The problem

The engine classifies every order into one of four values — `OK`, `BOUNCE`, `ILLEGAL`, `CUT` — and `_STATUS_TO_GODIP` in `adjudication/service.py` turned those into the stored vocabulary through a four-entry lookup. That lookup is lossy by construction: `OrderResolutionStatus` names ten outcomes, so every rejected order was reported as `ErrIllegalMove` and every failed move as `ErrBounce`, regardless of which rule produced it.

The information was never missing. The engine carries two things about an outcome:

- `Status` — coarse, machine-readable, and load-bearing: the strength solver compares against it in ~50 places (`if self._dec_value((_SUPPORT_CUT, k)) != Status.OK`, `if resolutions[j].status == Status.ILLEGAL: continue`)
- `failure_reason` — precise, but human prose, and dropped entirely at the boundary

The missing third thing is *precise and machine-readable*. Without it there is nowhere to put "this move failed because its convoy broke, not because it lost a fight", so #1134 reconstructs it by matching the prose — which makes rewording a player-facing message silently change an API code.

### The fix

`ResolutionCode` is a closed enum in `adjudicator/types.py` whose members are exactly the reporting vocabulary. It is carried on the internal `OrderResolution` and on the external `Resolution`, and every site that assigns a final status now assigns a code beside it:

- `Check` declares `CODE` as a class attribute next to the `MESSAGE` it already declares, and `ApplyLegalityChecksReducer` reads it — the "fixed configuration → declarative class attribute" pattern from `CLAUDE.md`. The base supplies the generic code; a subclass overrides only where the vocabulary names its rule specifically (none yet — that's the follow-up).
- The 11 non-check failure sites in `engine.py` and `resolution.py` name their code explicitly. The solver's `move_status` decision value becomes `(status, code, reason)`.
- `_build_resolutions` copies `resolution.code`. `_STATUS_TO_GODIP` is deleted.

`Status` is untouched, which is why the test churn is small: it stays the solver's control-flow value and stays deliberately coarse. Codes are the reporting vocabulary layered over it, free to name any number of distinct failures per status.

`common.constants.OrderResolutionStatus` now takes its values from `ResolutionCode` and contributes only the display labels, so the persisted vocabulary and the engine's cannot drift apart. Sourcing them there rather than importing `ResolutionCode` into each app keeps the engine dependency at a single import site.

The codes stay godip's strings. Not out of deference to godip — it's gone — but because they are what every stored `OrderResolution` row already holds and what the recorded games in `integration/fixtures` assert against. Renaming the values is a data migration that buys no behaviour, and is independent of this.

### What this deliberately does not do

- **No reported code changes.** Every code emitted here equals what `_STATUS_TO_GODIP` produced. The three specific codes (`ErrMissingConvoyPath`, `ErrConvoyDislodged`, `ErrInvalidSupporteeOrder`) are the follow-up, where they become overrides on three existing declarations plus a migration.
- **`by` is unchanged.** `_find_by_province` still re-derives the blocking province from raw orders, returning the first competing move at the target rather than the one that actually blocked. Same class of problem — the solver knows the exact index and discards it — but it's a separate change.

## Testing

- Four new tests in `adjudicator/tests.py` covering the code reaching the external `Resolution` for each outcome kind. The illegal-order one asserts against `MoveTargetIsReachableCheck.CODE`, so it fails if the declared attribute stops being what travels to the boundary.
- Full backend suite: **2122 passed, 8 skipped**.
- Full-game replay suite (`integration/test_replay.py`, excluded from the default run): 4 failed / 1 passed, with a **byte-identical failure set to `main`** — captured on both sides and diffed. That is the behaviour-preservation evidence: those fixtures are production ground truth covering 2287 `OK`, 440 `ErrBounce`, 113 `ErrSupportBroken` and 15 `ErrInvalidSupporteeOrder` outcomes across five recorded games.
- `makemigrations --check` produces no `order` migration, confirming the field choices are unchanged. (It reports a pre-existing pending `variant` migration, present on `main` too.)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no UI or API-shape changes; the serialised value is `get_status_display`, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1QT3vDSRC8fNgruZsnKkv)_