### PR TITLE
Allow low commitment players to create private games

### DIFF
--- a/packages/web/src/screens/Home/CreateGame.test.tsx
+++ b/packages/web/src/screens/Home/CreateGame.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
 
 class ResizeObserverMock {
   observe() {}
@@ -865,6 +866,109 @@ describe("CreateGame — variant category toggle", () => {
     await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
     expect(createGameMutateAsync.mock.calls[0][0].data.variantId).toBe(
       "homebrew"
+    );
+  });
+});
+
+describe("CreateGame — low commitment creator", () => {
+  let createGameMutateAsync: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createGameMutateAsync = vi.fn().mockResolvedValue({ id: "created-game" });
+
+    mockedUseUserRetrieveSuspense.mockReturnValue({
+      data: { ...mockUserProfile, commitment: "low" },
+    } as unknown as ReturnType<typeof useUserRetrieveSuspense>);
+
+    mockedUseVariantsListSuspense.mockReturnValue({
+      data: variantsFixture,
+    } as unknown as ReturnType<typeof useVariantsListSuspense>);
+
+    mockedUseGameCreate.mockReturnValue({
+      mutateAsync: createGameMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useGameCreate>);
+
+    mockedUseSandboxGameCreate.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useSandboxGameCreate>);
+
+    stubFindSimilar(null);
+  });
+
+  const selectMode = async (
+    user: ReturnType<typeof userEvent.setup>,
+    mode: RegExp
+  ) => {
+    await user.click(screen.getByRole("combobox", { name: /mode/i }));
+    await user.click(screen.getByRole("option", { name: mode }));
+  };
+
+  it("checks and disables the private checkbox with an explanation", () => {
+    renderCreateGame();
+
+    const privateCheckbox = screen.getByRole("checkbox", { name: /private/i });
+    expect(privateCheckbox).toBeChecked();
+    expect(privateCheckbox).toBeDisabled();
+    expect(
+      screen.getByText(/Your commitment rating is Low, so games you create/i)
+    ).toBeInTheDocument();
+  });
+
+  it("leaves the game master checkbox available", () => {
+    renderCreateGame();
+
+    expect(
+      screen.getByRole("checkbox", { name: /game master/i })
+    ).toBeEnabled();
+  });
+
+  it("sends private true in the create payload", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() => expect(createGameMutateAsync).toHaveBeenCalled());
+    expect(createGameMutateAsync.mock.calls[0][0].data.private).toBe(true);
+  });
+
+  it("restores the forced private state after leaving sandbox mode", async () => {
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await selectMode(user, /sandbox/i);
+    expect(screen.getByRole("checkbox", { name: /private/i })).not.toBeChecked();
+
+    await selectMode(user, /standard/i);
+    expect(screen.getByRole("checkbox", { name: /private/i })).toBeChecked();
+  });
+
+  it("surfaces the server message when creation is rejected", async () => {
+    const toastErrorSpy = vi.spyOn(toast, "error");
+    createGameMutateAsync.mockRejectedValue({
+      response: {
+        data: {
+          private: ["Your commitment rating only allows creating private games."],
+        },
+      },
+    });
+
+    const user = userEvent.setup();
+    renderCreateGame();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: /create game/i }));
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith(
+        "Your commitment rating only allows creating private games."
+      )
     );
   });
 });

--- a/packages/web/src/screens/Home/CreateGame.tsx
+++ b/packages/web/src/screens/Home/CreateGame.tsx
@@ -16,6 +16,7 @@ import {
   Users,
 } from "lucide-react";
 import { toast } from "sonner";
+import { AxiosError } from "axios";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -118,6 +119,15 @@ const modeToBackendFields = (mode: "standard" | "gunboat") =>
     anonymous: mode === "gunboat",
     pressType: mode === "gunboat" ? "no_press" : "full_press",
   }) as const;
