### PR TITLE
Add allow-builds-in-any-home-center adjudication modifier

### DIFF
--- a/service/adjudicator/tests.py
+++ b/service/adjudicator/tests.py
@@ -5118,14 +5118,21 @@ def _edges(*pairs) -> dict:
     return by_loc
 
 
-def make_variant(*, allow_non_home: bool = False) -> Variant:
+def make_variant(
+    *,
+    allow_non_home: bool = False,
+    any_home: bool = False,
+    neutral_home: bool = False,
+) -> Variant:
     """Construct the minimal test variant used across all engine tests.
 
     Provinces:
       - "lhs", "rhs", "ldd" : land. lhs and rhs are home SCs; ldd is a
         landlocked home SC of north (used for the fleet-in-landlocked
         build test).
-      - "mid"               : coastal SC, no home nation (neutral SC).
+      - "mid"               : coastal SC, no home nation (neutral SC),
+        unless `neutral_home` is set, in which case it is a home center
+        of the non-playable "neutral" nation.
       - "mlc"               : coastal SC, home of north, with two named
         coasts (mlc/nc, mlc/sc) — used for the fleet-multi-coast test.
       - "iso", "far"        : coastal non-SC; iso is adjacent to mid,
@@ -5135,6 +5142,13 @@ def make_variant(*, allow_non_home: bool = False) -> Variant:
     The `allow_non_home` flag adds the adjudication modifier that
     permits builds in any owned supply center, exercising the
     BuildLocationIsHomeCenter check from both sides.
+
+    The `any_home` flag adds the adjudication modifier that permits
+    builds in any owned supply center that is a home center of any
+    nation, including non-playable neutral nations.
+
+    The `neutral_home` flag makes "mid" a home center of a non-playable
+    "neutral" nation instead of having no home nation.
     """
     edges = _edges(
         ("lhs", "rhs", "both"),
@@ -5159,7 +5173,11 @@ def make_variant(*, allow_non_home: bool = False) -> Variant:
             "rhs", ProvinceType.LAND, sc=True, home=SOUTH, adj=edges.get("rhs", ())
         ),
         "mid": _province(
-            "mid", ProvinceType.COASTAL, sc=True, home=None, adj=edges.get("mid", ())
+            "mid",
+            ProvinceType.COASTAL,
+            sc=True,
+            home="neutral" if neutral_home else None,
+            adj=edges.get("mid", ()),
         ),
         "ldd": _province(
             "ldd", ProvinceType.LAND, sc=True, home=NORTH, adj=edges.get("ldd", ())
@@ -5207,6 +5225,19 @@ def make_variant(*, allow_non_home: bool = False) -> Variant:
             ),
         ),
     )
