### PR TITLE
Retry game id generation when the id is taken between check and insert

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -4,7 +4,7 @@ import re
 import uuid
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 from django.db.models import (
     Count,
@@ -44,6 +44,8 @@ from channel.models import ChannelMember, ChannelMessage
 from adjudication import service as adjudication_service
 
 tracer = trace.get_tracer(__name__)
+
+ID_GENERATION_ATTEMPTS = 3
 
 
 class GameQuerySet(models.QuerySet):
@@ -476,17 +478,37 @@ class Game(BaseModel):
     )
 
     def save(self, *args, **kwargs):
-        if not self.id:
-            self.id = self._generate_id()
-        super().save(*args, **kwargs)
+        if self.id:
+            super().save(*args, **kwargs)
+            return
 
-    def _generate_id(self):
+        base_id = self._generate_base_id()
+        self.id = self._generate_id(base_id)
+        kwargs.setdefault("force_insert", True)
+
+        for _ in range(ID_GENERATION_ATTEMPTS):
+            try:
+                with transaction.atomic():
+                    super().save(*args, **kwargs)
+                return
+            except IntegrityError:
+                if not Game.objects.filter(id=self.id).exists():
+                    raise
+                self.id = self._suffixed_id(base_id)
+
+        raise IntegrityError(f"Could not generate a unique id for game {self.name}")
+
+    def _generate_base_id(self):
         base_id = re.sub(r"[^a-z0-9]+", "-", self.name.lower())
-        base_id = re.sub(r"^-+|-+$", "", base_id)
+        return re.sub(r"^-+|-+$", "", base_id)
 
-        if not Game.objects.filter(id=base_id).exists():
-            return base_id
+    def _generate_id(self, base_id):
+        if Game.objects.filter(id=base_id).exists():
+            return self._suffixed_id(base_id)
 
+        return base_id
+
+    def _suffixed_id(self, base_id):
         return f"{base_id}-{str(uuid.uuid4())[:8]}"
 
     @property

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -45,8 +45,6 @@ from adjudication import service as adjudication_service
 
 tracer = trace.get_tracer(__name__)
 
-ID_GENERATION_ATTEMPTS = 3
-
 
 class GameQuerySet(models.QuerySet):
 
@@ -486,17 +484,12 @@ class Game(BaseModel):
         self.id = self._generate_id(base_id)
         kwargs.setdefault("force_insert", True)
 
-        for _ in range(ID_GENERATION_ATTEMPTS):
-            try:
-                with transaction.atomic():
-                    super().save(*args, **kwargs)
-                return
-            except IntegrityError:
-                if not Game.objects.filter(id=self.id).exists():
-                    raise
-                self.id = self._suffixed_id(base_id)
-
-        raise IntegrityError(f"Could not generate a unique id for game {self.name}")
+        try:
+            with transaction.atomic():
+                super().save(*args, **kwargs)
+        except IntegrityError:
+            self.id = self._suffixed_id(base_id)
+            super().save(*args, **kwargs)
 
     def _generate_base_id(self):
         base_id = re.sub(r"[^a-z0-9]+", "-", self.name.lower())

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1980,7 +1980,7 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 45
+        assert query_count == 47
 
     @pytest.mark.django_db
     def test_create_game_query_count_large_variant(self, authenticated_client, classical_variant):
@@ -2000,7 +2000,7 @@ class TestGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 45
+        assert query_count == 47
 
 
 class TestGamePrivateFiltering:
