### PR TITLE
Bump Ruby to 3.3 in mobile release workflows

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           working-directory: packages/web
 

--- a/.github/workflows/ios-pr-build.yml
+++ b/.github/workflows/ios-pr-build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           working-directory: packages/web
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           working-directory: packages/web
 


### PR DESCRIPTION
## What this PR does

Fixes the [iOS release workflow failure](https://github.com/johnpooch/diplicity-react/actions/runs/32757312228/job/97527724272) by bumping Ruby from 3.2 to 3.3 in `ios-release.yml`, `ios-pr-build.yml`, and `android-release.yml`.

Root cause: the dependabot bundler-dependencies bump in #1228 pulled fastlane up to 2.238.0, which now depends on `excon` 1.7.0 — a gem that requires Ruby >= 3.3.0. All three workflows share `packages/web/Gemfile.lock` and were still pinned to Ruby 3.2, so `bundle install` failed with exit code 5 as soon as that lockfile change reached `main` (the first affected run was triggered by the version bump in #1241).

Verified locally with Ruby 3.3.6 that `bundle install` against the current `Gemfile.lock` now completes cleanly.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [ ] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

No tests or screenshots apply — this is a CI workflow configuration fix with no application code or visual change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqRbL67teQnguFZ73mHoJQ)_