+    modifiers = []
+    if allow_non_home:
+        modifiers.append("allow-builds-in-non-home-centers")
+    if any_home:
+        modifiers.append("allow-builds-in-any-home-center")
+    nations = [
+        Nation(id=NORTH, name="North", color="#000000"),
+        Nation(id=SOUTH, name="South", color="#ffffff"),
+    ]
+    if neutral_home:
+        nations.append(
+            Nation(id="neutral", name="Neutral", color="#888888", non_playable=True)
+        )
     return Variant(
         id="test",
         name="Test",
@@ -5214,14 +5245,9 @@ def make_variant(*, allow_non_home: bool = False) -> Variant:
         author="",
         victory_conditions=(SupplyCenterMajorityVictory(supply_centers=99),),
         rules=None,
-        adjudication_modifiers=(
-            ("allow-builds-in-non-home-centers",) if allow_non_home else ()
-        ),
+        adjudication_modifiers=tuple(modifiers),
         phase_progression=progression,
-        nations=(
-            Nation(id=NORTH, name="North", color="#000000"),
-            Nation(id=SOUTH, name="South", color="#ffffff"),
-        ),
+        nations=tuple(nations),
         provinces=provinces,
         named_coasts=named_coasts,
         dominance_rules=(),
@@ -7007,6 +7033,112 @@ def test_build_at_non_home_center_with_modifier_is_ok():
 
     assert _resolution(result, "mid") == Status.OK
     assert _unit_at(result, "mid") is not None
+
+
+def test_build_at_captured_enemy_home_center_without_modifier_is_illegal():
+    variant = make_variant()
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[
+            SupplyCenter(nation=SOUTH, province="rhs"),
+            SupplyCenter(nation=SOUTH, province="lhs"),
+        ],
+        orders=[
+            RawOrder(
+                nation=SOUTH,
+                source="lhs",
+                order_type="Build",
+                target="lhs",
+                unit_type=Unit.ARMY,
+            )
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "lhs") == Status.ILLEGAL
+
+
+def test_build_at_captured_enemy_home_center_with_any_home_modifier_is_ok():
+    variant = make_variant(any_home=True)
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[
+            SupplyCenter(nation=SOUTH, province="rhs"),
+            SupplyCenter(nation=SOUTH, province="lhs"),
+        ],
+        orders=[
+            RawOrder(
+                nation=SOUTH,
+                source="lhs",
+                order_type="Build",
+                target="lhs",
+                unit_type=Unit.ARMY,
+            )
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "lhs") == Status.OK
+    assert _unit_at(result, "lhs") is not None
+
+
+def test_build_at_neutral_home_center_with_any_home_modifier_is_ok():
+    variant = make_variant(any_home=True, neutral_home=True)
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[
+            SupplyCenter(nation=NORTH, province="lhs"),
+            SupplyCenter(nation=NORTH, province="mid"),
+        ],
+        orders=[
+            RawOrder(
+                nation=NORTH,
+                source="mid",
+                order_type="Build",
+                target="mid",
+                unit_type=Unit.ARMY,
+            )
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "mid") == Status.OK
+    assert _unit_at(result, "mid") is not None
+
+
+def test_build_at_no_home_nation_sc_with_any_home_modifier_is_illegal():
+    variant = make_variant(any_home=True)
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[
+            SupplyCenter(nation=NORTH, province="lhs"),
+            SupplyCenter(nation=NORTH, province="mid"),
+        ],
+        orders=[
+            RawOrder(
+                nation=NORTH,
+                source="mid",
+                order_type="Build",
+                target="mid",
+                unit_type=Unit.ARMY,
+            )
+        ],
+    )
+
+    result = Engine().adjudicate(state)
+
+    assert _resolution(result, "mid") == Status.ILLEGAL
 
 
 def test_build_at_occupied_province_is_illegal():
@@ -10965,6 +11097,24 @@ def test_options_adjustment_build_excludes_non_home_sc_without_modifier():
     build_sources = {o.source for o in options if o.order_type == "Build"}
     assert "mid" not in build_sources
     assert "lhs" in build_sources
+
+
+def test_options_adjustment_build_with_any_home_modifier_offers_captured_home_excludes_no_home():
+    variant = make_variant(any_home=True)
+    state = make_state(
+        variant,
+        phase_type=Phase.ADJUSTMENT,
+        units=[],
+        supply_centers=[
+            SupplyCenter(nation=SOUTH, province="rhs"),
+            SupplyCenter(nation=SOUTH, province="lhs"),
+            SupplyCenter(nation=SOUTH, province="mid"),
+        ],
+    )
+    options = get_options(state)
+    build_sources = {o.source for o in options if o.order_type == "Build"}
+    assert "lhs" in build_sources
+    assert "mid" not in build_sources
 
 
 def test_options_adjustment_no_builds_when_no_allowed_builds():

--- a/service/adjudicator/types.py
+++ b/service/adjudicator/types.py
@@ -90,11 +90,15 @@ class OrderType:
 # Variant modifier id permitting builds in any owned supply center.
 ALLOW_NON_HOME_BUILDS: str = "allow-builds-in-non-home-centers"
 
