### PR TITLE
Downscale images in the browser before upload

### DIFF
--- a/packages/web/src/screens/Home/Account.test.tsx
+++ b/packages/web/src/screens/Home/Account.test.tsx
@@ -31,13 +31,17 @@ let mockUserProfile: {
 };
 
 const mockSetPreference = vi.fn();
-const { mockUploadPicture, mockRemovePicture, mockToastError } = vi.hoisted(
-  () => ({
-    mockUploadPicture: vi.fn(),
-    mockRemovePicture: vi.fn(),
-    mockToastError: vi.fn(),
-  })
-);
+const {
+  mockUploadPicture,
+  mockRemovePicture,
+  mockToastError,
+  mockDownscaleImage,
+} = vi.hoisted(() => ({
+  mockUploadPicture: vi.fn(),
+  mockRemovePicture: vi.fn(),
+  mockToastError: vi.fn(),
+  mockDownscaleImage: vi.fn(),
+}));
 
 vi.mock("@/api/generated/endpoints", () => ({
   useUserRetrieveSuspense: () => ({ data: mockUserProfile }),
@@ -59,6 +63,10 @@ vi.mock("@/api/generated/endpoints", () => ({
 
 vi.mock("sonner", () => ({
   toast: { error: mockToastError },
+}));
+
+vi.mock("@/utils/downscaleImage", () => ({
+  downscaleImage: mockDownscaleImage,
 }));
 
 vi.mock("@/hooks/useMessaging", () => ({
@@ -158,6 +166,7 @@ describe("Account - Appearance section", () => {
 describe("Account - profile picture", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDownscaleImage.mockImplementation(async (file: File) => file);
     mockUserProfile = { ...mockUserProfile, picture: null };
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -179,6 +188,21 @@ describe("Account - profile picture", () => {
 
     expect(mockUploadPicture).toHaveBeenCalledWith({ data: { picture: file } });
     expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("uploads the downscaled file rather than the original", async () => {
+    const original = new File(["original"], "me.png", { type: "image/png" });
+    const downscaled = new File(["small"], "me.png", { type: "image/png" });
+    mockDownscaleImage.mockResolvedValue(downscaled);
+    const user = userEvent.setup();
+    const { container } = renderAccount();
+
+    await user.upload(getFileInput(container), original);
+
+    expect(mockDownscaleImage).toHaveBeenCalledWith(original);
+    expect(mockUploadPicture).toHaveBeenCalledWith({
+      data: { picture: downscaled },
+    });
   });
 
   it("surfaces the server's message when an upload is rejected", async () => {

--- a/packages/web/src/screens/Home/Account.tsx
+++ b/packages/web/src/screens/Home/Account.tsx
@@ -39,6 +39,7 @@ import { useTheme } from "@/theme/useTheme";
 import { useLogout } from "@/hooks/useLogout";
 import { useNavigate } from "react-router";
 import { useMessaging } from "@/hooks/useMessaging";
+import { downscaleImage } from "@/utils/downscaleImage";
 import {
   useUserRetrieveSuspense,
   useUserUpdatePartialUpdate,
@@ -71,8 +72,8 @@ const ProfilePictureEditor: React.FC<ProfilePictureEditorProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadPictureMutation = useUserPictureUpdate();
   const removePictureMutation = useUserPictureDestroy();
-  const isPending =
-    uploadPictureMutation.isPending || removePictureMutation.isPending;
+  const [isUploading, setIsUploading] = useState(false);
+  const isPending = isUploading || removePictureMutation.isPending;
 
   const refreshProfile = () =>
     Promise.all([
@@ -83,13 +84,17 @@ const ProfilePictureEditor: React.FC<ProfilePictureEditorProps> = ({
     ]);
 
   const handleUpload = async (file: File) => {
+    setIsUploading(true);
     try {
+      const picture = await downscaleImage(file);
       await uploadPictureMutation.mutateAsync({
-        data: { picture: file as unknown as UserProfilePicture["picture"] },
+        data: { picture: picture as unknown as UserProfilePicture["picture"] },
       });
       await refreshProfile();
     } catch (error) {
       toast.error(pictureErrorMessage(error, "Failed to upload picture"));
+    } finally {
+      setIsUploading(false);
     }
   };
 

--- a/packages/web/src/utils/downscaleImage.test.ts
+++ b/packages/web/src/utils/downscaleImage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { downscaleImage } from "./downscaleImage";
+
+const createFile = (type: string) =>
+  new File(["original"], "photo.jpg", { type });
+
+const stubBitmap = (width: number, height: number) => {
+  const close = vi.fn();
+  vi.stubGlobal(
+    "createImageBitmap",
+    vi.fn(async () => ({ width, height, close }))
+  );
+  return close;
+};
+
+const stubCanvas = () => {
+  const drawImage = vi.fn();
+  let size: { width: number; height: number } | undefined;
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    function (this: HTMLCanvasElement) {
+      size = { width: this.width, height: this.height };
+      return { drawImage, imageSmoothingQuality: "low" } as never;
+    }
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(
+    (callback, type) => callback(new Blob(["downscaled"], { type }))
+  );
+  return {
+    drawImage,
+    get size() {
+      return size;
+    },
+  };
+};
+
+describe("downscaleImage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("downscales a large image to the bounded dimension", async () => {
+    stubBitmap(4000, 3000);
+    const canvas = stubCanvas();
+    const file = createFile("image/jpeg");
+
+    const result = await downscaleImage(file);
+
+    expect(canvas.size).toEqual({ width: 512, height: 384 });
+    expect(canvas.drawImage).toHaveBeenCalled();
+    expect(result).not.toBe(file);
+    expect(result.name).toBe("photo.jpg");
+    expect(result.type).toBe("image/jpeg");
+  });
+
+  it("bounds the taller side of a portrait image", async () => {
+    stubBitmap(1500, 3000);
+    const canvas = stubCanvas();
+
+    await downscaleImage(createFile("image/jpeg"));
+
+    expect(canvas.size).toEqual({ width: 256, height: 512 });
+  });
+
+  it("releases the decoded bitmap", async () => {
+    const close = stubBitmap(4000, 3000);
+    stubCanvas();
+
+    await downscaleImage(createFile("image/jpeg"));
+
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("returns the original file when it is already within bounds", async () => {
+    stubBitmap(256, 256);
+    const canvas = stubCanvas();
+    const file = createFile("image/png");
+
+    expect(await downscaleImage(file)).toBe(file);
+    expect(canvas.size).toBeUndefined();
+  });
+
+  it("returns the original file for a type the server does not accept", async () => {
+    stubBitmap(4000, 3000);
+    const file = createFile("image/heic");
+
+    expect(await downscaleImage(file)).toBe(file);
+  });
+
+  it("returns the original file when the browser cannot decode images", async () => {
+    const file = createFile("image/jpeg");
+
+    expect(await downscaleImage(file)).toBe(file);
+  });
+
+  it("returns the original file when decoding fails", async () => {
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(async () => {
+        throw new Error("decode failed");
+      })
+    );
+    const file = createFile("image/jpeg");
+
+    expect(await downscaleImage(file)).toBe(file);
+  });
+
+  it("returns the original file when encoding yields nothing", async () => {
+    stubBitmap(4000, 3000);
+    stubCanvas();
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(
+      callback => callback(null)
+    );
+    const file = createFile("image/jpeg");
+
+    expect(await downscaleImage(file)).toBe(file);
+  });
+});

--- a/packages/web/src/utils/downscaleImage.ts
+++ b/packages/web/src/utils/downscaleImage.ts
@@ -1,0 +1,40 @@
+const MAX_DIMENSION = 512;
+const IMAGE_QUALITY = 0.9;
+const DOWNSCALABLE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export const downscaleImage = async (file: File): Promise<File> => {
+  if (!DOWNSCALABLE_TYPES.includes(file.type)) return file;
+  if (typeof createImageBitmap !== "function") return file;
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+  } catch {
+    return file;
+  }
+
+  const scale = MAX_DIMENSION / Math.max(bitmap.width, bitmap.height);
+  if (scale >= 1) {
+    bitmap.close();
+    return file;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(bitmap.width * scale);
+  canvas.height = Math.round(bitmap.height * scale);
+  const context = canvas.getContext("2d");
+  if (!context) {
+    bitmap.close();
+    return file;
+  }
+  context.imageSmoothingQuality = "high";
+  context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>(resolve =>
+    canvas.toBlob(resolve, file.type, IMAGE_QUALITY)
+  );
+  if (!blob) return file;
+
+  return new File([blob], file.name, { type: blob.type });
+};


### PR DESCRIPTION
## What this PR does

Mobile users were pushing 3–12MB camera photos over cellular to an endpoint that re-encodes to a 256px square, so almost every byte was discarded on arrival. `downscaleImage` (`packages/web/src/utils/downscaleImage.ts`) now decodes the selected file, bounds it to 512px on its longest side and re-encodes it before `handleUpload` sends it. Closes [#1255](https://github.com/johnpooch/diplicity-react/issues/1255).

Measured in Chromium against the real module (generated photos, `createImageBitmap` on the output to read back its dimensions):

| Input | Output |
| --- | --- |
| 3.16MB JPEG, 4032×3024 | 87KB, 512×384 |
| 5.89MB PNG, 1500×3000 | 395KB, 256×512 |
| 75KB JPEG, 300×300 | untouched — the original `File` is returned |

Three decisions worth flagging:

- **The source format is preserved** (`toBlob(callback, file.type, 0.9)`), so PNG and WebP transparency survives and the server's format check in `normalise_picture` (`service/user_profile/utils.py:39-40`) sees what it saw before.
- **EXIF orientation is applied during the decode**, via `createImageBitmap(file, { imageOrientation: "from-image" })`. The canvas re-encode strips the metadata that `ImageOps.exif_transpose` (`service/user_profile/utils.py:50`) would otherwise have used, so getting this wrong would upload sideways photos. Verified in Chromium: a 2000×1000 JPEG carrying an APP1 orientation-6 tag comes out 256×512, i.e. rotated before the strip.
- **Every step falls back to the original file** — an unaccepted MIME type, no `createImageBitmap`, a decode failure, no 2D context, or a null blob. This is a transfer-cost change only; server-side normalisation remains the validation boundary.

The avatar spinner now covers the resize as well as the request, since decoding a 12MB photo on a phone is not instant.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change — 8 unit tests over `downscaleImage` (bounding, aspect ratio, bitmap release, and each fallback path) plus an `Account` test asserting the downscaled file is what gets uploaded
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — no visual change; the Account screen renders exactly as it did after #1291

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCAhLz2Rm2nvu9wcuG2h8s)_