### PR TITLE
Keep serving the seating paths shipped mobile builds call

### DIFF
--- a/.claude/rules/backend/api-design.md
+++ b/.claude/rules/backend/api-design.md
@@ -37,3 +37,17 @@ Extra path segments imply an operation beyond ordinary CRUD.
 **Example:**
 
 - Join a game: `POST /api/game/<game_id>/member/join`
+
+## Never delete a path that shipped
+
+The iOS and Android apps are Capacitor builds with `webDir: "dist"` — each store release bakes in its own copy of the web bundle and calls whatever paths that bundle was generated against. Deleting a route does not migrate those installs, it breaks them until every user updates. This is what took game joining down for app users in August 2026: `/game/<id>/join/` moved to `/game/<id>/member/join/`, and every shipped build kept POSTing to a path that now 404s.
+
+Renaming a path is fine; removing the old one is not. Leave the old path serving the same view through a subclass excluded from the schema, so codegen keeps emitting only the new path and no client is generated against the alias:
+
+```python
+@extend_schema(exclude=True)
+class LegacyMemberJoinView(MemberJoinView):
+    """Serves POST /game/<id>/join/ for mobile builds shipped before ..."""
+```
+
+Register it in the owning app's `urls.py` with a `-legacy` suffix on the URL name, and cover it with a test asserting the literal path — that string is the contract, so `reverse()` alone does not protect it. Aliases are removed once the store metrics show the old builds are gone, not as part of the rename.

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -17,6 +17,8 @@ User = get_user_model()
 
 join_viewname = "game-join"
 seat_viewname = "game-member-create"
+legacy_join_viewname = "game-join-legacy"
+legacy_seat_viewname = "game-add-bot-legacy"
 retrieve_viewname = "game-retrieve"
 recovery_viewname = "civil-disorder-recovery"
 