+# Variant modifier id permitting builds in any owned supply center that is a
+# home center of any nation, including non-playable neutral nations.
+ANY_HOME_CENTER_BUILDS: str = "allow-builds-in-any-home-center"
+
 # Variant modifier id enabling auto-rebuild for non-playable nations.
 NEUTRAL_NATIONS_AUTO_BUILD: str = "neutral-nations-auto-build"
 
 SUPPORTED_ADJUDICATION_MODIFIERS: frozenset = frozenset(
-    {ALLOW_NON_HOME_BUILDS, NEUTRAL_NATIONS_AUTO_BUILD}
+    {ALLOW_NON_HOME_BUILDS, ANY_HOME_CENTER_BUILDS, NEUTRAL_NATIONS_AUTO_BUILD}
 )
 
 
@@ -547,7 +551,10 @@ class BuildLocationIsOwnedCheck(Check):
 class BuildLocationIsHomeCenterCheck(Check):
     """The build location's parent supply center must be a home center of
     the building nation, unless the variant declares the
-    `allow-builds-in-non-home-centers` adjudication modifier."""
+    `allow-builds-in-non-home-centers` adjudication modifier (any owned
+    supply center) or the `allow-builds-in-any-home-center` adjudication
+    modifier (any owned supply center that is a home center of any nation,
+    including non-playable neutral nations)."""
 
     MESSAGE = "Build location is not a home supply center for this nation."
 
@@ -558,6 +565,8 @@ class BuildLocationIsHomeCenterCheck(Check):
             return True
         parent = state.variant().parent_of(order.location)
         province = state.variant().provinces.get(parent)
+        if ANY_HOME_CENTER_BUILDS in state.variant().adjudication_modifiers:
+            return province is not None and province.home_nation is not None
         return province is not None and province.home_nation == order.nation
 
 

--- a/service/variant/tests.py
+++ b/service/variant/tests.py
@@ -327,6 +327,12 @@ class TestVariantToCanonicalDict:
         deserialize_variant(canonical)
 
     @pytest.mark.django_db
+    def test_any_home_center_builds_modifier_accepted(self, classical_variant):
+        canonical = variant_to_canonical_dict(classical_variant)
+        canonical["adjudicationModifiers"] = ["allow-builds-in-any-home-center"]
+        deserialize_variant(canonical)
+
+    @pytest.mark.django_db
     def test_unknown_modifier_raises_variant_validation_error(self, classical_variant):
         canonical = variant_to_canonical_dict(classical_variant)
         canonical["adjudicationModifiers"] = ["not-a-real-modifier"]


### PR DESCRIPTION
## What this PR does

Adds a third, opt-in build rule as an adjudication modifier: `allow-builds-in-any-home-center`. With it set, a nation may build in any vacant supply center it currently owns that is a home center of *any* nation — including non-playable neutral nations — but not in supply centers that started with no home nation. This sits between the existing default (own home centers only) and `allow-builds-in-non-home-centers` (any owned SC, used by the Hundred variant).

Closes #998

All engine changes are in `service/adjudicator/types.py`: a new `ANY_HOME_CENTER_BUILDS` constant added to `SUPPORTED_ADJUDICATION_MODIFIERS` (so `deserialize_variant` accepts it with no serializer change needed), and a new branch in `BuildLocationIsHomeCenterCheck.check` that returns whether the build location's province has any `home_nation` set, resolved via `parent_of` exactly as the classical branch does.

Tests extend the `make_variant` test helper in `service/adjudicator/tests.py` with `any_home` and `neutral_home` flags, following the existing pattern for the non-home-centers modifier, and cover: building on a captured enemy home center (with and without the modifier), building on a neutral nation's home center with the modifier, building on a no-home-nation SC remaining illegal even with the modifier, and the corresponding options-generation case. A test in `service/variant/tests.py` confirms `deserialize_variant` accepts the new modifier.

No model change, no migration, no codegen — the modifier travels in the existing `Variant.adjudication_modifiers` JSON list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A185UKqQi7wkQc8Vqyeyy5)_