### PR TITLE
Reject responses that never got a status

### DIFF
--- a/packages/web/src/api/axiosInstance.test.ts
+++ b/packages/web/src/api/axiosInstance.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { AxiosError, AxiosHeaders } from "axios";
+import type { AxiosResponse } from "axios";
+import axiosInstance, { customInstance } from "./axiosInstance";
+import { isNetworkError } from "@/utils/network";
+
+const respondWith = (status: number, data: unknown) => {
+  axiosInstance.defaults.adapter = async config =>
+    ({
+      status,
+      statusText: "",
+      data,
+      headers: new AxiosHeaders(),
+      config,
+    }) as AxiosResponse;
+};
+
+describe("customInstance", () => {
+  it("resolves with the response body", async () => {
+    respondWith(200, [{ id: "classical" }]);
+
+    await expect(customInstance({ url: "/variants/" })).resolves.toEqual([
+      { id: "classical" },
+    ]);
+  });
+
+  it("rejects a response with no status rather than returning its empty body", async () => {
+    respondWith(0, "");
+
+    await expect(customInstance({ url: "/variants/" })).rejects.toMatchObject({
+      code: AxiosError.ERR_NETWORK,
+    });
+  });
+
+  it("rejects a response with no status as a network error", async () => {
+    respondWith(0, "");
+
+    const error = await customInstance({ url: "/variants/" }).catch(e => e);
+
+    expect(isNetworkError(error)).toBe(true);
+  });
+});

--- a/packages/web/src/api/axiosInstance.ts
+++ b/packages/web/src/api/axiosInstance.ts
@@ -38,7 +38,17 @@ const processQueue = (error: Error | null) => {
 };
 
 axiosInstance.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    if (!response.status) {
+      throw new AxiosError(
+        'Network Error',
+        AxiosError.ERR_NETWORK,
+        response.config,
+        response.request
+      );
+    }
+    return response;
+  },
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 


### PR DESCRIPTION
## What this PR does

Closes #1170, but at the transport layer rather than in `useGameVariant`.

The API never returns a non-list from `/variants/`. `variants` is a non-list when the **request failed and axios reported the failure as a success**:

1. An XHR that never received an HTTP response reports `status === 0`. `axios/lib/core/settle.js` short-circuits on `!response.status` and **resolves** — before `validateStatus` is ever consulted. It's a `file:` protocol workaround; the legacy `onreadystatechange` path in the XHR adapter still guards against it explicitly (*"the request errored out and we didn't get a response, this will be handled by onerror instead"*), but the `onloadend` path used by every current browser has no such guard and relies entirely on `onerror`/`onabort` having fired first.
2. The empty body then passes through `transformResponse` untouched, because it only parses *truthy* strings.

So the query resolves with `""`, React Query stores it as successful data, and every `.find`/`.map` over it throws.

### Evidence

| Sentry | Call site | Breadcrumb immediately before the throw |
|---|---|---|
| DIPLICITY-REACT-Y | `OrdersScreen`, `orders.find(...)` | `GET .../orders/51579` `status_code: 0` at 16:25:17.610 → throw at 16:25:17.613 |
| DIPLICITY-REACT-17 | `useGameVariant.ts:11` | `GET /variants/` `status_code: 0` at 12:52:48.049 → throw at 12:52:48.056 |
| DIPLICITY-REACT-18 | `GameMap.tsx:80` | same page load, same trace, same payload |

None of the three is followed by an `AxiosError` — the requests resolved. DIPLICITY-REACT-Y is decisive: the user had just navigated to phase 51579, and the orders query keys per phase, so there was no previously cached array. The only way that screen rendered with data is that the status-0 request resolved.

Two notes that bear on #1170's framing:

- DIPLICITY-REACT-Y is not `useGameVariant` — its stack is `OrdersScreen`, over the *orders* list. Same defect, different endpoint.
- DIPLICITY-REACT-18 is `GameMap.tsx:80`, which is *already* guarded as `variants?.find(...)`. Optional chaining doesn't help, because `""` is not nullish. Per-call-site `Array.isArray` guards are one guard per site against something that can hit every list-returning query in the app.

### The change

One check in the existing response interceptor, rejecting with the same `ERR_NETWORK` code axios uses for the failures it does catch. `isNetworkError` then classifies it, so the screen shows the offline notice with a retry instead of crashing to the app-level error boundary — and React Query's `retry` and `refetchOnReconnect` get to do their job, rather than caching an empty string as the answer.

`validateStatus` can't express this: `settle` returns before consulting it.

Deliberately not included: setting `transitional.silentJSONParsing = false` to also catch truncated/HTML bodies. `transformResponse` skips falsy data, so it would not have caught this case, and it would newly throw on 204s.

### Screenshots

Both states reproduced against `dev:mocks` on `/game/active-movement/phase/101/chat` (the route from DIPLICITY-REACT-17). A status-0 completion cannot be produced in Chromium — it is the Firefox-specific half of this — so each end is simulated: the crash by serving the empty body the browser handed the app, the fix by a network failure, which is what a status-0 completion is now classified as.

**Before** — `TypeError: variants?.find is not a function`, the app-level error boundary:

<!-- screenshot: before-crash.png -->

**After** — the existing offline notice, with a working retry:

<!-- screenshot: after-offline.png -->

(This environment can't upload image attachments to GitHub — the two PNGs are attached in the session for dragging in here.)

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, one-condition change; the reasoning is set out above
- [x] Tests cover the change — `src/api/axiosInstance.test.ts`; the status-0 case fails without the fix with `promise resolved "''" instead of rejecting`
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — see above

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rark4kzxMsgGkVR1PNPDSY)_