### PR TITLE
Bump version to 1.5.9 for iOS release

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diplicity-react",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diplicity-react",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "dependencies": {
         "@capacitor-firebase/messaging": "^8.1.0",
         "@capacitor/android": "^8.3.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "diplicity-react",
   "private": true,
-  "version": "1.5.8",
+  "version": "1.5.9",
   "type": "module",
   "scripts": {
     "dev": "vite --host",


### PR DESCRIPTION
## What this PR does

Bumps the app version from 1.5.8 to 1.5.9 in `packages/web/package.json` (and the lockfile) so the next Fastlane release cuts a new iOS build — Fastlane reads this field to set `MARKETING_VERSION`.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

No tests or screenshots apply — this is a version string bump with no behavioral or visual change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqRbL67teQnguFZ73mHoJQ)_