@@ -2422,7 +2422,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 55
+        assert query_count == 57
 
     @pytest.mark.django_db
     def test_create_sandbox_game_query_count_large_variant(
@@ -2443,7 +2443,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 55
+        assert query_count == 57
 
 
 class TestSandboxGameFiltering:
@@ -2943,6 +2943,47 @@ class TestGameCloneToSandbox:
         large_query_count = len(connection.queries)
 
         assert large_query_count == small_query_count
+
+    @pytest.mark.django_db
+    def test_clone_to_sandbox_twice_creates_two_games(
+        self, authenticated_client, active_game_with_phase_state, adjudication_data_classical
+    ):
+        url = reverse(clone_to_sandbox_viewname, args=[active_game_with_phase_state.id])
+        with patch("adjudication.service.start") as mock_start:
+            mock_start.return_value = adjudication_data_classical
+            first_response = authenticated_client.post(url)
+            second_response = authenticated_client.post(url)
+
+        assert first_response.status_code == status.HTTP_201_CREATED
+        assert second_response.status_code == status.HTTP_201_CREATED
+        assert first_response.data["id"] != second_response.data["id"]
+
+
+class TestGameIdGeneration:
+
+    @pytest.mark.django_db
+    def test_unique_name_keeps_slug_id(self, classical_variant):
+        game = Game.objects.create(name="A Unique Name", variant=classical_variant)
+        assert game.id == "a-unique-name"
+
+    @pytest.mark.django_db
+    def test_duplicate_name_is_suffixed(self, classical_variant):
+        first = Game.objects.create(name="Shared Name", variant=classical_variant)
+        second = Game.objects.create(name="Shared Name", variant=classical_variant)
+
+        assert first.id == "shared-name"
+        assert second.id.startswith("shared-name-")
+
+    @pytest.mark.django_db
+    def test_id_taken_after_availability_check_is_retried(self, classical_variant):
+        existing = Game.objects.create(name="Shared Name", variant=classical_variant)
+
+        with patch.object(Game, "_generate_id", return_value=existing.id):
+            game = Game.objects.create(name="Shared Name", variant=classical_variant)
+
+        assert game.id != existing.id
+        assert game.id.startswith("shared-name-")
+        assert Game.objects.filter(name="Shared Name").count() == 2
 
 
 pause_viewname = "game-pause"


### PR DESCRIPTION
## What this PR does

`Game.save` checked `Game.objects.filter(id=base_id).exists()` and then inserted in a separate statement, so two concurrent creates of the same name both saw the id as free and the loser hit `IntegrityError: duplicate key value violates unique constraint "game_game_pkey"` — a 500. Clone-to-sandbox always derives the same name (`f"{source_game.name} (Sandbox)"`), so submitting that request twice hit it reliably (Sentry `DIPLICITY-API-9H`). Fixes #1167.

The suffixing rule is unchanged — a duplicate id gets `-<8 hex>` appended. What changes is *when* a duplicate can be detected: the `SELECT` can't see a row another request hasn't committed yet, so the insert itself is now the second detector.

```python
base_id = self._generate_base_id()
self.id = self._generate_id(base_id)
kwargs.setdefault("force_insert", True)

try:
    with transaction.atomic():
        super().save(*args, **kwargs)
except IntegrityError:
    self.id = self._suffixed_id(base_id)
    super().save(*args, **kwargs)
```

- The savepoint (`transaction.atomic()`) is what makes the retry possible at all — `create_sandbox` and the clone serializer both insert inside an outer transaction, which a failed statement would otherwise poison.
- `_generate_id` is split into `_generate_base_id` / `_generate_id` / `_suffixed_id` so the retry reaches for the suffixed form directly instead of re-running the availability read that just proved stale.
- Names that are genuinely unique still get the clean slug id — the first attempt is the old code path, so ordinary game creation is unaffected.
- `force_insert` defaults to `True` once an id has been generated. A generated id means the row is new, and without it Django issues an `UPDATE ... WHERE id = <slug>` first, which in the race would silently overwrite the other game's row instead of raising.
- An unrelated `IntegrityError` (a bad FK, say) is not swallowed: it raises again on the retry and propagates.

The savepoint costs two extra statements (`SAVEPOINT` / `RELEASE SAVEPOINT`) per game insert, so the four game-creation query-count assertions move 45 → 47 and 55 → 57.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings

  `/review-pr` fails in this environment (its `gh pr diff` call needs a GraphQL endpoint that isn't served here), so I ran `/code-review high` instead. It raised nothing against this diff.
- [x] Tests cover the change

  - `test_id_taken_after_availability_check_is_retried` — simulates the stale read (`_generate_id` returns an id another game already holds) and asserts the save lands on a suffixed id instead of raising
  - `test_clone_to_sandbox_twice_creates_two_games` — two clones of one source game both return 201 with distinct ids
  - `test_unique_name_keeps_slug_id` / `test_duplicate_name_is_suffixed` — pin the unchanged non-race behaviour
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only

Full backend suite: 2157 passed, 8 skipped.