### PR TITLE
Add a minimum client version gate for native builds

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,6 +4,7 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Router from "./Router";
 import { MaintenanceMode } from "./components/MaintenanceMode";
+import { UpdateGate } from "./components/UpdateGate";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { AuthProvider, useAuth } from "./auth";
 import { Toaster } from "./components/ui/sonner";
@@ -117,16 +118,18 @@ function App() {
       ) : (
         <MaybeGoogleOAuthProvider>
           <QueryClientProvider client={queryClient}>
-            <AuthProvider>
-              <AppContent />
-              <Toaster
-                position="top-center"
-                closeButton
-                richColors
-                duration={1200}
-                mobileOffset={{ top: "calc(72px + env(safe-area-inset-top, 0px))" }}
-              />
-            </AuthProvider>
+            <UpdateGate>
+              <AuthProvider>
+                <AppContent />
+                <Toaster
+                  position="top-center"
+                  closeButton
+                  richColors
+                  duration={1200}
+                  mobileOffset={{ top: "calc(72px + env(safe-area-inset-top, 0px))" }}
+                />
+              </AuthProvider>
+            </UpdateGate>
           </QueryClientProvider>
         </MaybeGoogleOAuthProvider>
       )}

--- a/packages/web/src/api/generated/endpoints.ts
+++ b/packages/web/src/api/generated/endpoints.ts
@@ -969,6 +969,7 @@ export interface VerifyEmail {
 export interface Version {
   environment: string;
   version: string;
+  minimumClientVersion: string;
 }
 
 export type ApiSchemaRetrieveParams = {

--- a/packages/web/src/components/UpdateGate.test.tsx
+++ b/packages/web/src/components/UpdateGate.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UpdateGate } from "./UpdateGate";
+import { APP_STORE_URL, PLAY_STORE_URL } from "@/constants";
+
+const mockIsNativePlatform = vi.fn();
+const mockIsIosPlatform = vi.fn();
+const mockGetInfo = vi.fn();
+const mockVersionRetrieve = vi.fn();
+
+vi.mock("@/utils/platform", () => ({
+  isNativePlatform: () => mockIsNativePlatform(),
+  isIosPlatform: () => mockIsIosPlatform(),
+}));
+
+vi.mock("@capacitor/app", () => ({
+  App: { getInfo: () => mockGetInfo() },
+}));
+
+vi.mock("@/api/generated/endpoints", async () => {
+  const actual = await vi.importActual("@/api/generated/endpoints");
+  return {
+    ...actual,
+    useVersionRetrieveSuspense: () => mockVersionRetrieve(),
+  };
+});
+
+const renderUpdateGate = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UpdateGate>
+        <div>App content</div>
+      </UpdateGate>
+    </QueryClientProvider>
+  );
+};
+
+describe("UpdateGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsNativePlatform.mockReturnValue(true);
+    mockIsIosPlatform.mockReturnValue(false);
+    mockGetInfo.mockResolvedValue({ version: "1.5.8" });
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "0.0.0" },
+    });
+  });
+
+  it("renders children on web without checking the app version", () => {
+    mockIsNativePlatform.mockReturnValue(false);
+    renderUpdateGate();
+    expect(screen.getByText("App content")).toBeInTheDocument();
+    expect(mockGetInfo).not.toHaveBeenCalled();
+  });
+
+  it("renders children when the native version matches the minimum", async () => {
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "1.5.8" },
+    });
+    renderUpdateGate();
+    expect(await screen.findByText("App content")).toBeInTheDocument();
+  });
+
+  it("renders children when the native version is above the minimum", async () => {
+    mockGetInfo.mockResolvedValue({ version: "1.10.0" });
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "1.9.0" },
+    });
+    renderUpdateGate();
+    expect(await screen.findByText("App content")).toBeInTheDocument();
+  });
+
+  it("blocks the app when the native version is below the minimum", async () => {
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "1.6.0" },
+    });
+    renderUpdateGate();
+    expect(await screen.findByText("Update required")).toBeInTheDocument();
+    expect(screen.queryByText("App content")).not.toBeInTheDocument();
+  });
+
+  it("links to the Play Store on Android", async () => {
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "1.6.0" },
+    });
+    renderUpdateGate();
+    expect(await screen.findByRole("link", { name: "Update Diplicity" })).toHaveAttribute(
+      "href",
+      PLAY_STORE_URL
+    );
+  });
+
+  it("links to the App Store on iOS", async () => {
+    mockIsIosPlatform.mockReturnValue(true);
+    mockVersionRetrieve.mockReturnValue({
+      data: { minimumClientVersion: "1.6.0" },
+    });
+    renderUpdateGate();
+    expect(await screen.findByRole("link", { name: "Update Diplicity" })).toHaveAttribute(
+      "href",
+      APP_STORE_URL
+    );
+  });
+
+  it("renders children when the version request fails", () => {
+    mockVersionRetrieve.mockImplementation(() => {
+      throw new Error("Network error");
+    });
+    renderUpdateGate();
+    expect(screen.getByText("App content")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/UpdateGate.tsx
+++ b/packages/web/src/components/UpdateGate.tsx
@@ -1,0 +1,105 @@
+import React, { Component, Suspense } from "react";
+import { App as CapacitorApp } from "@capacitor/app";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ArrowUpCircle } from "lucide-react";
+import { useVersionRetrieveSuspense } from "@/api/generated/endpoints";
+import { Button } from "@/components/ui/button";
+import { Notice } from "@/components/Notice";
+import { SafeAreaView } from "@/components/SafeAreaView";
+import { APP_STORE_URL, PLAY_STORE_URL } from "@/constants";
+import { isIosPlatform, isNativePlatform } from "@/utils/platform";
+
+const parseVersion = (version: string): number[] =>
+  version.split(".").map((part) => Number.parseInt(part, 10) || 0);
+
+const isBelowMinimum = (current: string, minimum: string): boolean => {
+  const currentParts = parseVersion(current);
+  const minimumParts = parseVersion(minimum);
+  const length = Math.max(currentParts.length, minimumParts.length);
+  for (let i = 0; i < length; i++) {
+    const currentPart = currentParts[i] ?? 0;
+    const minimumPart = minimumParts[i] ?? 0;
+    if (currentPart !== minimumPart) return currentPart < minimumPart;
+  }
+  return false;
+};
+
+const UpdateRequired: React.FC = () => (
+  <div className="max-w-sm mx-auto">
+    <SafeAreaView className="flex flex-col items-center justify-center min-h-screen">
+      <Notice
+        icon={ArrowUpCircle}
+        title="Update required"
+        message="This version of Diplicity is no longer supported. Update to the latest version to keep playing."
+        actions={
+          <Button asChild>
+            <a
+              href={isIosPlatform() ? APP_STORE_URL : PLAY_STORE_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Update Diplicity
+            </a>
+          </Button>
+        }
+      />
+    </SafeAreaView>
+  </div>
+);
+
+interface UpdateGateProps {
+  children: React.ReactNode;
+}
+
+const NativeUpdateGate: React.FC<UpdateGateProps> = ({ children }) => {
+  const { data: version } = useVersionRetrieveSuspense();
+  const { data: appInfo } = useSuspenseQuery({
+    queryKey: ["capacitorAppInfo"],
+    queryFn: () => CapacitorApp.getInfo(),
+  });
+
+  if (isBelowMinimum(appInfo.version, version.minimumClientVersion)) {
+    return <UpdateRequired />;
+  }
+  return <>{children}</>;
+};
+
+interface FailOpenBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+interface FailOpenBoundaryState {
+  failed: boolean;
+}
+
+class FailOpenBoundary extends Component<
+  FailOpenBoundaryProps,
+  FailOpenBoundaryState
+> {
+  constructor(props: FailOpenBoundaryProps) {
+    super(props);
+    this.state = { failed: false };
+  }
+
+  static getDerivedStateFromError(): FailOpenBoundaryState {
+    return { failed: true };
+  }
+
+  render() {
+    return this.state.failed ? this.props.fallback : this.props.children;
+  }
+}
+
+const UpdateGate: React.FC<UpdateGateProps> = ({ children }) => {
+  if (!isNativePlatform()) return <>{children}</>;
+  return (
+    <FailOpenBoundary fallback={children}>
+      <Suspense fallback={null}>
+        <NativeUpdateGate>{children}</NativeUpdateGate>
+      </Suspense>
+    </FailOpenBoundary>
+  );
+};
+
+export { UpdateGate };

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -1,5 +1,10 @@
 import { DurationEnum } from "@/api/generated/endpoints";
 
+export const APP_STORE_URL = "https://apps.apple.com/app/id6759169536";
+
+export const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.diplicityreact.app";
+
 export const DURATION_OPTIONS = [
   { value: "1 hour", label: "1 hour" },
   { value: "2 hours", label: "2 hours" },

--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -80,7 +80,11 @@ const recoveredCivilDisorderGames = new Set<string>();
 
 export const handlers = [
   http.get("*/version/", () =>
-    HttpResponse.json({ environment: "mock", version: "mock" } satisfies Version)
+    HttpResponse.json({
+      environment: "mock",
+      version: "mock",
+      minimumClientVersion: "0.0.0",
+    } satisfies Version)
   ),
 
   http.get("*/variants/", () =>

--- a/packages/web/src/screens/Login.test.tsx
+++ b/packages/web/src/screens/Login.test.tsx
@@ -15,7 +15,8 @@ vi.mock("@/auth", () => ({
   useAuth: () => ({ login: mockLogin }),
 }));
 
-vi.mock("@/api/generated/endpoints", () => ({
+vi.mock("@/api/generated/endpoints", async () => ({
+  ...(await vi.importActual("@/api/generated/endpoints")),
   useAuthAppleLoginCreate: () => ({
     mutateAsync: mockAppleMutateAsync,
     isPending: false,

--- a/packages/web/src/screens/Login.tsx
+++ b/packages/web/src/screens/Login.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { GuideContent } from "@/components/GuideContent";
+import { APP_STORE_URL, PLAY_STORE_URL } from "@/constants";
 import {
   Form,
   FormControl,
@@ -75,7 +76,7 @@ type LoginFormValues = z.infer<typeof loginSchema>;
 
 const PlayStoreBadge: React.FC = () => (
   <a
-    href="https://play.google.com/store/apps/details?id=com.diplicityreact.app"
+    href={PLAY_STORE_URL}
     target="_blank"
     rel="noreferrer"
     className="relative inline-block box-border overflow-hidden rounded-[6px] border border-[#a6a6a6]"
@@ -269,7 +270,7 @@ const Login: React.FC = () => {
           {(!isNativePlatform() || isIosPlatform()) && (
             <div className="flex items-center gap-3 mt-8">
               <a
-                href="https://apps.apple.com/app/id6759169536"
+                href={APP_STORE_URL}
                 target="_blank"
                 rel="noreferrer"
               >
@@ -410,7 +411,7 @@ const Login: React.FC = () => {
         {(!isNativePlatform() || isIosPlatform()) && (
           <div className="relative z-10 lg:hidden mt-6 flex items-center gap-3">
             <a
-              href="https://apps.apple.com/app/id6759169536"
+              href={APP_STORE_URL}
               target="_blank"
               rel="noreferrer"
             >

--- a/service/harness/generated/api.py
+++ b/service/harness/generated/api.py
@@ -354,6 +354,7 @@ class VerifyEmail(TypedDict):
 class Version(TypedDict):
     environment: str
     version: str
+    minimum_client_version: str
 
 
 class Victory(TypedDict):

--- a/service/openapi-schema.yaml
+++ b/service/openapi-schema.yaml
@@ -3710,8 +3710,11 @@ components:
           type: string
         version:
           type: string
+        minimumClientVersion:
+          type: string
       required:
       - environment
+      - minimumClientVersion
       - version
     Victory:
       type: object

--- a/service/project/settings.py
+++ b/service/project/settings.py
@@ -322,6 +322,7 @@ RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 VERSION = os.getenv("GIT_SHA", "0.0.0")
+MINIMUM_CLIENT_VERSION = os.getenv("MINIMUM_CLIENT_VERSION", "0.0.0")
 
 if DEBUG:
     ROOT_LOG_LEVEL = "INFO"

--- a/service/version/serializers.py
+++ b/service/version/serializers.py
@@ -4,3 +4,4 @@ from rest_framework import serializers
 class VersionSerializer(serializers.Serializer):
     environment = serializers.CharField()
     version = serializers.CharField()
+    minimum_client_version = serializers.CharField()

--- a/service/version/tests.py
+++ b/service/version/tests.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -12,8 +13,10 @@ class TestVersionRetrieveView:
         assert response.status_code == status.HTTP_200_OK
         assert "environment" in response.data
         assert "version" in response.data
+        assert "minimum_client_version" in response.data
         assert isinstance(response.data["environment"], str)
         assert isinstance(response.data["version"], str)
+        assert isinstance(response.data["minimum_client_version"], str)
 
     @pytest.mark.django_db
     def test_retrieve_version_unauthenticated(self, unauthenticated_client):
@@ -22,5 +25,21 @@ class TestVersionRetrieveView:
         assert response.status_code == status.HTTP_200_OK
         assert "environment" in response.data
         assert "version" in response.data
+        assert "minimum_client_version" in response.data
         assert isinstance(response.data["environment"], str)
         assert isinstance(response.data["version"], str)
+        assert isinstance(response.data["minimum_client_version"], str)
+
+    @pytest.mark.django_db
+    def test_retrieve_minimum_client_version_reflects_setting(self, unauthenticated_client):
+        url = reverse("version-retrieve")
+        with override_settings(MINIMUM_CLIENT_VERSION="1.6.0"):
+            response = unauthenticated_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["minimum_client_version"] == "1.6.0"
+
+    @pytest.mark.django_db
+    def test_retrieve_minimum_client_version_defaults_to_gate_disabled(self, unauthenticated_client):
+        url = reverse("version-retrieve")
+        response = unauthenticated_client.get(url)
+        assert response.data["minimum_client_version"] == "0.0.0"

--- a/service/version/utils.py
+++ b/service/version/utils.py
@@ -5,4 +5,5 @@ def get_version_data():
     return {
         "environment": settings.ENVIRONMENT,
         "version": settings.VERSION,
+        "minimum_client_version": settings.MINIMUM_CLIENT_VERSION,
     }


### PR DESCRIPTION
## What this PR does

Native builds bundle their web assets (`webDir: "dist"` in `packages/web/capacitor.config.ts`) and point at the production API baked in at build time, so an installed app runs **frozen JS against the live backend**. There is currently no API versioning and no client-version gate, so a breaking API change crashes shipped builds with no way to tell users why. This adds the floor.

**Backend**
- `MINIMUM_CLIENT_VERSION` env var (`service/project/settings.py`), surfaced as `minimum_client_version` on `GET /version/` via `get_version_data()` and `VersionSerializer`.
- Driving it from an env var rather than code means **raising the floor is a Railway config change, not a deploy** — which matters when you want to flip it in the same window as a store release.
- Defaults to `0.0.0`, so this ships **inert**: nothing is gated until the value is raised.

**Frontend**
- `UpdateGate` wraps the app inside `QueryClientProvider`. On native it compares the build version from `@capacitor/app`'s `App.getInfo()` against `minimumClientVersion` and renders a blocking update prompt when the build is too old.
- **Web is never gated** — `isNativePlatform()` short-circuits before any request is made.
- **Fails open.** If the version request errors (offline, backend hiccup) `FailOpenBoundary` renders the app rather than the wall. A version check that can brick the app on a network blip is worse than no check.
- Comparison is numeric per segment, so `1.10.0` correctly beats `1.9.0`.
- Store URLs moved to `src/constants.ts` since the wall and `Login.tsx` now share them.

## Why this has to ship before any breaking change

A force-update check only works if the **installed** build already contains it — 1.5.8 does not. So the gate cannot ride along with the refactor it is meant to protect: it has to reach installs first, then the floor gets raised on a later release. That is why this PR is deliberately inert.

## Screenshot

The wall is native-only, so it was captured by temporarily forcing it to render against `npm run dev:mocks` at a 390×844 viewport (the temporary patch is not in the diff). This environment cannot upload GitHub attachments — the PNG is delivered in the Claude session for drag-in.

## Notes

- `service/openapi-schema.internal.yaml` is untracked on `main` and stays untracked.
- Codegen was run natively (no docker daemon here) with the config `.claude/rules/backend/codegen.md` requires. `harness/generated/api.py` on `main` was generated **without** Firebase, so it was regenerated the same way to keep the diff to the one new field rather than bundling an unrelated `FCMDevice` restoration.
- `Login.test.tsx`'s `@/api/generated/endpoints` mock gained an `importActual` spread — `Login.tsx` now imports `@/constants`, which needs the real `DurationEnum`.

## Verification

- Backend: `pytest -n auto --create-db` → **2166 passed, 8 skipped**
- Frontend: `npx tsc -b --noEmit`, `npm run lint`, `npm run test` → **569 passed** across 63 files

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — taken, but this environment cannot upload attachments; delivered via the session for drag-in

---
_Generated by [Claude Code](https://claude.ai/code/session_01535zPH28Tppow2s6ryYu2P)_