@@ -1193,3 +1195,110 @@ class TestSeatMember:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert game.members.count() == 2
+
+
+class TestLegacyMemberJoinView:
+
+    def test_serves_the_path_shipped_mobile_builds_call(self):
+        assert reverse(legacy_join_viewname, args=["abc123"]) == "/game/abc123/join/"
+
+    @pytest.mark.django_db
+    def test_join_game_success(
+        self, authenticated_client, pending_game_created_by_secondary_user, primary_user
+    ):
+        url = reverse(legacy_join_viewname, args=[pending_game_created_by_secondary_user.id])
+        response = authenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["name"] == primary_user.profile.name
+        assert response.data["is_current_user"] is True
+        assert pending_game_created_by_secondary_user.members.filter(user=primary_user).exists()
+
+    @pytest.mark.django_db
+    def test_join_game_unauthenticated(self, unauthenticated_client, pending_game_created_by_secondary_user):
+        url = reverse(legacy_join_viewname, args=[pending_game_created_by_secondary_user.id])
+        response = unauthenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.django_db
+    def test_join_game_already_member(self, authenticated_client, pending_game_created_by_primary_user):
+        url = reverse(legacy_join_viewname, args=[pending_game_created_by_primary_user.id])
+        response = authenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_join_game_non_pending(self, authenticated_client, pending_game_created_by_secondary_user):
+        game = pending_game_created_by_secondary_user
+        game.status = GameStatus.ACTIVE
+        game.save()
+
+        url = reverse(legacy_join_viewname, args=[game.id])
+        response = authenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_join_game_not_found(self, authenticated_client):
+        url = reverse(legacy_join_viewname, args=[999])
+        response = authenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.django_db
+    def test_joining_the_last_seat_starts_the_game(
+        self, authenticated_client, pending_game_created_by_secondary_user, italy_vs_germany_variant
+    ):
+        game = pending_game_created_by_secondary_user
+        game.variant = italy_vs_germany_variant
+        game.save()
+
+        url = reverse(legacy_join_viewname, args=[game.id])
+        response = authenticated_client.post(url, {}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        game.refresh_from_db()
+        assert game.status == GameStatus.ACTIVE
+
+
+class TestLegacyMemberCreateView:
+
+    def test_serves_the_path_shipped_mobile_builds_call(self):
+        assert reverse(legacy_seat_viewname, args=["abc123"]) == "/game/abc123/add-bot/"
+
+    @pytest.mark.django_db
+    def test_manager_can_seat_a_bot(self, allowlisted_client, classical_variant, bot_user):
+        game = _create_game_via_api(allowlisted_client, classical_variant.id)
+
+        response = allowlisted_client.post(
+            reverse(legacy_seat_viewname, args=[game.id]), {"user_id": bot_user.id}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["is_bot"] is True
+        member = game.members.get(user=bot_user)
+        assert game.get_public_press().member_channels.filter(member=member).exists()
+
+    @pytest.mark.django_db
+    def test_human_user_is_rejected(self, allowlisted_client, classical_variant, secondary_user):
+        game = _create_game_via_api(allowlisted_client, classical_variant.id)
+
+        response = allowlisted_client.post(
+            reverse(legacy_seat_viewname, args=[game.id]), {"user_id": secondary_user.id}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.django_db
+    def test_user_off_the_allowlist_cannot_seat_a_bot(
+        self, allowlisted_client, classical_variant, bot_user, settings
+    ):
+        game = _create_game_via_api(allowlisted_client, classical_variant.id)
+        settings.BOT_OPPONENT_ALLOWLIST = []
+
+        response = allowlisted_client.post(
+            reverse(legacy_seat_viewname, args=[game.id]), {"user_id": bot_user.id}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/service/member/urls.py
+++ b/service/member/urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     path("game/<str:game_id>/leave/", views.MemberDeleteView.as_view(), name="game-leave"),
     path("game/<str:game_id>/kick/<int:member_id>/", views.MemberKickView.as_view(), name="game-kick"),
     path("game/<str:game_id>/recover-from-civil-disorder/", views.CivilDisorderRecoveryView.as_view(), name="civil-disorder-recovery"),
+    path("game/<str:game_id>/join/", views.LegacyMemberJoinView.as_view(), name="game-join-legacy"),
+    path("game/<str:game_id>/add-bot/", views.LegacyMemberCreateView.as_view(), name="game-add-bot-legacy"),
 ]

--- a/service/member/views.py
+++ b/service/member/views.py
@@ -24,6 +24,21 @@ class MemberJoinView(SeatClaimMixin, generics.CreateAPIView):
     permission_classes = [permissions.IsAuthenticated, IsPendingGame, IsNotGameMember, IsNotGameMaster, IsSpaceAvailable, MeetsCommitmentRequirement]
 
 
+@extend_schema(exclude=True)
+class LegacyMemberJoinView(MemberJoinView):
+    """Serves POST /game/<id>/join/ for mobile builds shipped before the seating
+    endpoints moved under /member/. Kept out of the schema so codegen only ever
+    emits the current path. Remove once those builds are out of circulation."""
+
+
+@extend_schema(exclude=True)
+class LegacyMemberCreateView(MemberCreateView):
+    """Serves POST /game/<id>/add-bot/ for mobile builds shipped before the
+    seating endpoints moved under /member/. Kept out of the schema so codegen
+    only ever emits the current path. Remove once those builds are out of
+    circulation."""
+
+
 class MemberDeleteView(SelectedGameMixin, generics.DestroyAPIView):
     serializer_class = EmptySerializer
     permission_classes = [permissions.IsAuthenticated, IsPendingGame, IsGameMember]

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -985,28 +985,29 @@ class TestCanCreateBotGamesFlag:
         assert response.data["can_create_bot_games"] is False
 
 
-class TestAddableUserList:
+def _create_bot_seat_game(client, variant_id):
+    response = client.post(
+        reverse("game-create"),
+        {
+            "name": "Bot Seat Game",
+            "variant_id": variant_id,
+            "nation_assignment": "random",
+            "private": False,
+            "deadline_mode": "duration",
+            "movement_phase_duration": "24 hours",
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    return Game.objects.get(id=response.data["id"])
 
-    def _create_game(self, client, variant_id):
-        response = client.post(
-            reverse("game-create"),
-            {
-                "name": "Bot Seat Game",
-                "variant_id": variant_id,
-                "nation_assignment": "random",
-                "private": False,
-                "deadline_mode": "duration",
-                "movement_phase_duration": "24 hours",
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        return Game.objects.get(id=response.data["id"])
+
+class TestAddableUserList:
 
     @pytest.mark.django_db
     def test_lists_bots_sorted_by_name(self, authenticated_client, classical_variant, settings):
         settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
-        game = self._create_game(authenticated_client, classical_variant.id)
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
 
         response = authenticated_client.get(reverse("game-addable-user-list", args=[game.id]))
 
@@ -1018,7 +1019,7 @@ class TestAddableUserList:
     @pytest.mark.django_db
     def test_excludes_humans(self, authenticated_client, classical_variant, secondary_user, settings):
         settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
-        game = self._create_game(authenticated_client, classical_variant.id)
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
 
         response = authenticated_client.get(reverse("game-addable-user-list", args=[game.id]))
 
@@ -1029,7 +1030,7 @@ class TestAddableUserList:
         self, authenticated_client, classical_variant, bot_user, settings
     ):
         settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
-        game = self._create_game(authenticated_client, classical_variant.id)
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
         game.members.create(user=bot_user)
 
         response = authenticated_client.get(reverse("game-addable-user-list", args=[game.id]))
@@ -1042,7 +1043,7 @@ class TestAddableUserList:
         self, authenticated_client, authenticated_client_for_secondary_user, classical_variant, settings
     ):
         settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com", "secondary@example.com"]
-        game = self._create_game(authenticated_client, classical_variant.id)
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
 
         response = authenticated_client_for_secondary_user.get(
             reverse("game-addable-user-list", args=[game.id])
@@ -1053,7 +1054,7 @@ class TestAddableUserList:
     @pytest.mark.django_db
     def test_user_off_the_allowlist_forbidden(self, authenticated_client, classical_variant, settings):
         settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
-        game = self._create_game(authenticated_client, classical_variant.id)
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
         settings.BOT_OPPONENT_ALLOWLIST = []
 
         response = authenticated_client.get(reverse("game-addable-user-list", args=[game.id]))
@@ -1068,6 +1069,59 @@ class TestAddableUserList:
 
         response = authenticated_client.get(
             reverse("game-addable-user-list", args=[active_game_created_by_primary_user.id])
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestLegacyAvailableBotListView:
+
+    def test_serves_the_path_shipped_mobile_builds_call(self):
+        assert reverse("game-available-bots-legacy", args=["abc123"]) == "/game/abc123/available-bots/"
+
+    @pytest.mark.django_db
+    def test_lists_bots_sorted_by_name(self, authenticated_client, classical_variant, settings):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
+
+        response = authenticated_client.get(reverse("game-available-bots-legacy", args=[game.id]))
+
+        assert response.status_code == status.HTTP_200_OK
+        names = [user["name"] for user in response.data]
+        assert names == sorted(names)
+        assert all(user["user_id"] for user in response.data)
+
+    @pytest.mark.django_db
+    def test_excludes_bots_already_in_the_game(
+        self, authenticated_client, classical_variant, bot_user, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
+        game.members.create(user=bot_user)
+
+        response = authenticated_client.get(reverse("game-available-bots-legacy", args=[game.id]))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert bot_user.id not in [user["user_id"] for user in response.data]
+
+    @pytest.mark.django_db
+    def test_user_off_the_allowlist_forbidden(self, authenticated_client, classical_variant, settings):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+        game = _create_bot_seat_game(authenticated_client, classical_variant.id)
+        settings.BOT_OPPONENT_ALLOWLIST = []
+
+        response = authenticated_client.get(reverse("game-available-bots-legacy", args=[game.id]))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_non_pending_game_forbidden(
+        self, authenticated_client, active_game_created_by_primary_user, settings
+    ):
+        settings.BOT_OPPONENT_ALLOWLIST = ["primary@example.com"]
+
+        response = authenticated_client.get(
+            reverse("game-available-bots-legacy", args=[active_game_created_by_primary_user.id])
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/service/user_profile/urls.py
+++ b/service/user_profile/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("user/delete/", views.UserAccountDeleteView.as_view(), name="user-delete"),
     path("users/<int:user_id>/", views.PublicUserProfileRetrieveView.as_view(), name="public-user-profile"),
     path("game/<str:game_id>/addable-user/", views.AddableUserListView.as_view(), name="game-addable-user-list"),
+    path("game/<str:game_id>/available-bots/", views.LegacyAvailableBotListView.as_view(), name="game-available-bots-legacy"),
 ]

--- a/service/user_profile/views.py
+++ b/service/user_profile/views.py
@@ -1,6 +1,7 @@
 from rest_framework import permissions, generics
 from django.db import transaction
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 
 from game.models import Game
 from member.models import Member
@@ -43,6 +44,13 @@ class AddableUserListView(SelectedGameMixin, generics.ListAPIView):
 
     def get_queryset(self):
         return UserProfile.objects.addable_to_game(self.get_game())
+
+
+@extend_schema(exclude=True)
+class LegacyAvailableBotListView(AddableUserListView):
+    """Serves GET /game/<id>/available-bots/ for mobile builds shipped before the
+    endpoint was renamed. Kept out of the schema so codegen only ever emits the
+    current path. Remove once those builds are out of circulation."""
 
 
 class UserAccountDeleteView(generics.DestroyAPIView):


### PR DESCRIPTION
## What this PR does

Restores the three seating paths that `0d20ebd` deleted, so app users on an older store build can join games again instead of hitting "Failed to join game".

The apps are Capacitor builds with `webDir: "dist"` (`capacitor.config.ts`), so each store release bakes in its own copy of the web bundle and calls whatever paths that bundle was generated against. When the seating endpoints moved under `/member/`, every installed build kept POSTing `/game/{id}/join/` — which now 404s, with no way out but updating the app. Web users were unaffected because they get the new bundle on reload, which matches what players reported in Discord (updating or reinstalling the app fixed it; the web app worked).

Each renamed path routes to its current view again through a subclass decorated `@extend_schema(exclude=True)`, so codegen still emits only the new path and no client is ever generated against an alias:

| Legacy path | View |
| --- | --- |
| `POST /game/{id}/join/` | `MemberJoinView` |
| `POST /game/{id}/add-bot/` | `MemberCreateView` |
| `GET /game/{id}/available-bots/` | `AddableUserListView` |

Permissions, serializers and seat-claim locking are untouched — the aliases are pure routing, so an old build gets exactly the behaviour a current build gets.

`add-bot` and `available-bots` were broken the same way but are allowlist-gated, so nobody had reported them yet.

Verification: regenerating `openapi-schema.yaml` leaves it byte-identical apart from the `/devices/` + `FCMDevice` removal this session's missing Firebase config always produces. Reverting just the two `urls.py` files fails 12 of the new tests, so they are not passing by accident.

`.claude/rules/backend/api-design.md` gains a "Never delete a path that shipped" section, since the existing note in `codegen.md` ("breaks shipped mobile builds; treat it separately") was not enough to prevent this.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

Notes on the checklist: `/review-pr` has not been run. The only refactor is lifting `TestAddableUserList._create_game` to a module-level `_create_bot_seat_game` so both test classes share it. No visual changes — this is backend routing only, and the web app already calls the current paths.