### PR TITLE
Stop notifying kicked and replaced members of game-wide events

### DIFF
--- a/service/emit/tests.py
+++ b/service/emit/tests.py
@@ -42,7 +42,7 @@ class TestEmitDispatch:
         state = _build_game_state(game_factory, member_factory, user_factory, classical_variant, with_game_master=True)
         emit.emit("game_start", game=state["game"])
 
-        member_ids = set(state["game"].member_user_ids(include_gm=True))
+        member_ids = state["game"].seated_member_user_ids()
         notifications = Notification.objects.filter(event_type="game_start", recipient_id__in=member_ids)
         assert set(notifications.values_list("recipient_id", flat=True)) == {
             state["active_one"].user_id,

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -685,32 +685,23 @@ class Game(BaseModel):
 
             emit("game_admin_reassigned", game=self)
 
-    def notification_user_ids(self, exclude_user_id=None, active_only=False):
-        members = self.members.filter(eliminated=False, kicked=False) if active_only else self.members.all()
-        user_ids = {
-            member.user_id for member in members
-            if member.user_id is not None
-        }
-        if self.game_master_id is not None:
-            user_ids.add(self.game_master_id)
-        if exclude_user_id is not None:
-            user_ids.discard(exclude_user_id)
-        return list(user_ids)
-
     def _with_game_master(self, user_ids):
         result = set(user_ids)
         if self.game_master_id is not None:
             result.add(self.game_master_id)
         return result
 
-    def member_user_ids(self, include_gm=False):
-        ids = {m.user_id for m in self.members.all() if m.user_id is not None}
-        return self._with_game_master(ids) if include_gm else ids
+    def seated_member_user_ids(self):
+        ids = {
+            m.user_id for m in self.members.all()
+            if m.user_id is not None and not m.kicked
+        }
+        return self._with_game_master(ids)
 
-    def active_member_user_ids(self, include_gm=False):
+    def active_member_user_ids(self):
         active = self.members.filter(eliminated=False, kicked=False, civil_disorder=False)
         ids = {m.user_id for m in active if m.user_id is not None}
-        return self._with_game_master(ids) if include_gm else ids
+        return self._with_game_master(ids)
 
     def winner_members(self):
         victory = Victory.objects.filter(game=self).prefetch_related("members").first()

--- a/service/game/views.py
+++ b/service/game/views.py
@@ -151,7 +151,7 @@ class GameDeleteView(SelectedGameMixin, generics.DestroyAPIView):
             and instance.game_master_id is not None
             and instance.game_master_id == self.request.user.id
         )
-        user_ids = instance.notification_user_ids(exclude_user_id=self.request.user.id)
+        user_ids = list(instance.seated_member_user_ids() - {self.request.user.id})
         game_name = instance.name
         instance.delete()
         if is_game_master_delete:

--- a/service/notification/registry.py
+++ b/service/notification/registry.py
@@ -128,7 +128,7 @@ class DrawProposalSpec(NotificationSpec):
     exclude_actor = True
 
     def get_audience(self):
-        return self.context.game.active_member_user_ids(include_gm=True)
+        return self.context.game.active_member_user_ids()
 
     def get_link(self):
         return f"{self._game_url()}/phase/{self.context.phase.id}/draw-proposals"
@@ -142,7 +142,7 @@ class GameStartSpec(NotificationSpec):
     channels = [Channel.PUSH, Channel.EMAIL]
 
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_body(self):
         return "The game has started. You can now chat with other players and submit your orders. Good luck!"
@@ -154,7 +154,7 @@ class GameStartSpec(NotificationSpec):
 @register("game_draw")
 class GameDrawSpec(NotificationSpec):
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_body(self):
         names = ", ".join(member.name for member in self.context.game.winner_members())
@@ -173,7 +173,7 @@ class GameSoloWinSpec(NotificationSpec):
 @register("game_solo_loss")
 class GameSoloLossSpec(NotificationSpec):
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True) - self.context.game.winner_user_ids()
+        return self.context.game.seated_member_user_ids() - self.context.game.winner_user_ids()
 
     def get_body(self):
         winners = self.context.game.winner_members()
@@ -186,7 +186,7 @@ class PhaseResolvedSpec(NotificationSpec):
     channels = [Channel.PUSH, Channel.EMAIL]
 
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_body(self):
         return f"{self.context.phase.name} has been resolved"
@@ -200,7 +200,7 @@ class PhaseResolvedEarlySpec(NotificationSpec):
     channels = [Channel.PUSH, Channel.EMAIL]
 
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_body(self):
         return f"{self.context.phase.name} resolved early — all players confirmed their orders."
@@ -232,7 +232,7 @@ class GameManagementSpec(NotificationSpec):
     exclude_actor = True
 
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def manager_label(self):
         label = self.context.game.manager_label
@@ -283,7 +283,7 @@ class SeatFilledSpec(NotificationSpec):
     exclude_actor = True
 
     def get_audience(self):
