### PR TITLE
Drop orphaned bot app tables before deleting the legacy bot user

### DIFF
--- a/service/user_profile/migrations/0009_seed_bot_roster.py
+++ b/service/user_profile/migrations/0009_seed_bot_roster.py
@@ -57,5 +57,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS bot_llmcall",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS bot_botprofile",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.RunPython(seed_roster, remove_roster),
     ]


### PR DESCRIPTION
## What this PR does

Forward-fixes the production deploy failure in `user_profile.0009_seed_bot_roster` (`ForeignKeyViolation` on `bot_botprofile_user_id_..._fk_auth_user_id`, introduced by #1208). The original `bot` app was deleted in #1045 without dropping its tables, leaving `bot_botprofile` and `bot_llmcall` orphaned in production; `bot_botprofile` still holds a row referencing the legacy `diplicitybot` user (id 2652), so the deferred FK check fired at commit when 0009 deleted that user. The failed migration rolled back and was never recorded in `django_migrations` (verified in prod), so 0009 is edited in place to `DROP TABLE IF EXISTS` both orphaned tables before the roster seed runs. Dropping `bot_llmcall` also removes its stale FKs into `channel`, `member`, and `phase`, which would have blocked future deletes there.

Verified by reproducing prod conditions locally (rolled back to 0008, recreated `bot_botprofile` with a row referencing a `diplicitybot` user, re-ran migrate): migration now applies, both tables are dropped, and the 21-bot roster seeds.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — skipped, 8-line migration edit
- [x] Tests cover the change (`user_profile` suite passes; migration behavior verified against reproduced prod state)
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — no visual changes