### PR TITLE
Forbid a user holding two members in one game

### DIFF
--- a/service/adjudicator/test_service.py
+++ b/service/adjudicator/test_service.py
@@ -671,20 +671,18 @@ class TestAdjudicationService:
         classical_austria_nation,
         classical_russia_nation,
         classical_turkey_nation,
-        primary_user,
-        secondary_user,
-        tertiary_user,
+        user_factory,
     ):
         game = Game.objects.create(variant=classical_variant, name="Classical Test Game", status=GameStatus.ACTIVE)
 
         members_by_nation = {
-            "England": Member.objects.create(nation=classical_england_nation, user=primary_user, game=game),
-            "France": Member.objects.create(nation=classical_france_nation, user=secondary_user, game=game),
-            "Germany": Member.objects.create(nation=classical_germany_nation, user=tertiary_user, game=game),
-            "Italy": Member.objects.create(nation=classical_italy_nation, user=primary_user, game=game),
-            "Austria": Member.objects.create(nation=classical_austria_nation, user=secondary_user, game=game),
-            "Russia": Member.objects.create(nation=classical_russia_nation, user=tertiary_user, game=game),
-            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=primary_user, game=game),
+            "England": Member.objects.create(nation=classical_england_nation, user=user_factory(), game=game),
+            "France": Member.objects.create(nation=classical_france_nation, user=user_factory(), game=game),
+            "Germany": Member.objects.create(nation=classical_germany_nation, user=user_factory(), game=game),
+            "Italy": Member.objects.create(nation=classical_italy_nation, user=user_factory(), game=game),
+            "Austria": Member.objects.create(nation=classical_austria_nation, user=user_factory(), game=game),
+            "Russia": Member.objects.create(nation=classical_russia_nation, user=user_factory(), game=game),
+            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=user_factory(), game=game),
         }
 
         phase = Phase.objects.create(
@@ -733,20 +731,18 @@ class TestAdjudicationService:
         classical_austria_nation,
         classical_russia_nation,
         classical_turkey_nation,
-        primary_user,
-        secondary_user,
-        tertiary_user,
+        user_factory,
     ):
         game = Game.objects.create(variant=classical_variant, name="Classical Test Game", status=GameStatus.ACTIVE)
 
         members_by_nation = {
-            "England": Member.objects.create(nation=classical_england_nation, user=primary_user, game=game),
-            "France": Member.objects.create(nation=classical_france_nation, user=secondary_user, game=game),
-            "Germany": Member.objects.create(nation=classical_germany_nation, user=tertiary_user, game=game),
-            "Italy": Member.objects.create(nation=classical_italy_nation, user=primary_user, game=game),
-            "Austria": Member.objects.create(nation=classical_austria_nation, user=secondary_user, game=game),
-            "Russia": Member.objects.create(nation=classical_russia_nation, user=tertiary_user, game=game),
-            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=primary_user, game=game),
+            "England": Member.objects.create(nation=classical_england_nation, user=user_factory(), game=game),
+            "France": Member.objects.create(nation=classical_france_nation, user=user_factory(), game=game),
+            "Germany": Member.objects.create(nation=classical_germany_nation, user=user_factory(), game=game),
+            "Italy": Member.objects.create(nation=classical_italy_nation, user=user_factory(), game=game),
+            "Austria": Member.objects.create(nation=classical_austria_nation, user=user_factory(), game=game),
+            "Russia": Member.objects.create(nation=classical_russia_nation, user=user_factory(), game=game),
+            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=user_factory(), game=game),
         }
 
         phase = Phase.objects.create(
@@ -784,20 +780,18 @@ class TestAdjudicationService:
         classical_austria_nation,
         classical_russia_nation,
         classical_turkey_nation,
-        primary_user,
-        secondary_user,
-        tertiary_user,
+        user_factory,
     ):
         game = Game.objects.create(variant=classical_variant, name="Classical Test Game", status=GameStatus.ACTIVE)
 
         members_by_nation = {
-            "England": Member.objects.create(nation=classical_england_nation, user=primary_user, game=game),
-            "France": Member.objects.create(nation=classical_france_nation, user=secondary_user, game=game),
-            "Germany": Member.objects.create(nation=classical_germany_nation, user=tertiary_user, game=game),
-            "Italy": Member.objects.create(nation=classical_italy_nation, user=primary_user, game=game),
-            "Austria": Member.objects.create(nation=classical_austria_nation, user=secondary_user, game=game),
-            "Russia": Member.objects.create(nation=classical_russia_nation, user=tertiary_user, game=game),
-            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=primary_user, game=game),
+            "England": Member.objects.create(nation=classical_england_nation, user=user_factory(), game=game),
+            "France": Member.objects.create(nation=classical_france_nation, user=user_factory(), game=game),
+            "Germany": Member.objects.create(nation=classical_germany_nation, user=user_factory(), game=game),
+            "Italy": Member.objects.create(nation=classical_italy_nation, user=user_factory(), game=game),
+            "Austria": Member.objects.create(nation=classical_austria_nation, user=user_factory(), game=game),
+            "Russia": Member.objects.create(nation=classical_russia_nation, user=user_factory(), game=game),
+            "Turkey": Member.objects.create(nation=classical_turkey_nation, user=user_factory(), game=game),
         }
 
         phase = Phase.objects.create(

--- a/service/conftest.py
+++ b/service/conftest.py
@@ -577,7 +577,7 @@ def game_factory(db):
 
 
 @pytest.fixture
-def phase_factory(db, classical_variant, primary_user):
+def phase_factory(db, classical_variant, primary_user, user_factory):
     def _create(
         game=None,
         type=None,
@@ -631,9 +631,12 @@ def phase_factory(db, classical_variant, primary_user):
 
                 member = game.members.filter(nation=nation).first()
                 if not member:
+                    user = config.get("user")
+                    if user is None:
+                        user = primary_user if not game.members.filter(user=primary_user).exists() else user_factory()
                     member = Member.objects.create(
                         nation=nation,
-                        user=config.get("user", primary_user),
+                        user=user,
                         game=game,
                     )
 
@@ -898,7 +901,7 @@ def sandbox_game_factory(db, primary_user, classical_variant, base_active_phase,
         phase = base_active_phase(game)
         phase.options = sample_options
         phase.save()
-        game.members.create(user=user)
+        game.members.create(user=user, sandbox=True)
         return game
 
     return _create
@@ -1093,7 +1096,7 @@ def sandbox_game_with_phase_options(
     phase.options = sample_options
     phase.save()
     for nation in base_active_game_for_primary_user.variant.nations.all():
-        member = base_active_game_for_primary_user.members.create(user=primary_user, nation=nation)
+        member = base_active_game_for_primary_user.members.create(user=primary_user, nation=nation, sandbox=True)
         phase.phase_states.create(member=member)
     return base_active_game_for_primary_user
 

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -334,7 +334,7 @@ class GameManager(models.Manager):
             game = self.create_from_template(variant, name=name, **kwargs)
 
             nations_list = [n for n in variant.nations.all() if not n.non_playable]
-            members_to_create = [Member(game=game, user=user) for _ in nations_list]
+            members_to_create = [Member(game=game, user=user, sandbox=True) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 
             current_phase = getattr(game, "_created_phase", None)

--- a/service/game/serializers.py
+++ b/service/game/serializers.py
@@ -635,7 +635,7 @@ class GameCloneToSandboxSerializer(serializers.Serializer):
             )
 
             nations_list = [n for n in source_game.variant.nations.all() if not n.non_playable]
-            members_to_create = [Member(game=game, user=user) for _ in nations_list]
+            members_to_create = [Member(game=game, user=user, sandbox=True) for _ in nations_list]
             created_members = Member.objects.bulk_create(members_to_create)
 
             game.start(current_phase=game._created_phase, members=created_members)

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1172,6 +1172,7 @@ class TestGameListViewQueryPerformance:
         classical_variant,
         primary_user,
         secondary_user,
+        tertiary_user,
         classical_england_nation,
         classical_france_nation,
         classical_edinburgh_province,
@@ -1185,7 +1186,7 @@ class TestGameListViewQueryPerformance:
             )
             member1 = game.members.create(user=primary_user, nation=classical_england_nation)
             member2 = game.members.create(user=secondary_user, nation=classical_france_nation)
-            member3 = game.members.create(user=secondary_user, nation=classical_germany_nation)
+            member3 = game.members.create(user=tertiary_user, nation=classical_germany_nation)
 
             phase = game.phases.create(
                 game=game,

--- a/service/member/migrations/0009_member_sandbox.py
+++ b/service/member/migrations/0009_member_sandbox.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("member", "0008_nationpreference_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="member",
+            name="sandbox",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/service/member/migrations/0010_backfill_member_sandbox.py
+++ b/service/member/migrations/0010_backfill_member_sandbox.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def backfill_member_sandbox(apps, schema_editor):
+    Member = apps.get_model("member", "Member")
+    Member.objects.filter(game__sandbox=True).update(sandbox=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("member", "0009_member_sandbox"),
+        ("game", "0004_game_sandbox_alter_game_movement_phase_duration"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_member_sandbox, migrations.RunPython.noop),
+    ]

--- a/service/member/migrations/0011_unique_member_per_user_per_game.py
+++ b/service/member/migrations/0011_unique_member_per_user_per_game.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("member", "0010_backfill_member_sandbox"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="member",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("sandbox", False)),
+                fields=("game", "user"),
+                name="unique_member_per_user_per_game",
+            ),
+        ),
+    ]

--- a/service/member/models.py
+++ b/service/member/models.py
@@ -97,6 +97,7 @@ class Member(BaseModel):
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name="members")
     game = models.ForeignKey("game.Game", on_delete=models.CASCADE, related_name="members")
     nation = models.ForeignKey("nation.Nation", on_delete=models.CASCADE, related_name="members", null=True, blank=True)
+    sandbox = models.BooleanField(default=False)
     won = models.BooleanField(default=False)
     drew = models.BooleanField(default=False)
     eliminated = models.BooleanField(default=False)
@@ -123,7 +124,12 @@ class Member(BaseModel):
                 fields=["game", "nation"],
                 condition=models.Q(replaced_by__isnull=True),
                 name="member_unique_nation_per_game",
-            )
+            ),
+            models.UniqueConstraint(
+                fields=["game", "user"],
+                condition=models.Q(sandbox=False),
+                name="unique_member_per_user_per_game",
+            ),
         ]
 
     @property

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest.mock import patch
 from django.db import connection
