### PR TITLE
Stop expecting orders from a deleted account on the live phase

### DIFF
--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -227,6 +227,80 @@ class TestUserAccountDelete:
         assert not Game.objects.filter(id=game_id).exists()
 
     @pytest.mark.django_db
+    def test_current_phase_state_no_longer_has_possible_orders(
+        self, user_factory, authenticated_client_factory, base_active_game_for_primary_user, base_active_phase
+    ):
+        user = user_factory()
+        client = authenticated_client_factory(user)
+        game = base_active_game_for_primary_user
+        phase = base_active_phase(game)
+        member = game.members.create(user=user)
+        phase_state = phase.phase_states.create(member=member, has_possible_orders=True)
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        phase_state.refresh_from_db()
+        assert phase_state.has_possible_orders is False
+
+    @pytest.mark.django_db
+    def test_completed_phase_state_is_untouched(
+        self, user_factory, authenticated_client_factory, base_active_game_for_primary_user, base_active_phase
+    ):
+        user = user_factory()
+        client = authenticated_client_factory(user)
+        game = base_active_game_for_primary_user
+        phase = base_active_phase(game)
+        phase.status = PhaseStatus.COMPLETED
+        phase.save()
+        member = game.members.create(user=user)
+        phase_state = phase.phase_states.create(member=member, has_possible_orders=True)
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        phase_state.refresh_from_db()
+        assert phase_state.has_possible_orders is True
+
+    @pytest.mark.django_db
+    def test_deleted_member_no_longer_blocks_early_resolution(
+        self, user_factory, authenticated_client_factory, active_game_with_confirmed_phase_state, classical_france_nation
+    ):
+        game = active_game_with_confirmed_phase_state
+        phase = game.current_phase
+        user = user_factory()
+        client = authenticated_client_factory(user)
+        member = game.members.create(user=user, nation=classical_france_nation)
+        phase.phase_states.create(member=member, has_possible_orders=True)
+
+        assert not Phase.objects.filter_due_phases().filter(id=phase.id).exists()
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        assert Phase.objects.filter_due_phases().filter(id=phase.id).exists()
+
+    @pytest.mark.django_db
+    def test_deleted_member_does_not_consume_nmr_extensions(
+        self, user_factory, authenticated_client_factory, base_active_game_for_primary_user, base_active_phase
+    ):
+        user = user_factory()
+        client = authenticated_client_factory(user)
+        game = base_active_game_for_primary_user
+        phase = base_active_phase(game)
+        phase.scheduled_resolution = timezone.now()
+        phase.save()
+        member = game.members.create(user=user, nmr_extensions_remaining=1)
+        phase.phase_states.create(member=member, has_possible_orders=True)
+
+        url = reverse("user-delete")
+        client.delete(url)
+
+        assert Phase.objects._check_and_apply_nmr_extensions(phase) is None
+        member.refresh_from_db()
+        assert member.nmr_extensions_remaining == 1
+
+    @pytest.mark.django_db
     def test_pending_game_with_other_members_is_preserved(
         self, user_factory, authenticated_client_factory, base_pending_game_for_primary_user, secondary_user
     ):

--- a/service/user_profile/views.py
+++ b/service/user_profile/views.py
@@ -4,7 +4,8 @@ from django.shortcuts import get_object_or_404
 
 from game.models import Game
 from member.models import Member
-from common.constants import GameStatus
+from phase.models import PhaseState
+from common.constants import GameStatus, PhaseStatus
 from .models import UserProfile
 from .serializers import UserProfileSerializer, PublicUserProfileSerializer
 
@@ -49,9 +50,13 @@ class UserAccountDeleteView(generics.DestroyAPIView):
                 )
             )
             user_members.filter(game__status=GameStatus.PENDING).delete()
-            user_members.filter(
+            ongoing_members = user_members.filter(
                 game__status__in=[GameStatus.ACTIVE, GameStatus.COMPLETED]
-            ).update(kicked=True)
+            )
+            ongoing_members.update(kicked=True)
+            PhaseState.objects.filter(
+                member__in=ongoing_members, phase__status=PhaseStatus.ACTIVE
+            ).update(has_possible_orders=False)
             for game in Game.objects.filter(id__in=pending_game_ids):
                 game.delete_if_empty_pending()
             instance.delete()


### PR DESCRIPTION
## What this PR does

Account deletion marked active-game members `kicked` but never touched their `PhaseState` on the phase already under way, so the seat kept `has_possible_orders=True`: it blocked early resolution in `filter_due_phases` and consumed the game's NMR extensions in `_check_and_apply_nmr_extensions`, pushing the deadline back for everyone else. `UserAccountDeleteView.perform_destroy` now clears the flag on the leaver's phase states for phases still `active`, as `replace_member_with_bot` already does when handing a seat to a bot. Fixes #1187.

The update is scoped to `phase__status=active`, which both leaves resolved phases' records intact (past-phase `has_possible_orders` feeds the commitment statistics) and skips a phase mid-resolution. Phases created after the deletion were already correct via `create_from_adjudication_data`.

## Self-review

`/review-pr` couldn't run in this session (`gh pr diff` needs a GraphQL query that isn't served here), so I ran `/code-review` over the same diff instead. It raised one finding against this change: deletion clears the flag but emits no `phase_state_confirmed` and defers no `resolve_phase`, so bots never get `finalize` tasks and the phase "idles to its deadline with every bot NMR-ing".

Not acting on it here, for two reasons:

- The NMR half is wrong. `agent.plan` already calls `api.submit_orders` (`service/agent/tasks.py`), so a bot that has only planned still has real orders on file; the deadline resolves them normally. And the missing `resolve_phase.defer` is covered — `phase.sweep_due_phases` is `@app.periodic(cron="* * * * *")`, so a newly-due phase is picked up within the minute; the deferral on confirmation is a latency shortcut, not the only trigger.
- What's left is real but out of scope: if the leaver was the *last* unconfirmed human in a game with bots, nothing re-evaluates `Phase.has_unconfirmed_human`, so the bots don't finalize and the phase waits for its deadline instead of resolving early. That gap pre-dates this PR — before the fix the leaver's seat kept `has_unconfirmed_human` permanently `True`, so the bots were blocked outright. This change is a precondition for fixing it, and the fix itself (what event the deletion path should raise for the agent specs) belongs in its own issue.

The review's other six findings are all in commits already on `main`, not in this diff.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — see Self-review above for the substitution and the response
- [x] Tests cover the change — four new tests in `TestUserAccountDelete`; the three behavioural ones (flag cleared, phase becomes due for early resolution, NMR extension not consumed) fail without the fix, and `test_completed_phase_state_is_untouched` guards the active-phase scoping. Full backend suite green (2120 passed).
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — backend only, no visual change