### PR TITLE
Upload and remove your picture from the Account screen

### DIFF
--- a/packages/web/src/mocks/handlers.ts
+++ b/packages/web/src/mocks/handlers.ts
@@ -46,6 +46,8 @@ const mapSvgs: Record<string, string> = {
   "youngstown-redux.d.svg": youngstownMapSvg,
 };
 
+let uploadedPicture: string | null = null;
+
 const svgResponse = (body: string) =>
   new HttpResponse(body, {
     headers: { "Content-Type": "image/svg+xml" },
@@ -118,7 +120,9 @@ export const handlers = [
     return flag ? svgResponse(flag) : notFound();
   }),
 
-  http.get("*/user/", () => HttpResponse.json(currentUserProfile)),
+  http.get("*/user/", () =>
+    HttpResponse.json({ ...currentUserProfile, picture: uploadedPicture })
+  ),
 
   http.get("*/users/:userId/", ({ params }) => {
     const profile = publicProfiles[Number(params.userId)];
@@ -407,4 +411,23 @@ export const handlers = [
   http.patch("*/user/update/", () => HttpResponse.json(currentUserProfile)),
   http.put("*/user/update/", () => HttpResponse.json(currentUserProfile)),
   http.delete("*/user/delete/", () => new HttpResponse(null, { status: 204 })),
+
+  http.put("*/user/picture/", async ({ request }) => {
+    const picture = (await request.formData()).get("picture");
+    if (!(picture instanceof File)) {
+      return HttpResponse.json(
+        { picture: ["Picture could not be read as an image."] },
+        { status: 400 }
+      );
+    }
+    uploadedPicture = URL.createObjectURL(picture);
+    return HttpResponse.json({
+      ...currentUserProfile,
+      picture: uploadedPicture,
+    });
+  }),
+  http.delete("*/user/picture/", () => {
+    uploadedPicture = null;
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/packages/web/src/screens/Home/Account.test.tsx
+++ b/packages/web/src/screens/Home/Account.test.tsx
@@ -1,18 +1,43 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Account } from "./Account";
 import { themeStorage } from "@/theme/themeStorage";
 
-const mockUserProfile = {
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+let mockUserProfile: {
+  id: number;
+  userId: number;
+  email: string;
+  name: string;
+  picture: string | null;
+} = {
   id: 1,
+  userId: 1,
   email: "player@example.com",
   name: "Test Player",
   picture: null,
 };
 
 const mockSetPreference = vi.fn();
+const { mockUploadPicture, mockRemovePicture, mockToastError } = vi.hoisted(
+  () => ({
+    mockUploadPicture: vi.fn(),
+    mockRemovePicture: vi.fn(),
+    mockToastError: vi.fn(),
+  })
+);
 
 vi.mock("@/api/generated/endpoints", () => ({
   useUserRetrieveSuspense: () => ({ data: mockUserProfile }),
@@ -20,7 +45,20 @@ vi.mock("@/api/generated/endpoints", () => ({
     mutateAsync: vi.fn(),
     isPending: false,
   }),
+  useUserPictureUpdate: () => ({
+    mutateAsync: mockUploadPicture,
+    isPending: false,
+  }),
+  useUserPictureDestroy: () => ({
+    mutateAsync: mockRemovePicture,
+    isPending: false,
+  }),
   getUserRetrieveQueryKey: () => ["user"],
+  getUsersRetrieveQueryKey: (userId: number) => ["users", userId],
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError },
 }));
 
 vi.mock("@/hooks/useMessaging", () => ({
@@ -100,7 +138,9 @@ describe("Account - Appearance section", () => {
 
   it("renders the theme select trigger", async () => {
     renderAccount();
-    expect(await screen.findByRole("combobox", { name: /theme/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("combobox", { name: /theme/i })
+    ).toBeInTheDocument();
   });
 
   it("Appearance section appears before Notifications section", async () => {
@@ -112,5 +152,83 @@ describe("Account - Appearance section", () => {
     expect(appearanceIndex).toBeGreaterThanOrEqual(0);
     expect(notificationsIndex).toBeGreaterThanOrEqual(0);
     expect(appearanceIndex).toBeLessThan(notificationsIndex);
+  });
+});
+
+describe("Account - profile picture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserProfile = { ...mockUserProfile, picture: null };
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: createMatchMediaMock(false),
+    });
+    themeStorage.initialize();
+  });
+
+  const getFileInput = (container: HTMLElement) =>
+    container.querySelector<HTMLInputElement>('input[type="file"]')!;
+
+  it("uploads the chosen file", async () => {
+    const user = userEvent.setup();
+    const { container } = renderAccount();
+    const file = new File(["image"], "me.png", { type: "image/png" });
+
+    await user.upload(getFileInput(container), file);
+
+    expect(mockUploadPicture).toHaveBeenCalledWith({ data: { picture: file } });
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server's message when an upload is rejected", async () => {
+    mockUploadPicture.mockRejectedValue({
+      response: {
+        data: { picture: ["Picture is too large (max 2097152 bytes)."] },
+      },
+    });
+    const user = userEvent.setup();
+    const { container } = renderAccount();
+
+    await user.upload(
+      getFileInput(container),
+      new File(["image"], "me.png", { type: "image/png" })
+    );
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Picture is too large (max 2097152 bytes)."
+      )
+    );
+  });
+
+  it("offers no remove option when no picture is set", async () => {
+    const user = userEvent.setup();
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: "Change picture" }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Upload picture" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove picture" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes the picture when one is set", async () => {
+    mockUserProfile = {
+      ...mockUserProfile,
+      picture: "https://example.com/me.png",
+    };
+    const user = userEvent.setup();
+    renderAccount();
+
+    await user.click(screen.getByRole("button", { name: "Change picture" }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Remove picture" })
+    );
+
+    expect(mockRemovePicture).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/screens/Home/Account.tsx
+++ b/packages/web/src/screens/Home/Account.tsx
@@ -1,10 +1,27 @@
-import React, { Suspense, useState } from "react";
-import { Check, X, Pencil, ChevronRight } from "lucide-react";
+import React, { Suspense, useRef, useState } from "react";
+import { AxiosError } from "axios";
+import {
+  Check,
+  X,
+  Pencil,
+  ChevronRight,
+  Camera,
+  Loader2,
+  Trash2,
+  Upload,
+} from "lucide-react";
 import { Link } from "react-router";
+import { toast } from "sonner";
 
 import { QueryErrorBoundary } from "@/components/QueryErrorBoundary";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ScreenCard, ScreenCardContent } from "@/components/ui/screen-card";
 import { ScreenHeader } from "@/components/ui/screen-header";
 import { ScreenContainer } from "@/components/ui/screen-container";
@@ -25,9 +42,118 @@ import { useMessaging } from "@/hooks/useMessaging";
 import {
   useUserRetrieveSuspense,
   useUserUpdatePartialUpdate,
+  useUserPictureUpdate,
+  useUserPictureDestroy,
   getUserRetrieveQueryKey,
+  getUsersRetrieveQueryKey,
+  UserProfilePicture,
 } from "@/api/generated/endpoints";
 import { useQueryClient } from "@tanstack/react-query";
+
+const pictureErrorMessage = (error: unknown, fallback: string) => {
+  const data = (error as AxiosError<{ picture?: string[]; detail?: string }>)
+    .response?.data;
+  return data?.picture?.[0] ?? data?.detail ?? fallback;
+};
+
+interface ProfilePictureEditorProps {
+  userId: number;
+  name: string;
+  picture: string | null;
+}
+
+const ProfilePictureEditor: React.FC<ProfilePictureEditorProps> = ({
+  userId,
+  name,
+  picture,
+}) => {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadPictureMutation = useUserPictureUpdate();
+  const removePictureMutation = useUserPictureDestroy();
+  const isPending =
+    uploadPictureMutation.isPending || removePictureMutation.isPending;
+
+  const refreshProfile = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: getUserRetrieveQueryKey() }),
+      queryClient.invalidateQueries({
+        queryKey: getUsersRetrieveQueryKey(userId),
+      }),
+    ]);
+
+  const handleUpload = async (file: File) => {
+    try {
+      await uploadPictureMutation.mutateAsync({
+        data: { picture: file as unknown as UserProfilePicture["picture"] },
+      });
+      await refreshProfile();
+    } catch (error) {
+      toast.error(pictureErrorMessage(error, "Failed to upload picture"));
+    }
+  };
+
+  const handleRemove = async () => {
+    try {
+      await removePictureMutation.mutateAsync();
+      await refreshProfile();
+    } catch (error) {
+      toast.error(pictureErrorMessage(error, "Failed to remove picture"));
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Avatar className="size-12">
+        <AvatarImage src={picture ?? undefined} />
+        <AvatarFallback>{name[0]?.toUpperCase()}</AvatarFallback>
+      </Avatar>
+      {isPending && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-full bg-background/70">
+          <Loader2 className="size-4 animate-spin" />
+        </div>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="secondary"
+            disabled={isPending}
+            aria-label="Change picture"
+            className="absolute -bottom-1 -right-1 size-6 rounded-full border"
+          >
+            <Camera className="size-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onSelect={() => fileInputRef.current?.click()}>
+            <Upload />
+            {picture ? "Replace picture" : "Upload picture"}
+          </DropdownMenuItem>
+          {picture && (
+            <DropdownMenuItem variant="destructive" onSelect={handleRemove}>
+              <Trash2 />
+              Remove picture
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden
+        onChange={event => {
+          const file = event.target.files?.[0];
+          if (file) handleUpload(file);
+          event.target.value = "";
+        }}
+      />
+    </div>
+  );
+};
 
 const Account: React.FC = () => {
   const queryClient = useQueryClient();
@@ -101,14 +227,11 @@ const Account: React.FC = () => {
             </Button>
           </div>
           <div className="flex items-center gap-4">
-            <div>
-              <Avatar className="size-12">
-                <AvatarImage src={userProfile?.picture ?? undefined} />
-                <AvatarFallback>
-                  {userProfile?.name?.[0]?.toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
-            </div>
+            <ProfilePictureEditor
+              userId={userProfile.userId}
+              name={userProfile.name}
+              picture={userProfile.picture}
+            />
 
             <div className="flex-1">
               {isEditingName ? (


### PR DESCRIPTION
## What this PR does

The Account avatar was display-only. It now carries a camera badge that opens a menu to upload, replace or remove the profile picture, calling the generated `PUT`/`DELETE /user/picture/` mutations through a hidden file input — no Capacitor plugin, so it works in the iOS and Android WebViews too. A rejected upload surfaces the server's own message ("Picture is larger than 2048px on a side.", "Picture must be a JPEG, PNG or WebP image.") as an error toast; success has no toast, since the new avatar is its own confirmation. Both `user` and `users/<id>` queries are invalidated, so the sidebar and "View my profile" pick the change up immediately.

`src/mocks/handlers.ts` gains `PUT`/`DELETE /user/picture/` so the flow is exercisable under `npm run dev:mocks` — the mock echoes the chosen file back as an object URL.

Closes https://github.com/johnpooch/diplicity-react/issues/1254

## Screenshots

I could not embed screenshots here: `gh` in this session reports its `GH_TOKEN` invalid, and the MCP toolset has no endpoint for uploading a GitHub attachment. Committing them or serving them from `raw.githubusercontent.com` is ruled out by CLAUDE.md, so the images are being handed to @johnpooch directly to drop into this description. They cover: the avatar with the camera badge and no picture set, the menu with a picture set (Replace / Remove), the uploaded avatar on desktop and mobile, dark mode, and the error toast carrying the server's message.

Verified in a real browser against the mock server: the menu item opens the file chooser, the chosen image renders on the avatar and in the sidebar, and Remove restores the initials fallback.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [ ] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — see the note above

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCAhLz2Rm2nvu9wcuG2h8s)_