+
+const serverErrorMessage = (error: unknown): string | undefined => {
+  const data = (error as AxiosError<Record<string, unknown>>).response?.data;
+  if (!data || typeof data !== "object") return undefined;
+  const first = Object.values(data)[0];
+  if (typeof first === "string") return first;
+  if (Array.isArray(first) && typeof first[0] === "string") return first[0];
+  return undefined;
+};
 
 interface MetadataRow {
   label: string;
@@ -417,14 +427,20 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
   const initialCategory: VariantCategory =
     defaultVariant && !defaultVariant.official ? "community" : "official";
 
+  const isLowCommitment = creatorCommitment === "low";
+  const defaultMode = initialMode ?? "standard";
+
   const form = useForm<GameFormValues>({
     resolver: zodResolver(gameSchema),
     defaultValues: {
       name: randomGameName(),
       variantId: defaultVariantId,
-      mode: initialMode ?? "standard",
+      mode: defaultMode,
       nationAssignment: "random" as NationAssignmentEnum,
-      private: initialPrivate ?? false,
+      private:
+        isLowCommitment && defaultMode !== "sandbox"
+          ? true
+          : (initialPrivate ?? false),
       gameMaster: false,
       deadlineMode: "fixed_time",
       movementPhaseDuration: "24 hours",
@@ -521,6 +537,8 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
                       if (value === "sandbox") {
                         form.setValue("private", false);
                         form.setValue("gameMaster", false);
+                      } else if (isLowCommitment) {
+                        form.setValue("private", true);
                       }
                     }}
                     value={field.value}
@@ -580,15 +598,19 @@ const CreateGameForm: React.FC<CreateGameFormProps> = ({
                         }
                       }}
                       disabled={
-                        isSubmitting || isInitialVariantDraft || isSandbox
+                        isSubmitting ||
+                        isInitialVariantDraft ||
+                        isSandbox ||
+                        isLowCommitment
                       }
                     />
                   </FormControl>
                   <div className="space-y-1 leading-none">
                     <FormLabel>Private</FormLabel>
                     <FormDescription>
-                      Make this game private (only accessible via direct link,
-                      not shown in public listings)
+                      {isLowCommitment && !isSandbox
+                        ? "Your commitment rating is Low, so games you create must be private — only accessible via direct link, not shown in public listings."
+                        : "Make this game private (only accessible via direct link, not shown in public listings)"}
                     </FormDescription>
                   </div>
                 </FormItem>
@@ -1055,8 +1077,8 @@ const CreateGame: React.FC = () => {
       toast.success("Game created successfully");
       checkNotificationPermission();
       navigate(`/game-info/${game.id}`);
-    } catch {
-      toast.error("Failed to create game");
+    } catch (error) {
+      toast.error(serverErrorMessage(error) ?? "Failed to create game");
     }
   };
 

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -504,20 +504,21 @@ class GameCreateSerializer(serializers.Serializer):
                 {"game_master": "A Game Master is only available in private games."}
             )
 
-        if not attrs.get("game_master"):
-            request = self.context["request"]
-            commitment = request.user.profile.commitment
-            if commitment == Commitment.LOW:
-                raise serializers.ValidationError(
-                    {"commitment_requirement": "Your commitment rating does not allow creating games."}
-                )
-            if (
-                attrs["commitment_requirement"] == CommitmentRequirement.COMMITTED
-                and commitment != Commitment.HIGH
-            ):
-                raise serializers.ValidationError(
-                    {"commitment_requirement": "Only players with high commitment can require committed players."}
-                )
+        commitment = self.context["request"].user.profile.commitment
+
+        if not attrs.get("private") and commitment == Commitment.LOW:
+            raise serializers.ValidationError(
+                {"private": "Your commitment rating only allows creating private games."}
+            )
+
+        if (
+            not attrs.get("game_master")
+            and attrs["commitment_requirement"] == CommitmentRequirement.COMMITTED
+            and commitment != Commitment.HIGH
+        ):
+            raise serializers.ValidationError(
+                {"commitment_requirement": "Only players with high commitment can require committed players."}
+            )
 
         deadline_mode = attrs["deadline_mode"]
 

--- a/service/game/tests/test_commitment_requirement.py
+++ b/service/game/tests/test_commitment_requirement.py
@@ -64,7 +64,7 @@ class TestGameCreateCommitmentRequirement:
         assert "commitment_requirement" in response.data
 
     @pytest.mark.django_db
