### PR TITLE
Expire push notifications so backlogs are dropped, not dumped

### DIFF
--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -16,6 +16,7 @@ from notification.models import Notification, NotificationDelivery
 from notification.registry import REGISTRY as NOTIFICATION_REGISTRY
 from notification.registry import ChannelMessageSpec
 from notification.tasks import PRUNE_AFTER_DAYS, deliver, prune
+from notification.utils import PUSH_TTL, build_push_message
 from phase.models import Phase
 from user_profile.models import UserProfile
 from victory.models import Victory
@@ -853,3 +854,22 @@ class TestNotificationPrune:
 
         assert not Notification.objects.filter(id=old.id).exists()
         assert Notification.objects.filter(id=recent.id).exists()
+
+
+class TestBuildPushMessage:
+    def test_sets_matching_expiry_on_every_transport(self):
+        now = timezone.now()
+        with patch("notification.utils.timezone.now", return_value=now):
+            message = build_push_message("Game", "Started", "game_start")
+
+        assert message.android.ttl == PUSH_TTL
+        assert message.apns.headers["apns-expiration"] == str(int((now + PUSH_TTL).timestamp()))
+        assert message.webpush.headers["TTL"] == str(int(PUSH_TTL.total_seconds()))
+
+    def test_adds_event_type_to_data_without_mutating_the_delivery_payload(self):
+        data = {"game_id": "1"}
+
+        message = build_push_message("Game", "Started", "game_start", data)
+
+        assert message.data == {"game_id": "1", "type": "game_start"}
+        assert data == {"game_id": "1"}

--- a/service/notification/utils.py
+++ b/service/notification/utils.py
@@ -1,7 +1,34 @@
 import logging
+from datetime import timedelta
+
 from django.conf import settings
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+
+PUSH_TTL = timedelta(hours=1)
+
+
+def build_push_message(title, body, notification_type, data=None):
+    from firebase_admin.messaging import (
+        APNSConfig,
+        AndroidConfig,
+        Message,
+        Notification,
+        WebpushConfig,
+    )
+
+    message_data = dict(data or {})
+    message_data["type"] = notification_type
+    expiration = int((timezone.now() + PUSH_TTL).timestamp())
+
+    return Message(
+        notification=Notification(title=title, body=body),
+        data=message_data,
+        android=AndroidConfig(ttl=PUSH_TTL),
+        apns=APNSConfig(headers={"apns-expiration": str(expiration)}),
+        webpush=WebpushConfig(headers={"TTL": str(int(PUSH_TTL.total_seconds()))}),
+    )
 
 
 def send_notification_to_users(user_ids, title, body, notification_type, data=None):
@@ -12,22 +39,27 @@ def send_notification_to_users(user_ids, title, body, notification_type, data=No
         return
 
     from fcm_django.models import FCMDevice
-    from firebase_admin.messaging import Message, Notification
 
     devices = FCMDevice.objects.filter(user_id__in=user_ids, active=True)
     if not devices.exists():
         return
 
-    message_data = data or {}
-    message_data["type"] = notification_type
-
-    message = Message(
-        notification=Notification(title=title, body=body),
-        data=message_data,
-    )
+    message = build_push_message(title, body, notification_type, data)
 
     try:
-        devices.send_message(message)
-        logger.info(f"Sent {notification_type} notification to {len(user_ids)} users")
+        result = devices.send_message(message)
     except Exception as e:
         logger.error(f"Failed to send {notification_type} notification: {str(e)}")
+        return
+
+    logger.info(
+        f"Sent {notification_type} notification to {len(result.registration_ids_sent)} device(s) "
+        f"for {len(user_ids)} user(s): {result.success_count} delivered to FCM, "
+        f"{result.failure_count} rejected, "
+        f"{len(result.deactivated_registration_ids)} token(s) deactivated"
+    )
+    if result.has_failures:
+        logger.error(
+            f"FCM rejected {result.failure_count} of {len(result.registration_ids_sent)} "
+            f"{notification_type} message(s): {result.failed_exceptions}"
+        )


### PR DESCRIPTION
## What this PR does

Players reported being hit with bursts of "random" notifications for phases that had already passed. Production data shows the backend behaved correctly — each notification was created once, at the right time, for the right recipient — and the whole burst landed on the device at once, hours later. `service/notification/utils.py` built the FCM `Message` with no TTL, so FCM/APNs applied their four-week default, stored every undelivered message, and handed the device its entire backlog on reconnect. This sets a one-hour expiry on the Android, APNs and Webpush transports so stale nudges are dropped instead.

### Evidence

For the reporting player (user 4018), the nine notifications on their lock screen map exactly one-to-one onto nine `notification_notification` rows — created between 03:49 and 22:45 on the same day, each exactly once:

| created_at (UTC) | heading | body |
| --- | --- | --- |
| 03:49:01 | The Exchange of the Lachrymose Land | Fall 1962, Retreat has been resolved |
| 03:52:07 | The Encounter of the Irate Snake | Fall 4, Adjustment has been resolved |
| 06:59:01 | The Dissension of the Arcadian Organization | Spring 1955, Movement has been resolved |
| 07:06:17 | The Tiff of the Recondite Desire | Spring 1494, Retreat has been resolved |
| 13:26:05 | The Rivalry of the Defamatory Memory | Fall 1962, Movement has been resolved |
| 13:26:05 | Civil Disorder | NATO entered civil disorder. |
| 16:17:01 | The Disagreement of the Turbulent Government | Spring 1903, Movement has been resolved |
| 21:23:57 | The Match of the Garrulous Group | Spring 1902, Movement has been resolved |
| 22:45:01 | The Contention of the Draconian Decision | Fall 1904, Movement has been resolved |

The lock screen showed the newest of these as "1m ago" and the other eight as "now" — the live one arrived on time, then the backlog flushed behind it.

Supporting checks, all clean:

- The player is a member of all eight games, so `get_recipients()` targeted correctly.
- Every `notification.deliver` job succeeded on its first attempt within seconds of being deferred (12,454 jobs over two days, zero retries, max lag 120s, mean 2.5s).
- The player has one active `ios` device, same registration token since 9 Aug — no duplicate or reassigned tokens.
- `registration_id` is unique across the whole table, so no two accounts share a token.

The one device-table anomaly — 38 users with more than one active device of the same type — is legacy residue: the newest such row predates the dedup in `NotificationDeviceViewSet`, and `deactivate_stale_devices` cleans it up. It is not the cause here.

### Why one hour

These notifications are nudges to open the app, and the app shows current state on arrival. A "Spring 1903 has been resolved" alert delivered when the game is already in Fall 1904 is worse than no alert. One hour keeps the nudge useful for slow games while making a long offline period silent. `PUSH_TTL` is a single constant if that turns out to be too aggressive.

### Also in this PR

`send_notification_to_users` discarded the FCM response and logged success unconditionally, so a send where every message was rejected logged identically to one where every message landed. It now logs the delivered/rejected/deactivated counts, and logs the failures at error level. This is what made the incident hard to diagnose from logs alone.

### Not done here

Per-notification collapse keys (`apns-collapse-id` / `collapse_key`) would stop 14 phase-resolution alerts from one fast game stacking up on the lock screen, which is the other half of the "went crazy" complaint. Left out deliberately: FCM only honours four distinct collapse keys per device and drops the rest arbitrarily, so it needs its own design and its own PR.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — backend only, nothing visual changed

> Note: this is the 6th open PR, over the project's ≤ 5 target.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtCmBGedJ1YbckSwqfsriE)_