-from django.db.utils import IntegrityError
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -2053,77 +2052,3 @@ class TestMemberNationAssignView:
         url = reverse(assign_viewname, args=[game.id, 999999])
         response = authenticated_client.put(url, {"nation_id": "france"}, format="json")
         assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-class TestUniqueMemberPerUserPerGame:
-
-    @pytest.mark.django_db
-    def test_rejects_a_second_member_for_the_same_user(
-        self, classical_variant, primary_user
-    ):
-        game = Game.objects.create(
-            name="Test Game",
-            variant=classical_variant,
-            status=GameStatus.PENDING,
-        )
-        game.members.create(user=primary_user)
-
-        with pytest.raises(IntegrityError):
-            game.members.create(user=primary_user)
-
-    @pytest.mark.django_db
-    def test_allows_the_same_user_in_different_games(
-        self, classical_variant, primary_user
-    ):
-        first = Game.objects.create(
-            name="First Game", variant=classical_variant, status=GameStatus.PENDING
-        )
-        second = Game.objects.create(
-            name="Second Game", variant=classical_variant, status=GameStatus.PENDING
-        )
-
-        first.members.create(user=primary_user)
-        second.members.create(user=primary_user)
-
-        assert first.members.count() == 1
-        assert second.members.count() == 1
-
-    @pytest.mark.django_db
-    def test_allows_several_members_without_a_user(self, classical_variant):
-        game = Game.objects.create(
-            name="Test Game",
-            variant=classical_variant,
-            status=GameStatus.ACTIVE,
-        )
-
-        game.members.create(user=None, kicked=True)
-        game.members.create(user=None, kicked=True)
-
-        assert game.members.count() == 2
-
-    @pytest.mark.django_db
-    def test_allows_the_same_user_in_every_sandbox_seat(
-        self, classical_variant, primary_user
-    ):
-        game = Game.objects.create(
-            name="Test Sandbox",
-            variant=classical_variant,
-            status=GameStatus.ACTIVE,
-            sandbox=True,
-        )
-
-        for _ in range(7):
-            game.members.create(user=primary_user, sandbox=True)
-
-        assert game.members.count() == 7
-
-    @pytest.mark.django_db
-    def test_join_creates_a_member_that_is_not_a_sandbox_member(
-        self, authenticated_client, pending_game_created_by_secondary_user, primary_user
-    ):
-        game = pending_game_created_by_secondary_user
-
-        response = authenticated_client.post(reverse(join_viewname, args=[game.id]))
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert game.members.get(user=primary_user).sandbox is False

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch
 from django.db import connection
