### PR TITLE
Suppress notifications for sandbox games

### DIFF
--- a/service/emit/tests.py
+++ b/service/emit/tests.py
@@ -83,6 +83,20 @@ class TestEmitDispatch:
         assert _deliver_jobs(in_memory_procrastinate) == []
 
     @pytest.mark.django_db
+    def test_no_notification_or_job_created_for_sandbox_games(
+        self, game_factory, member_factory, user_factory, classical_variant, in_memory_procrastinate
+    ):
+        game = game_factory(variant=classical_variant, sandbox=True)
+        member = member_factory(game=game, user=user_factory())
+
+        emit.emit("game_start", game=game)
+        emit.emit("elimination", game=game, recipients=[member.user_id])
+
+        assert not Notification.objects.exists()
+        assert not NotificationDelivery.objects.exists()
+        assert _deliver_jobs(in_memory_procrastinate) == []
+
+    @pytest.mark.django_db
     def test_manager_label_and_deadline_are_inferred_into_copy(
         self, game_factory, member_factory, user_factory, classical_variant, in_memory_procrastinate
     ):

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -13,6 +13,7 @@ from common.constants import PhaseStatus, PhaseType, GameStatus, NationAssignmen
 from phase.models import Phase
 from nation.models import Nation
 from province.models import Province
+from notification.models import Notification, NotificationDelivery
 from user_profile.models import UserProfile
 from .models import Game
 
@@ -2361,6 +2362,20 @@ class TestSandboxGameCreation:
         assert game.current_phase.phase_states.count() == 7
 
     @pytest.mark.django_db
+    def test_create_sandbox_game_does_not_notify(
+        self, authenticated_client, classical_variant, in_memory_procrastinate
+    ):
+        url = reverse(sandbox_create_viewname)
+        payload = {
+            "name": "My Sandbox Game",
+            "variant_id": classical_variant.id,
+        }
+        response = authenticated_client.post(url, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Notification.objects.count() == 0
+        assert NotificationDelivery.objects.count() == 0
+
+    @pytest.mark.django_db
     def test_create_sandbox_game_missing_name(self, authenticated_client, classical_variant):
         url = reverse(sandbox_create_viewname)
         payload = {
@@ -2423,7 +2438,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 57
+        assert query_count == 52
 
     @pytest.mark.django_db
     def test_create_sandbox_game_query_count_large_variant(
@@ -2444,7 +2459,7 @@ class TestSandboxGameCreateViewPerformance:
 
         assert response.status_code == status.HTTP_201_CREATED
         query_count = len(connection.queries)
-        assert query_count == 57
+        assert query_count == 52
 
 
 class TestSandboxGameFiltering:
@@ -2879,6 +2894,22 @@ class TestGameCloneToSandbox:
 
         assert response.status_code == status.HTTP_201_CREATED
         assert not Game.objects.filter(id=oldest_sandbox_id).exists()
+
+    @pytest.mark.django_db
+    def test_clone_to_sandbox_does_not_notify(
+        self,
+        authenticated_client,
+        active_game_with_phase_state,
+        adjudication_data_classical,
+        in_memory_procrastinate,
+    ):
+        url = reverse(clone_to_sandbox_viewname, args=[active_game_with_phase_state.id])
+        with patch("adjudicator.service.start") as mock_start:
+            mock_start.return_value = adjudication_data_classical
+            response = authenticated_client.post(url)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Notification.objects.count() == 0
+        assert NotificationDelivery.objects.count() == 0
 
     @pytest.mark.django_db
     def test_clone_to_sandbox_unauthenticated(

--- a/service/notification/models.py
+++ b/service/notification/models.py
@@ -11,6 +11,8 @@ class NotificationManager(models.Manager):
         # Local import: notification.registry imports this module at top level.
         from notification.registry import get_spec
 
+        if context.game is not None and context.game.sandbox:
+            return []
         spec = get_spec(event_type, context)
         if spec is None:
             return []


### PR DESCRIPTION
## What this PR does

Sandbox games fired push and email notifications like any other game. Because a sandbox seats one user on *every* nation (`Member(game=game, user=user)` per playable nation — `game/models.py:330`, `game/serializers.py:642`), every per-member event multiplied by the nation count and landed on the same device. Cloning an ongoing Chaos game was the worst case: `clone_from_phase` copies only the units and supply centres present in the source phase (`game/models.py:364-384`), so every nation already dead in the source game starts the sandbox with nothing, and the first sandbox resolve emitted one `elimination` per dead nation (`phase/models.py:587-590`) — a wall of identical "You've been eliminated" pushes.

Other sandbox events that notified before this change: `game_start` on sandbox creation (`game/models.py:758`, reached from both `create_sandbox` and clone-to-sandbox), `phase_resolved` on every manual sandbox resolve (`phase/models.py:904`), and the `game_draw` / `game_solo_win` / `game_solo_loss` trio if a sandbox reaches a victory condition (`game/models.py:779-782`).

The fix is one guard in `NotificationManager.create_from_event` (`notification/models.py`): if the event's game is a sandbox, bail before any `Notification` or `NotificationDelivery` row is created, so no delivery job is deferred either. It covers every event type, present and future, rather than opting specs out one at a time. The `context.game is not None` check is needed because `game_deleted` is emitted without a game in context (`game/views.py:158`).

Deliberately unaffected: the `ChannelEvent` and `AgentTask` fan-outs in `emit/dispatch.py`. Both are already no-ops for sandboxes — no channels are created for a sandbox game, and agent specs target bot members, which sandboxes have none of.

No schema, wire, or frontend change; `Notification` rows are not exposed over HTTP (`notification/urls.py` is empty), so suppressing them loses nothing user-visible. The two sandbox-creation query-count assertions drop 57 → 52, which is the notification writes going away.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, two-line guard plus tests
- [x] Tests cover the change — HTTP-level tests on both sandbox entry points (`sandbox-game-create`, `game-clone-to-sandbox`) assert no notification rows, plus an `emit/tests.py` case covering the generic guard for `game_start` and `elimination`. Full backend suite green (2161 passed, 8 skipped).
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only

---
_Generated by [Claude Code](https://claude.ai/code/session_017FbtsokLafcRhLvBueHweX)_