### PR TITLE
Keep an uploaded picture across Google sign-in

### DIFF
--- a/service/login/serializers.py
+++ b/service/login/serializers.py
@@ -56,7 +56,7 @@ class GoogleAuthSerializer(serializers.Serializer):
             user=user,
             defaults={"name": name, "picture": id_info.get("picture")},
         )
-        if not created:
+        if not created and not profile.has_uploaded_picture:
             profile.picture = id_info.get("picture")
             profile.save(update_fields=["picture"])
         refresh = RefreshToken.for_user(user)

--- a/service/login/tests.py
+++ b/service/login/tests.py
@@ -1,3 +1,4 @@
+import io
 import json
 
 import pytest
@@ -11,7 +12,7 @@ from google.auth.exceptions import GoogleAuthError
 from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.tokens import RefreshToken
-from user_profile.models import UserProfile
+from user_profile.models import UserProfile, UserProfilePicture
 
 User = get_user_model()
 
@@ -111,6 +112,27 @@ class TestGoogleAuthView:
         assert user_profile.picture is None
         assert user_profile.name == "Test User"
         assert user_profile.user.email == "test@example.com"
+
+    def test_uploaded_picture_is_not_overwritten(
+        self, unauthenticated_client, mock_google_auth, mock_refresh_token, make_image
+    ):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123"
+        )
+        user_profile = UserProfile.objects.create(user=user, name="Test User")
+        buffer = io.BytesIO()
+        make_image().save(buffer, format="PNG")
+        picture = UserProfilePicture.objects.store(user_profile, buffer.getvalue(), "image/png")
+
+        url = reverse("auth")
+        response = unauthenticated_client.post(url, {"id_token": "valid_token"}, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+        user_profile.refresh_from_db()
+        assert user_profile.picture is None
+        assert user_profile.uploaded_picture.content_hash == picture.content_hash
 
     def test_creates_new_user_without_name(
         self, unauthenticated_client, mock_google_auth_without_name, mock_refresh_token

--- a/service/user_profile/models.py
+++ b/service/user_profile/models.py
@@ -54,6 +54,10 @@ class UserProfile(BaseModel):
     def is_bot(self):
         return self.kind != UserKind.HUMAN
 
+    @property
+    def has_uploaded_picture(self) -> bool:
+        return UserProfilePicture.objects.filter(profile=self).exists()
+
     def picture_url(self, request=None) -> str | None:
         try:
             picture = self.uploaded_picture


### PR DESCRIPTION
## What this PR does

Google sign-in wrote `id_info.get("picture")` over `UserProfile.picture` on every login (`service/login/serializers.py:59-61`), so a user who had uploaded their own picture and then signed in with Google had the Google URL written back underneath it. `GoogleAuthSerializer.create` now writes the Google URL only when the profile has no uploaded picture, so an upload survives any number of subsequent sign-ins. Closes #1253.

The check reads through a new `UserProfile.has_uploaded_picture` property, which sits next to the existing `picture_url` resolution rather than putting knowledge of `UserProfilePicture` in the login app.

Serving behaviour is unchanged: `picture_url` already preferred the uploaded image, so this only stops the stale Google URL being stored as the fallback that a later removal would fall back to.

Test added in `service/login/tests.py` — it fails on `main` and passes here; `login` and `user_profile` suites pass (171 tests).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — backend only, nothing visual changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCAhLz2Rm2nvu9wcuG2h8s)_