+from django.db.utils import IntegrityError
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -914,7 +915,7 @@ class TestMemberReplace:
 
 
 @pytest.mark.django_db
-def test_game_start_phase_not_immediately_resolvable(classical_variant, primary_user):
+def test_game_start_phase_not_immediately_resolvable(classical_variant, user_factory):
     # After game.start(), the active phase must NOT appear in filter_due_phases()
     # for a duration-based game with a future deadline.
     #
@@ -933,7 +934,7 @@ def test_game_start_phase_not_immediately_resolvable(classical_variant, primary_
         movement_phase_duration=MovementPhaseDuration.TWENTY_FOUR_HOURS,
     )
     for _ in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=user_factory())
     game.start()
 
     phase = game.current_phase
@@ -2052,3 +2053,77 @@ class TestMemberNationAssignView:
         url = reverse(assign_viewname, args=[game.id, 999999])
         response = authenticated_client.put(url, {"nation_id": "france"}, format="json")
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestUniqueMemberPerUserPerGame:
+
+    @pytest.mark.django_db
+    def test_rejects_a_second_member_for_the_same_user(
+        self, classical_variant, primary_user
+    ):
+        game = Game.objects.create(
+            name="Test Game",
+            variant=classical_variant,
+            status=GameStatus.PENDING,
+        )
+        game.members.create(user=primary_user)
+
+        with pytest.raises(IntegrityError):
+            game.members.create(user=primary_user)
+
+    @pytest.mark.django_db
+    def test_allows_the_same_user_in_different_games(
+        self, classical_variant, primary_user
+    ):
+        first = Game.objects.create(
+            name="First Game", variant=classical_variant, status=GameStatus.PENDING
+        )
+        second = Game.objects.create(
+            name="Second Game", variant=classical_variant, status=GameStatus.PENDING
+        )
+
+        first.members.create(user=primary_user)
+        second.members.create(user=primary_user)
+
+        assert first.members.count() == 1
+        assert second.members.count() == 1
+
+    @pytest.mark.django_db
+    def test_allows_several_members_without_a_user(self, classical_variant):
+        game = Game.objects.create(
+            name="Test Game",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+        )
+
+        game.members.create(user=None, kicked=True)
+        game.members.create(user=None, kicked=True)
+
+        assert game.members.count() == 2
+
+    @pytest.mark.django_db
+    def test_allows_the_same_user_in_every_sandbox_seat(
+        self, classical_variant, primary_user
+    ):
+        game = Game.objects.create(
+            name="Test Sandbox",
+            variant=classical_variant,
+            status=GameStatus.ACTIVE,
+            sandbox=True,
+        )
+
+        for _ in range(7):
+            game.members.create(user=primary_user, sandbox=True)
+
+        assert game.members.count() == 7
+
+    @pytest.mark.django_db
+    def test_join_creates_a_member_that_is_not_a_sandbox_member(
+        self, authenticated_client, pending_game_created_by_secondary_user, primary_user
+    ):
+        game = pending_game_created_by_secondary_user
+
+        response = authenticated_client.post(reverse(join_viewname, args=[game.id]))
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert game.members.get(user=primary_user).sandbox is False

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -248,7 +248,7 @@ def test_resolve_due_phases_skips_sandbox_games(db, classical_variant, primary_u
         movement_phase_duration=None,
     )
     for nation in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=primary_user, sandbox=True)
     game.start()
 
     phase = game.current_phase