-    def test_low_creator_cannot_create(
+    def test_low_creator_cannot_create_public_game(
         self, authenticated_client, primary_user, classical_variant, set_commitment
     ):
         set_commitment(primary_user, Commitment.LOW)
@@ -73,7 +73,19 @@ class TestGameCreateCommitmentRequirement:
             url, create_payload(classical_variant.id), format="json"
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "commitment_requirement" in response.data
+        assert "private" in response.data
+
+    @pytest.mark.django_db
+    def test_low_creator_can_create_private_game(
+        self, authenticated_client, primary_user, classical_variant, set_commitment
+    ):
+        set_commitment(primary_user, Commitment.LOW)
+        url = reverse(create_viewname)
+        payload = create_payload(classical_variant.id, private=True)
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        game = Game.objects.get(id=response.data["id"])
+        assert game.members.filter(user=primary_user).exists()
 
     @pytest.mark.django_db
     def test_low_game_master_can_create_private_game(
@@ -86,6 +98,21 @@ class TestGameCreateCommitmentRequirement:
         )
         response = authenticated_client.post(url, payload, format="json")
         assert response.status_code == status.HTTP_201_CREATED
+
+    @pytest.mark.django_db
+    def test_low_creator_cannot_require_committed_in_private_game(
+        self, authenticated_client, primary_user, classical_variant, set_commitment
+    ):
+        set_commitment(primary_user, Commitment.LOW)
+        url = reverse(create_viewname)
+        payload = create_payload(
+            classical_variant.id,
+            private=True,
+            commitment_requirement=CommitmentRequirement.COMMITTED,
+        )
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "commitment_requirement" in response.data
 
     @pytest.mark.django_db
     def test_invalid_value_rejected(self, authenticated_client, classical_variant):


### PR DESCRIPTION
## What this PR does

Fixes #1177. A player with a Low commitment rating could walk through the entire create game form and only discover at submit that they were blocked — the `catch` in `CreateGame.tsx` discarded the server's reason and showed a generic `Failed to create game` toast.

Rather than gating the form on the old rule, this relaxes the rule. `GameCreateSerializer.validate` blocked creation when `not game_master`, but `game_master` already requires `private` (existing validation), so the constraint was really "no public games" expressed through a narrower field. It now blocks public games directly, which means a Low player can create a private game whether or not they run it as Game Master. Every configuration allowed before is still allowed. The error also moves from the `commitment_requirement` key to `private` — the field that actually resolves it.

With the rule relaxed, the screen doesn't need a gate at all: for a Low player on standard or gunboat, `private` is forced on and disabled with copy explaining why, so no reachable configuration gets rejected. Sandbox still clears `private`, and Game Master stays freely selectable. Copy is describe-only — it states the constraint without implying private or sandbox play repairs the rating, because `get_rated_outcomes` excludes both.

The submit handler now surfaces the server's validation message as a backstop, for the case where a rating drops to Low between page load and submit.

### Not in scope

`MeetsCommitmentRequirement` still rejects a Low player from joining *any* game, private included, so a Low player can create a private game their equally-Low friend can't join. Filed as #1194 — it changes who can join games rather than who can create them.

## Screenshots

Screenshots were captured under `npm run dev:mocks` at 1280x800 but could not be uploaded from this session — `gh`'s token is rejected here and the REST API has no attachment-upload endpoint. The image files have been handed to the author to attach; committing them is forbidden by CLAUDE.md.

What they show, on Create Game / General with a Low commitment creator: the **Private** checkbox rendered checked and disabled, its description replaced with "Your commitment rating is Low, so games you create must be private — only accessible via direct link, not shown in public listings.", and **Game Master** still enabled. For any other rating the step is pixel-identical to `main`.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — captured, but see above; needs the author to attach

Backend (`game/tests/test_commitment_requirement.py`): `test_low_creator_cannot_create_public_game` (now asserting the `private` key), plus new `test_low_creator_can_create_private_game` (asserting the creator is seated) and `test_low_creator_cannot_require_committed_in_private_game`. Frontend: a new `CreateGame — low commitment creator` describe covering the forced/disabled checkbox, the copy, `private: true` in the payload, the sandbox round-trip, and the surfaced server message. 478 backend tests and 33 CreateGame tests pass; `tsc -b --noEmit` and ESLint are clean.

> **Note:** the WIP bot flags this as the 6th open PR against a target of 5.