### PR TITLE
Hold the phase lock while a draw proposal is accepted

### DIFF
--- a/service/draw_proposal/models.py
+++ b/service/draw_proposal/models.py
@@ -3,6 +3,7 @@ from common.models import BaseModel
 from common.constants import GameStatus
 from draw_proposal.constants import DrawProposalStatus
 from emit import emit
+from phase.models import Phase
 from victory.models import Victory
 
 
@@ -129,6 +130,9 @@ class DrawProposal(BaseModel):
             return None
 
         with transaction.atomic():
+            if Phase.objects.lock_if_active(self.phase_id) is None:
+                return None
+
             victory = Victory.objects.create(
                 game=self.game,
                 winning_phase=self.phase,

--- a/service/draw_proposal/tests.py
+++ b/service/draw_proposal/tests.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from common.constants import GameStatus, PhaseStatus
 from draw_proposal.models import DrawProposal, DrawVote
 from draw_proposal.constants import DrawProposalStatus
+from phase.models import Phase
 from victory.models import Victory
 
 
@@ -313,6 +314,30 @@ class TestDrawProposalProcessAcceptance:
         victory = proposal.process_acceptance()
         assert victory is None
 
+    def test_returns_none_when_phase_is_being_resolved(
+        self, game_factory, phase_factory, member_factory, draw_proposal_factory
+    ):
+        game = game_factory(variant__solo_victory_sc_count=18)
+        phase = phase_factory(game=game)
+        m1 = member_factory(game=game)
+        m2 = member_factory(game=game)
+
+        proposal = draw_proposal_factory(
+            game=game, created_by=m1, phase=phase,
+            included_member_ids=[m1.id, m2.id],
+        )
+        for vote in proposal.votes.all():
+            vote.accepted = True
+            vote.save()
+
+        Phase.objects.filter(pk=phase.pk).update(status=PhaseStatus.PROCESSING)
+
+        assert proposal.process_acceptance() is None
+        assert Victory.objects.count() == 0
+
+        game.refresh_from_db()
+        assert game.status == GameStatus.ACTIVE
+
 
 class TestDrawProposalCreateView:
     def _auth(self, api_client, user):
@@ -416,6 +441,22 @@ class TestDrawProposalCreateView:
         cd_vote = proposal.votes.get(member=cd_member)
         assert cd_vote.included is False
         assert cd_vote.accepted is True
+
+    def test_create_proposal_fails_while_phase_is_being_resolved(
+        self, api_client, game_factory, phase_factory, member_factory, primary_user,
+    ):
+        game = game_factory(variant__solo_victory_sc_count=18)
+        phase_factory(game=game, status=PhaseStatus.PROCESSING)
+        member_factory(game=game, user=primary_user)
+        member_factory(game=game)
+
+        self._auth(api_client, primary_user)
+        response = api_client.post(
+            f"/games/{game.id}/draw-proposals/create/", {}, format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert DrawProposal.objects.count() == 0
 
 
 class TestDrawProposalVoteView:
@@ -523,6 +564,29 @@ class TestDrawProposalVoteView:
             {"accepted": False}, format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_vote_fails_while_phase_is_being_resolved(
+        self, api_client, game_factory, phase_factory, member_factory,
+        draw_proposal_factory, primary_user,
+    ):
+        game = game_factory(variant__solo_victory_sc_count=18)
+        phase = phase_factory(game=game, status=PhaseStatus.PROCESSING)
+        proposer = member_factory(game=game)
+        voter = member_factory(game=game, user=primary_user)
+
+        proposal = draw_proposal_factory(
+            game=game, created_by=proposer, phase=phase,
+            included_member_ids=[proposer.id, voter.id],
+        )
+        self._auth(api_client, primary_user)
+
+        response = api_client.patch(
+            f"/games/{game.id}/draw-proposals/{proposal.id}/vote/",
+            {"accepted": True}, format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert Victory.objects.count() == 0
 
 
 class TestDrawProposalCancelView:

--- a/service/draw_proposal/views.py
+++ b/service/draw_proposal/views.py
@@ -5,6 +5,7 @@ from common.permissions import (
     IsActiveGame,
     IsActiveOrCompletedGame,
     IsActiveGameMember,
+    IsCurrentPhaseActive,
     IsNotSandboxGame,
 )
 from common.views import SelectedGameMixin, CurrentGameMemberMixin
@@ -31,6 +32,7 @@ class DrawProposalCreateView(SelectedGameMixin, CurrentGameMemberMixin, generics
         IsActiveGame,
         IsActiveGameMember,
         IsNotSandboxGame,
+        IsCurrentPhaseActive,
     ]
     serializer_class = DrawProposalSerializer
 
@@ -41,6 +43,7 @@ class DrawProposalVoteView(SelectedGameMixin, CurrentGameMemberMixin, generics.U
         IsActiveGame,
         IsActiveGameMember,
         IsNotSandboxGame,
+        IsCurrentPhaseActive,
     ]
     serializer_class = DrawVoteUpdateSerializer
 


### PR DESCRIPTION
## What this PR does

Accepting a draw ends the game from the draw proposal's own transaction — it writes a `Victory`, completes the game and completes the proposal's phase — and nothing coordinated that with phase resolution, which claims the same phase and adjudicates it. Both can run at once.

Production evidence that they did: in `gunboat-big-map` on 2026-06-25, resolution created the Fall 1908 Retreat phase (ordinal 37) at `11:14:01.086` while the draw wrote its 3-member `Victory` against the Fall 1908 Movement phase (ordinal 36) at `11:14:01.211`. The game ended one phase beyond the phase it was won in — the only game in the database where `max(phase.ordinal) > victory.winning_phase.ordinal`.

`DrawProposal.process_acceptance` now takes the phase row lock that order writes already use (`Phase.objects.lock_if_active`), so whichever transaction arrives first wins:

- draw first — the phase is completed under the lock, and resolution's compare-and-swap from `active` finds nothing to claim;
- resolution first — the proposal is left unprocessed and renders as `expired` once the next phase starts, rather than ending an already-adjudicated game a second time.

Proposing and voting are additionally gated on `IsCurrentPhaseActive`, so the ordinary case — a vote cast after the deadline has fired — is refused at the door instead of being recorded against a phase that is mid-flight. This mirrors how `OrderCreateView`/`OrderDestroyView` are gated.

This builds on the `processing` phase status from #1162; without that status there was no state for the lock to exclude against.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — three new tests in `draw_proposal/tests.py`, each verified to fail without the change: the model returns `None` and writes no `Victory` when the phase is `processing`, and both the create and vote endpoints return 403.
- [x] Screenshots embedded in the PR description for any visual changes — none, backend only

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWNayqRCUDWd7w3aC8Ej5p)_