### PR TITLE
Let low commitment players join private games

### DIFF
--- a/service/common/permissions.py
+++ b/service/common/permissions.py
@@ -130,7 +130,7 @@ class MeetsCommitmentRequirement(BasePermission):
         if not request.user.is_authenticated:
             return False
         return commitment_allows_requirement(
-            request.user.profile.commitment, game.commitment_requirement
+            request.user.profile.commitment, game.commitment_requirement, game.private
         )
 
 

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -583,7 +583,7 @@ class Game(BaseModel):
         if not user.is_authenticated:
             return None
         commitment = user.profile.commitment
-        if commitment == Commitment.LOW:
+        if commitment == Commitment.LOW and not self.private:
             return CommitmentEligibility.LOW_LOCKED
         if (
             self.commitment_requirement == CommitmentRequirement.COMMITTED

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -7,7 +7,6 @@ from django.apps import apps
 from drf_spectacular.utils import extend_schema_field
 from opentelemetry import trace
 from common.constants import Commitment, CommitmentEligibility, CommitmentRequirement, DeadlineMode, MinReliability, NationAssignment, MovementPhaseDuration, PhaseFrequency, PhaseStatus, PressType, VariantStatus
-from user_profile.commitment import commitment_allows_requirement
 from member.serializers import MemberSerializer
 from unit.models import Unit
 from supply_center.models import SupplyCenter

--- a/service/game/tests/test_commitment_requirement.py
+++ b/service/game/tests/test_commitment_requirement.py
@@ -150,6 +150,38 @@ class TestCommitmentRequirementSerializerExposure:
         listed = next(g for g in response.data["results"] if g["id"] == game.id)
         assert listed["commitment_eligibility"] == expected
 
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "commitment_requirement,expected",
+        [
+            (CommitmentRequirement.OPEN, "eligible"),
+            (CommitmentRequirement.COMMITTED, "committed_locked"),
+        ],
+    )
+    def test_private_game_is_not_low_locked(
+        self,
+        authenticated_client,
+        primary_user,
+        classical_variant,
+        game_factory,
+        base_pending_phase,
+        set_commitment,
+        commitment_requirement,
+        expected,
+    ):
+        set_commitment(primary_user, Commitment.LOW)
+        game = game_factory(
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+            private=True,
+            commitment_requirement=commitment_requirement,
+        )
+        base_pending_phase(game)
+        url = reverse(retrieve_viewname, args=[game.id])
+        response = authenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["commitment_eligibility"] == expected
+
 
 class TestEligibleOnlyFilter:
 

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -827,16 +827,18 @@ class TestReplaceableSerialization:
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "commitment,commitment_requirement,allowed",
+    "commitment,commitment_requirement,private,allowed",
     [
-        (Commitment.HIGH, CommitmentRequirement.OPEN, True),
-        (Commitment.HIGH, CommitmentRequirement.COMMITTED, True),
-        (Commitment.MEDIUM, CommitmentRequirement.OPEN, True),
-        (Commitment.MEDIUM, CommitmentRequirement.COMMITTED, False),
-        (Commitment.UNDEFINED, CommitmentRequirement.OPEN, True),
-        (Commitment.UNDEFINED, CommitmentRequirement.COMMITTED, False),
-        (Commitment.LOW, CommitmentRequirement.OPEN, False),
-        (Commitment.LOW, CommitmentRequirement.COMMITTED, False),
+        (Commitment.HIGH, CommitmentRequirement.OPEN, False, True),
+        (Commitment.HIGH, CommitmentRequirement.COMMITTED, False, True),
+        (Commitment.MEDIUM, CommitmentRequirement.OPEN, False, True),
+        (Commitment.MEDIUM, CommitmentRequirement.COMMITTED, False, False),
+        (Commitment.UNDEFINED, CommitmentRequirement.OPEN, False, True),
+        (Commitment.UNDEFINED, CommitmentRequirement.COMMITTED, False, False),
+        (Commitment.LOW, CommitmentRequirement.OPEN, False, False),
+        (Commitment.LOW, CommitmentRequirement.COMMITTED, False, False),
+        (Commitment.LOW, CommitmentRequirement.OPEN, True, True),
+        (Commitment.LOW, CommitmentRequirement.COMMITTED, True, False),
     ],
 )
 def test_join_game_commitment_requirement(
@@ -846,11 +848,13 @@ def test_join_game_commitment_requirement(
     set_commitment,
     commitment,
     commitment_requirement,
+    private,
     allowed,
 ):
     game = pending_game_created_by_secondary_user
     game.commitment_requirement = commitment_requirement
-    game.save(update_fields=["commitment_requirement"])
+    game.private = private
+    game.save(update_fields=["commitment_requirement", "private"])
     set_commitment(primary_user, commitment)
     url = reverse(join_viewname, args=[game.id])
 

--- a/service/user_profile/commitment.py
+++ b/service/user_profile/commitment.py
@@ -78,8 +78,8 @@ def recompute_commitment(user):
     return profile.commitment
 
 
-def commitment_allows_requirement(commitment, commitment_requirement):
-    if commitment == Commitment.LOW:
+def commitment_allows_requirement(commitment, commitment_requirement, private):
+    if commitment == Commitment.LOW and not private:
         return False
     if commitment_requirement == CommitmentRequirement.COMMITTED:
         return commitment == Commitment.HIGH

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -717,20 +717,28 @@ class TestScoreCommitment:
 class TestCommitmentAllowsRequirement:
 
     @pytest.mark.parametrize(
-        "commitment,commitment_requirement,expected",
+        "commitment,commitment_requirement,private,expected",
         [
-            (Commitment.HIGH, CommitmentRequirement.OPEN, True),
-            (Commitment.HIGH, CommitmentRequirement.COMMITTED, True),
-            (Commitment.MEDIUM, CommitmentRequirement.OPEN, True),
-            (Commitment.MEDIUM, CommitmentRequirement.COMMITTED, False),
-            (Commitment.UNDEFINED, CommitmentRequirement.OPEN, True),
-            (Commitment.UNDEFINED, CommitmentRequirement.COMMITTED, False),
-            (Commitment.LOW, CommitmentRequirement.OPEN, False),
-            (Commitment.LOW, CommitmentRequirement.COMMITTED, False),
+            (Commitment.HIGH, CommitmentRequirement.OPEN, False, True),
+            (Commitment.HIGH, CommitmentRequirement.COMMITTED, False, True),
+            (Commitment.MEDIUM, CommitmentRequirement.OPEN, False, True),
+            (Commitment.MEDIUM, CommitmentRequirement.COMMITTED, False, False),
+            (Commitment.UNDEFINED, CommitmentRequirement.OPEN, False, True),
+            (Commitment.UNDEFINED, CommitmentRequirement.COMMITTED, False, False),
+            (Commitment.LOW, CommitmentRequirement.OPEN, False, False),
+            (Commitment.LOW, CommitmentRequirement.COMMITTED, False, False),
+            (Commitment.LOW, CommitmentRequirement.OPEN, True, True),
+            (Commitment.LOW, CommitmentRequirement.COMMITTED, True, False),
+            (Commitment.MEDIUM, CommitmentRequirement.COMMITTED, True, False),
         ],
     )
-    def test_commitment_allows_requirement(self, commitment, commitment_requirement, expected):
-        assert commitment_allows_requirement(commitment, commitment_requirement) is expected
+    def test_commitment_allows_requirement(
+        self, commitment, commitment_requirement, private, expected
+    ):
+        assert (
+            commitment_allows_requirement(commitment, commitment_requirement, private)
+            is expected
+        )
 
 
 class TestRecomputeCommitment:


### PR DESCRIPTION
## What this PR does

Fixes #1194. `commitment_allows_requirement` (`service/user_profile/commitment.py`) and `Game.commitment_eligibility` (`service/game/models.py`) both returned a blanket rejection / `LOW_LOCKED` for a Low commitment player against every game, regardless of whether it was private. Both now apply the Low lock to public games only.

Two things this unblocks in `main` today: a Low player can create a private game **as Game Master** (`test_low_game_master_can_create_private_game`), and an equally-Low friend could not join it; and a Low player could not rejoin their own private game after leaving.

What is deliberately unchanged:

- **The COMMITTED requirement still applies in private games.** `Commitment.LOW` against `CommitmentRequirement.COMMITTED` remains rejected — the creator's explicit choice is not relaxed, only the blanket Low lock is.
- **`filter_eligible_only`** (`service/game/filters.py`) still returns `none()` for a Low player. It is only meaningful alongside `can_join`, which already filters `private=False`, so private games never reach that list.
- **Rating cannot be farmed through private play.** `get_rated_outcomes` filters `phase__game__private=False`, so phases in private games are excluded from the commitment score.

`commitment_allows_requirement` takes `private` as a required third argument rather than defaulting it, so a future call site has to state which rule it wants. The one production call site (`MeetsCommitmentRequirement`) passes `game.private`.

### One drive-by

`game/serializers.py` imported `commitment_allows_requirement` and never used it. The import is dead against the signature this PR changes, so it is removed — one line, no behaviour.

### Note on issue context

Issue #1194's Context says #1177 "let a Low player create private games". That was PR #1193, which was **closed unmerged** — in `main` a Low player can still only create a private game as Game Master, not as a player. The join relaxation this PR makes is correct and useful either way (Game-Master private games, and rejoining), and it means the join rule will already mirror the create rule whenever #1177 lands.

## Screenshots

No frontend files changed. `GameCard.tsx` renders its lock icon and `low_locked` microcopy purely from `commitmentEligibility`, so a private game a Low player is now eligible for renders as the existing eligible card — the same Join button any eligible game already shows. No new visual state is introduced; only which games land in an existing one.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in (bar the one dead import noted above)
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, six-line behaviour change
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, see above

Tests: `test_join_game_commitment_requirement` (`member/tests.py`) gains `private` to its parametrize, covering Low + private + OPEN as allowed and Low + private + COMMITTED as still forbidden; `test_commitment_allows_requirement` (`user_profile/tests.py`) gains the same private cases; `test_private_game_is_not_low_locked` (`game/tests/test_commitment_requirement.py`) asserts a Low player retrieving a private game gets `eligible` for OPEN and `committed_locked` for COMMITTED. Full backend suite: 2150 passed, 8 skipped.

> **Note:** the WIP bot may flag the open-PR count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGrpr4qf9wcsL7NBULKgHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGrpr4qf9wcsL7NBULKgHY)_