@@ -275,7 +275,7 @@ def test_sandbox_game_resolve_phase_success(authenticated_client, db, classical_
         movement_phase_duration=None,
     )
     for nation in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=primary_user, sandbox=True)
     game.start()
 
     mock_new_phase = MagicMock()
@@ -307,7 +307,7 @@ def test_sandbox_game_resolve_phase_unauthenticated(unauthenticated_client, db, 
         movement_phase_duration=None,
     )
     for nation in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=primary_user, sandbox=True)
     game.start()
 
     url = reverse("game-resolve-phase", args=[game.id])
@@ -337,7 +337,7 @@ def test_sandbox_game_resolve_phase_non_member(
         movement_phase_duration=None,
     )
     for nation in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=primary_user, sandbox=True)
     game.start()
 
     url = reverse("game-resolve-phase", args=[game.id])
@@ -1192,7 +1192,7 @@ class TestCreateFromAdjudicationDataPerformance:
     def test_create_from_adjudication_data_query_count_with_full_game(
         self,
         classical_variant,
-        primary_user,
+        user_factory,
         classical_england_nation,
         classical_france_nation,
         classical_germany_nation,
@@ -1223,7 +1223,7 @@ class TestCreateFromAdjudicationDataPerformance:
         ]
 
         for nation in nations:
