### PR TITLE
Add admin action to clear an uploaded profile picture

### DIFF
--- a/service/user_profile/admin.py
+++ b/service/user_profile/admin.py
@@ -1,7 +1,29 @@
 from django.contrib import admin
-from .models import UserProfile
+from django.contrib import messages
+
+from .models import UserProfile, UserProfilePicture
 
 
 @admin.register(UserProfile)
 class UserProfileAdmin(admin.ModelAdmin):
     list_display = ("name",)
+    actions = ["clear_uploaded_picture"]
+
+    def clear_uploaded_picture(self, request, queryset):
+        pictures = UserProfilePicture.objects.filter(profile__in=queryset).select_related("profile")
+        names = sorted(picture.profile.name for picture in pictures)
+
+        if not names:
+            self.message_user(
+                request, "None of the selected profiles has an uploaded picture.", level=messages.WARNING
+            )
+            return
+
+        pictures.delete()
+        self.message_user(
+            request,
+            f"Cleared the uploaded picture for {', '.join(names)}.",
+            level=messages.SUCCESS,
+        )
+
+    clear_uploaded_picture.short_description = "Clear uploaded profile picture"

--- a/service/user_profile/tests.py
+++ b/service/user_profile/tests.py
@@ -702,6 +702,70 @@ class TestUserProfilePictureImageView:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+def _clear_uploaded_picture(client, profile, follow=True):
+    return client.post(
+        reverse("admin:user_profile_userprofile_changelist"),
+        {
+            "action": "clear_uploaded_picture",
+            "_selected_action": [str(profile.pk)],
+        },
+        follow=follow,
+    )
+
+
+class TestUserProfileAdmin:
+
+    @pytest.mark.django_db
+    def test_clear_uploaded_picture_falls_back_to_google_url(
+        self, admin_client, primary_user, stored_picture
+    ):
+        primary_user.profile.picture = "http://example.com/google.jpg"
+        primary_user.profile.save()
+
+        response = _clear_uploaded_picture(admin_client, primary_user.profile)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not UserProfilePicture.objects.filter(profile=primary_user.profile).exists()
+        primary_user.profile.refresh_from_db()
+        assert primary_user.profile.picture_url() == "http://example.com/google.jpg"
+
+    @pytest.mark.django_db
+    def test_clear_uploaded_picture_deletes_stored_file(
+        self, admin_client, primary_user, stored_picture
+    ):
+        storage = stored_picture.image.storage
+        name = stored_picture.image.name
+        assert storage.exists(name)
+
+        _clear_uploaded_picture(admin_client, primary_user.profile)
+
+        assert not storage.exists(name)
+
+    @pytest.mark.django_db
+    def test_clear_uploaded_picture_leaves_other_profiles_untouched(
+        self, admin_client, primary_user, secondary_user, stored_picture
+    ):
+        _clear_uploaded_picture(admin_client, secondary_user.profile)
+
+        assert UserProfilePicture.objects.filter(profile=primary_user.profile).exists()
+
+    @pytest.mark.django_db
+    def test_clear_uploaded_picture_when_no_picture_uploaded(self, admin_client, secondary_user):
+        response = _clear_uploaded_picture(admin_client, secondary_user.profile)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not UserProfilePicture.objects.filter(profile=secondary_user.profile).exists()
+
+    @pytest.mark.django_db
+    def test_clear_uploaded_picture_requires_staff(self, client, primary_user, stored_picture):
+        client.force_login(primary_user)
+
+        response = _clear_uploaded_picture(client, primary_user.profile, follow=False)
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert UserProfilePicture.objects.filter(profile=primary_user.profile).exists()
+
+
 class TestPublicUserProfileRetrieveView:
 
     @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does

Profile pictures are user-supplied and served publicly, and there is no moderation flow anywhere in `service/`. This adds a **Clear uploaded profile picture** action to `UserProfileAdmin` (`service/user_profile/admin.py:10`) so an admin can remove an abusive picture from Django admin. Closes https://github.com/johnpooch/diplicity-react/issues/1256.

The action deletes the `UserProfilePicture` rows for the selected profiles. The existing `post_delete` receiver (`service/user_profile/signals.py:43`) removes the stored file, and `UserProfile.picture_url()` (`service/user_profile/models.py:64`) then falls back to the identity-provider avatar URL.

One judgement call worth flagging: the action leaves the `picture` URL field alone. That field is not user-supplied — it is re-populated from the Google ID token on every login (`service/login/serializers.py:59-61`), so clearing it would have no lasting effect.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, a 20-line admin action
- [x] Tests cover the change — `TestUserProfileAdmin` in `service/user_profile/tests.py` drives the action through the admin changelist POST and covers the fallback to the provider URL, deletion of the stored file, other profiles being untouched, a profile with no upload, and a non-staff user being refused. `python -m pytest user_profile/tests.py` — 122 passed.
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, no web-app change

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7G1TT3UjhFihZcjJw8Eou)_