### PR TITLE
Order the Finished games tab by completion date

### DIFF
--- a/packages/web/src/screens/Home/MyGames.test.tsx
+++ b/packages/web/src/screens/Home/MyGames.test.tsx
@@ -121,6 +121,19 @@ describe("MyGames empty states", () => {
   });
 });
 
+describe("MyGames ordering", () => {
+  it("requests the finished tab ordered by most recently finished", async () => {
+    const user = userEvent.setup();
+    renderMyGames();
+    const finishedTab = await screen.findByRole("tab", { name: /finished/i });
+    await user.click(finishedTab);
+
+    expect(mockUseGamesListInfinite).toHaveBeenLastCalledWith(
+      expect.objectContaining({ ordering: "finished" })
+    );
+  });
+});
+
 describe("MyGames eliminated games", () => {
   it("shows 'Eliminated' section header before eliminated games in the active tab", async () => {
     const activeGame = mockActiveGames[0];

--- a/packages/web/src/screens/Home/MyGames.tsx
+++ b/packages/web/src/screens/Home/MyGames.tsx
@@ -22,7 +22,7 @@ const statuses = [
     value: "completed",
     label: "Finished",
     statusFilter: "completed,abandoned",
-    ordering: undefined,
+    ordering: "finished",
   },
 ] as const;
 

--- a/service/game/filters.py
+++ b/service/game/filters.py
@@ -98,4 +98,6 @@ class GameFilter(django_filters.FilterSet):
                 F("next_deadline").asc(nulls_last=True),
                 "-created_at",
             )
+        if value == "finished":
+            return queryset.order_by("-finished_at")
         return queryset

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -1020,6 +1020,42 @@ class TestGameListViewOrdering:
         assert italy_game.id not in ordered_ids
         assert ordered_ids.index(classical_full.id) < ordered_ids.index(classical_empty.id)
 
+    @pytest.mark.django_db
+    def test_ordering_finished_most_recently_finished_first(
+        self, authenticated_client, primary_user, classical_variant, base_pending_phase
+    ):
+        completed_first = Game.objects.create(
+            name="Completed First",
+            variant=classical_variant,
+            status=GameStatus.COMPLETED,
+        )
+        base_pending_phase(completed_first)
+        completed_first.members.create(user=primary_user)
+
+        abandoned_later = Game.objects.create(
+            name="Abandoned Later",
+            variant=classical_variant,
+            status=GameStatus.ABANDONED,
+        )
+        base_pending_phase(abandoned_later)
+        abandoned_later.members.create(user=primary_user)
+
+        Game.objects.filter(id=completed_first.id).update(
+            finished_at=timezone.now() - timedelta(days=2)
+        )
+        Game.objects.filter(id=abandoned_later.id).update(
+            finished_at=timezone.now() - timedelta(days=1)
+        )
+
+        url = reverse(list_viewname)
+        response = authenticated_client.get(
+            url, {"mine": "true", "status": "completed,abandoned", "ordering": "finished"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        ordered_ids = [g["id"] for g in response.data["results"]]
+        assert ordered_ids.index(abandoned_later.id) < ordered_ids.index(completed_first.id)
+
 
 class TestGameListViewQueryPerformance:
 


### PR DESCRIPTION
## What this PR does

Orders games in the Finished tab of My Games by when they finished, most recently finished first, so a player can find a game that just ended without hunting for it. Previously the tab passed no `ordering`, so games fell back to the default `-created_at`, meaning a game that started long ago but only just finished sat far down the list.

Adds a `finished` branch to `GameFilter.filter_ordering` (`service/game/filters.py`) that orders on `-finished_at` (set on both completion and abandonment), and sets `ordering: "finished"` on the Finished tab entry in `MyGames.tsx`.

Closes #1237

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — no visual change here, only list ordering


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAjBRnTcmsqvxvPjXdbvLq)_