-        return self.context.game.active_member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_title(self):
         return "Seat Filled"
@@ -306,7 +306,7 @@ class CivilDisorderSpec(NotificationSpec):
     channels = [Channel.PUSH, Channel.EMAIL]
 
     def get_audience(self):
-        return self.context.game.active_member_user_ids(include_gm=True)
+        return self.context.game.active_member_user_ids()
 
     def get_link(self):
         return None
@@ -326,7 +326,7 @@ class CivilDisorderRecoverySpec(NotificationSpec):
     exclude_actor = True
 
     def get_audience(self):
-        return self.context.game.active_member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_link(self):
         return None
@@ -363,7 +363,7 @@ class NmrExtensionUsedSpec(NotificationSpec):
 @register("nmr_extension_applied")
 class NmrExtensionAppliedSpec(NotificationSpec):
     def get_audience(self):
-        return self.context.game.member_user_ids(include_gm=True)
+        return self.context.game.seated_member_user_ids()
 
     def get_body(self):
         deadline = self.context.phase.formatted_deadline

--- a/service/notification/tests.py
+++ b/service/notification/tests.py
@@ -12,6 +12,7 @@ from common.constants import DeadlineMode, GameStatus, PhaseFrequency, PhaseStat
 from draw_proposal.models import DrawProposal
 from emit.context import build_context
 from game.models import Game
+from member.models import Member
 from notification.models import Notification, NotificationDelivery
 from notification.registry import REGISTRY as NOTIFICATION_REGISTRY
 from notification.registry import ChannelMessageSpec
@@ -166,6 +167,8 @@ def emit_game(db, game_factory, member_factory, user_factory, classical_variant)
         eliminated = member_factory(game=game, user=user_factory(), eliminated=True)
         kicked = member_factory(game=game, user=user_factory(), kicked=True)
         civil = member_factory(game=game, user=user_factory(), civil_disorder=True)
+        replaced = member_factory(game=game, user=user_factory())
+        replacement = Member.objects.hand_over_seat(replaced, user_factory())
         return {
             "game": game,
             "game_master": game_master,
@@ -174,6 +177,8 @@ def emit_game(db, game_factory, member_factory, user_factory, classical_variant)
             "eliminated": eliminated,
             "kicked": kicked,
             "civil": civil,
+            "replaced": replaced,
+            "replacement": replacement,
         }
 
     return _create
@@ -210,12 +215,13 @@ class TestRegistry:
 
 
 class TestActiveResolver:
