### PR TITLE
Fix test_a_sandbox_phase_is_never_armed member creation

### DIFF
--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -247,7 +247,7 @@ def test_a_sandbox_phase_is_never_armed(db, classical_variant, primary_user):
         movement_phase_duration=None,
     )
     for nation in classical_variant.nations.all():
-        game.members.create(user=primary_user)
+        game.members.create(user=primary_user, sandbox=True)
     game.start()
 
     assert game.current_phase.resolution_job_id is None


### PR DESCRIPTION
## What this PR does

Fixes the backend test failure on [#1232](https://github.com/johnpooch/diplicity-react/pull/1232). `test_a_sandbox_phase_is_never_armed` created one member per nation for the same user via `game.members.create(user=primary_user)` (`service/phase/tests.py:250`), omitting `sandbox=True`. The partial unique constraint `unique_member_per_user_per_game` on `(game, user)` applies where `sandbox=False` (`service/member/models.py:132-136`), so the second nation's member raised `IntegrityError: duplicate key value violates unique constraint "unique_member_per_user_per_game"`. The neighbouring sandbox tests in the same file (lines 225, 269) already pass `sandbox=True`; this test now matches them.

Targets the PR branch rather than `main` so it lands inside #1232.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — no visual changes

Verified locally: the test reproduced the CI failure before the change, and `pytest -n auto` on `service/` is now **2268 passed, 8 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_018xzEAF9km5jotDMpKG1F8n)_