-            game.members.create(user=primary_user, nation=nation)
+            game.members.create(user=user_factory(), nation=nation)
 
         berlin = Province.objects.get(province_id="ber", variant=classical_variant)
         rome = Province.objects.get(province_id="rom", variant=classical_variant)


### PR DESCRIPTION
## What this PR does

Adds a database unique constraint on `(game, user)` for `Member`, so a user can never hold two seats in the same game. Relates to #1163.

The join view's "is this user already a member?" test lived in a permission class, which reads the game before anything is written — two overlapping joins both passed and both took a seat. b1b6475 closed that race in the application with `SeatClaimMixin`, but nothing in the database stopped a duplicate. Two production games had already been left with one user holding several nations, which is what broke `POST /games/{id}/channels/create/`: `ChannelManager.create_from_member_ids` resolves the caller with a bare `get()` and raised `Member.MultipleObjectsReturned` (Sentry `DIPLICITY-API-9K`). Both games have since been deleted, so production currently holds zero non-sandbox duplicates.

**Why the constraint is conditional.** Sandbox games deliberately seat one user in every nation (`Game.objects.create_sandbox`, and the same pattern in `GameCloneToSandboxSerializer`), so an unconditional constraint is not available. Postgres cannot reference `game.sandbox` from a partial index predicate, so `Member` carries its own `sandbox` flag and the constraint keys off it:

```python
models.UniqueConstraint(
    fields=["game", "user"],
    condition=models.Q(sandbox=False),
    name="unique_member_per_user_per_game",
)
```

`Game.sandbox` is fixed at creation and never mutated, so the flag cannot drift, and the two sandbox seeding paths are the only writers. A future path that forgets to set it fails loudly on its second member rather than silently duplicating.

`user` stays nullable — account deletion nulls it — and Postgres treats NULLs as distinct, so a game with several deleted-account members is still legal.

**Migrations.** `0008` adds the field, `0009` backfills `sandbox=True` for members of sandbox games (378 game/user pairs in production), `0010` adds the constraint. `0009` must run before `0010` or the constraint rejects every existing sandbox game. Verified end to end: the staging deploy applied all three against a production snapshot and the backend served (`/variants/` → 200).

**Test fixtures.** Several fixtures and tests seated one user in many nations of a *non-sandbox* game as a shortcut. Those now give each seat its own user, which is what the tests meant; `phase_factory` keeps `primary_user` for the first seat so tests that authenticate as them are unaffected. Sandbox fixtures pass `sandbox=True`.

No serializer exposes the new field (`BaseMemberSerializer` is an explicit `Serializer`), so the OpenAPI schemas are unchanged.

**Open question on test style.** `.claude/rules/backend/tests.md` gained "do not test models, managers, or querysets directly — assert behaviour through HTTP endpoints" after this branch was written. Four of the five tests in `TestUniqueMemberPerUserPerGame` create `Member` rows directly and assert `IntegrityError`, because the constraint guards a race the HTTP layer rejects first — `SeatClaimMixin` returns 403 before the insert, so an endpoint cannot reach the constraint. The HTTP-observable behaviour is already covered by the existing join-race and sandbox-creation tests. Happy to drop the direct-model tests if the rule should win here.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — `TestUniqueMemberPerUserPerGame` covers the rejected duplicate, the same user across two games, several members without a user, a full sandbox seating, and that a join creates a non-sandbox member. Full backend suite on a clean checkout: 2171 passed, 8 skipped.
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only