-    def test_civil_disorder_excludes_eliminated_kicked_civil_and_includes_game_master(self, emit_game):
+    def test_civil_disorder_excludes_eliminated_kicked_replaced_civil_and_includes_game_master(self, emit_game):
         state = emit_game(with_game_master=True)
         result = resolve_recipients("civil_disorder", game=state["game"])
         assert result == {
             state["active_one"].user_id,
             state["active_two"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 
@@ -225,31 +231,62 @@ class TestActiveResolver:
         assert result == {
             state["active_one"].user_id,
             state["active_two"].user_id,
+            state["replacement"].user_id,
         }
 
 
-class TestAllRecipientsResolver:
+class TestSeatedResolver:
     @pytest.mark.parametrize(
         "event_type",
         ["game_start", "game_draw", "phase_resolved", "phase_resolved_early"],
     )
-    def test_includes_eliminated_and_kicked_and_game_master(self, emit_game, event_type):
+    def test_includes_eliminated_and_civil_disorder_but_not_kicked_or_replaced(self, emit_game, event_type):
         state = emit_game(with_game_master=True)
         result = resolve_recipients(event_type, game=state["game"])
         assert result == {
             state["active_one"].user_id,
             state["active_two"].user_id,
             state["eliminated"].user_id,
-            state["kicked"].user_id,
             state["civil"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 
-
-class TestAllPlayersExceptActorResolver:
     @pytest.mark.parametrize(
         "event_type",
-        ["game_paused", "game_resumed", "game_deadline_extended"],
+        [
+            "game_start",
+            "game_draw",
+            "game_solo_loss",
+            "phase_resolved",
+            "phase_resolved_early",
+            "game_paused",
+            "game_resumed",
+            "game_deadline_extended",
+            "nmr_extension_applied",
+            "seat_filled",
+            "civil_disorder_recovery",
+        ],
+    )
+    def test_kicked_and_replaced_members_are_not_notified(self, emit_game, event_type):
+        state = emit_game(with_game_master=True)
+        result = resolve_recipients(
+            event_type, game=state["game"], actor=state["active_one"].user
+        )
+        assert state["kicked"].user_id not in result
+        assert state["replaced"].user_id not in result
+
+
+class TestSeatedExceptActorResolver:
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "game_paused",
+            "game_resumed",
+            "game_deadline_extended",
+            "seat_filled",
+            "civil_disorder_recovery",
+        ],
     )
     def test_excludes_the_actor(self, emit_game, event_type):
         state = emit_game(with_game_master=True)
@@ -259,8 +296,8 @@ class TestAllPlayersExceptActorResolver:
         assert result == {
             state["active_two"].user_id,
             state["eliminated"].user_id,
-            state["kicked"].user_id,
             state["civil"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 
@@ -275,17 +312,8 @@ class TestAllPlayersExceptActorResolver:
 
 
 class TestActiveExceptActorResolver:
-    def test_civil_disorder_recovery_excludes_eliminated_kicked_civil_disorder_and_actor(self, emit_game):
-        state = emit_game(with_game_master=True)
-        actor = state["active_one"].user
-        result = resolve_recipients("civil_disorder_recovery", game=state["game"], actor=actor)
-        assert result == {
-            state["active_two"].user_id,
-            state["game_master"].id,
-        }
-
     @pytest.mark.django_db
-    def test_draw_proposal_excludes_eliminated_kicked_civil_disorder_and_actor(self, emit_game):
+    def test_draw_proposal_excludes_eliminated_kicked_replaced_civil_disorder_and_actor(self, emit_game):
         state = emit_game(with_game_master=True)
         phase = Phase.objects.create(
             game=state["game"],
@@ -302,6 +330,7 @@ class TestActiveExceptActorResolver:
         result = resolve_recipients("draw_proposal", draw_proposal=proposal)
         assert result == {
             state["active_two"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 
@@ -325,8 +354,8 @@ class TestWinnersResolver:
         assert result == {
             state["active_two"].user_id,
             state["eliminated"].user_id,
-            state["kicked"].user_id,
             state["civil"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 
@@ -339,8 +368,8 @@ class TestNmrExtensionAppliedResolver:
             state["active_one"].user_id,
             state["active_two"].user_id,
             state["eliminated"].user_id,
-            state["kicked"].user_id,
             state["civil"].user_id,
+            state["replacement"].user_id,
             state["game_master"].id,
         }
 


### PR DESCRIPTION
## What this PR does

Members kicked from an active game, or whose seat was handed to a replacement, kept receiving that game's phase resolutions, pause notices and other game-wide notifications indefinitely, because `Game.member_user_ids` applied no filter beyond dropping null users (`service/game/models.py:706` before this change). This replaces it with `Game.seated_member_user_ids`, which filters `kicked=False` and always adds the game master. `Member.objects.hand_over_seat` sets `kicked=True` alongside `replaced_by` (`service/member/models.py:30-32`), so the single filter covers replacement too.

Closes https://github.com/johnpooch/diplicity-react/issues/1279

### Audience decisions

The issue left it open whether the specs on `active_member_user_ids` should move to the new helper.

**Moved to `seated_member_user_ids`** — `seat_filled` and `civil_disorder_recovery`. Both are game-wide news; an eliminated player still watching the game should learn that a seat was filled or that a player returned.

**Kept on `active_member_user_ids`** — `draw_proposal` and `civil_disorder`.

- `draw_proposal` is a call to act ("Respond to it now"), and its audience is exactly the set of members who hold a vote: `DrawProposalManager.create_proposal` builds votes from `eliminated=False, kicked=False` members and marks civil-disorder members `included=False` (`service/draw_proposal/models.py:50-80`) — the same three filters `active_member_user_ids` applies.
- `civil_disorder` is emitted immediately after the affected members are flagged (`service/phase/models.py:526`), so the `civil_disorder=False` filter is what stops "France entered civil disorder" being sent to France. Moving it would have needed the emit site to pass the newly-flagged member ids so they could be excluded by identity rather than by flag — larger than this change, and worth its own issue if wanted.

So `active_member_user_ids` stays, with two callers instead of four.

### Two things beyond the issue's "Where" section

- **The issue lists three specs on `active_member_user_ids`; there are four.** `civil_disorder` (`service/notification/registry.py:306`) also uses it and was not mentioned. It is covered by the decision above.
- **`GameDeleteView` used a third audience helper with the same bug.** `Game.notification_user_ids` (`service/game/views.py:154` before this change) also returned kicked members, so a kicked player was told "The game was deleted by the Game Master." It also carried an `active_only` flag no caller ever passed. Since the issue's goal is one audience helper for game-wide events, this now calls `seated_member_user_ids` and `notification_user_ids` is deleted. Say the word if you'd rather that were split out.

`member_user_ids` is removed — the new helper took every caller.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — backend only, nothing visual changed

The `emit_game` fixture in `service/notification/tests.py` now seats a replaced member and its replacement via the real `Member.objects.hand_over_seat`, alongside the existing plain, eliminated, kicked and civil-disorder members — matching the setup the issue reproduced against. Every audience assertion in that file is updated, and a parametrized regression test asserts that neither the kicked nor the replaced member appears in the recipients of any of the nine specs named in the issue, plus the two that moved.

Full backend suite: 2258 passed, 8 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTSUJGBPgDacmsi1kyi1ze)_