### PR TITLE
Document uploaded profile pictures in the privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** March 18, 2026
+**Last updated:** August 28, 2026
 
 Diplicity is a mobile and web application for playing the classic Diplomacy board game online. This privacy policy explains what data we collect, how we use it, and your rights regarding that data.
 
@@ -14,9 +14,20 @@ When you sign in with Google, we receive and store:
 
 - **Name** — your Google account display name
 - **Email address** — your Google account email
-- **Profile picture URL** — a link to your Google profile photo
+- **Profile picture URL** — a link to your Google profile photo, used unless you upload your own picture
 
 We do not access your Google password, contacts, or any other Google account data.
+
+### Profile Pictures
+
+You can upload your own picture to replace the one from your Google account. If you do:
+
+- **We store the image ourselves**, on the same infrastructure that runs the app — it is not sent to a third-party image host
+- **We re-encode it on upload.** The image is resized, cropped to a square, and written back out from raw pixel data, which discards all embedded metadata. That includes EXIF GPS coordinates, so if you upload a photo taken on a phone, the location it was taken in is not stored or served
+- **The picture is served from an unauthenticated URL.** The address of your picture has to be loadable without signing in, so anyone who has the link can view the image. Treat a picture you upload as public
+- **Your picture is visible to other players** in games you join, in game chat, and on your public profile. In anonymous games it is hidden from other players, along with your name, until the game finishes
+
+We accept JPEG, PNG and WebP images. Uploading a picture is optional; you can remove it at any time from the Account screen.
 
 ### Gameplay Data
 
@@ -69,6 +80,7 @@ We do not sell or share your personal data with any other third parties.
 - All data is transmitted over HTTPS/TLS
 - The backend runs on Railway's infrastructure with managed PostgreSQL
 - Authentication uses industry-standard JWT tokens
+- Profile picture URLs are the one exception to authenticated access — see Profile Pictures above
 - We follow security best practices but cannot guarantee absolute security — no system is 100% secure
 
 ## 5. Data Retention & Deletion
@@ -78,6 +90,7 @@ We do not sell or share your personal data with any other third parties.
 - **Account data** is retained as long as your account exists
 - **Gameplay data** (games, orders, messages) is retained indefinitely as part of the game record
 - **FCM device tokens** are removed when you sign out or disable notifications
+- **Uploaded profile pictures** are kept until you remove your picture or delete your account; the stored image file is deleted in both cases
 
 ### Account deletion
 
@@ -101,6 +114,8 @@ Diplicity does **not** collect or access:
 - Payment or financial information
 - Browsing history or cross-app tracking data
 - Advertising identifiers
+
+This holds for pictures you upload too. A photo taken on a phone often carries the location it was taken in as EXIF metadata; that metadata is discarded when we re-encode the picture, so it is never stored or served.
 
 ## 7. Children's Privacy
 


### PR DESCRIPTION
## What this PR does

`PRIVACY.md` still described the profile picture as a URL received from Google, which stopped being the whole story once users could upload their own. This adds a **Profile Pictures** subsection under *Information We Collect* recording that uploaded pictures are stored by us, served from an unauthenticated URL, and stripped of EXIF metadata on re-encode — plus the matching lines in the storage, retention, and "what we don't collect" sections. Closes https://github.com/johnpooch/diplicity-react/issues/1257.

Each claim is taken from the code:

- **Stored by us, not a third party** — `UserProfilePicture.image` is an `ImageField` on the default storage backend, which is `FileSystemStorage` (`service/project/settings.py:231-236`). The R2 settings below it are unused by any application code.
- **Unauthenticated serve endpoint** — `UserProfilePictureImageView` is a plain Django `View` with no permission classes, and responds `Cache-Control: public, max-age=31536000, immutable` (`service/user_profile/views.py:60-71`).
- **EXIF stripped on re-encode** — `normalise_picture` fits the image to 256×256 and rebuilds it via `Image.frombytes(...cropped.tobytes())`, so nothing but raw pixels survives into the saved file (`service/user_profile/utils.py:47-73`). Covered by `test_upload_picture_strips_exif_metadata`, which asserts `stored.getexif() == {}` for an upload carrying a GPS IFD tag (`service/user_profile/tests.py:492-505`).
- **Visible to other players, hidden in anonymous games** — member and channel serializers expose `picture_url` (`service/member/serializers.py:63-69`, `service/channel/models.py:25`), and `_is_masked` returns `None` for the picture in an anonymous game until it completes (`service/member/serializers.py:32-40`).
- **Deleted when you remove it or delete your account** — a `post_delete` receiver on `UserProfilePicture` deletes the underlying file (`service/user_profile/signals.py:44-46`), reached from `perform_destroy` (`service/user_profile/views.py:56-57`) and by cascade from user deletion.
- **Accepted formats** — `PICTURE_CONTENT_TYPES` allows JPEG, PNG and WebP (`service/user_profile/utils.py:29-33`).

The "Last updated" date moves to August 28, 2026.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: n/a — documentation-only change to a single file
- [x] Tests cover the change — n/a for a policy document; the behaviour it describes is covered by the existing `service/user_profile/tests.py` picture tests cited above
- [x] Screenshots embedded in the PR description for any visual changes — none; no application code is touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLCatxAnmGwnij4G6Xdehm)_