### PR TITLE
Keep NMR'd players removable across phases they could not order in

### DIFF
--- a/service/game/models.py
+++ b/service/game/models.py
@@ -107,10 +107,20 @@ class GameQuerySet(models.QuerySet):
             .distinct("game_id")
             .values("id")
         )
+        latest_orderable_phase_state_ids = (
+            PhaseState.objects.filter(
+                phase__status=PhaseStatus.COMPLETED, has_possible_orders=True
+            )
+            .order_by("member_id", "-phase__ordinal", "-phase_id")
+            .distinct("member_id")
+            .values("id")
+        )
         phase_states_prefetch = Prefetch(
             "phase_states",
             queryset=PhaseState.objects.filter(
-                Q(phase__in=current_phase_ids) | Q(phase__in=latest_completed_phase_ids)
+                Q(phase__in=current_phase_ids)
+                | Q(phase__in=latest_completed_phase_ids)
+                | Q(id__in=latest_orderable_phase_state_ids)
             )
             .select_related("member")
             .annotate(order_count=Count("orders")),
@@ -175,10 +185,20 @@ class GameQuerySet(models.QuerySet):
             .distinct("game_id")
             .values("id")
         )
+        latest_orderable_phase_state_ids = (
+            PhaseState.objects.filter(
+                phase__status=PhaseStatus.COMPLETED, has_possible_orders=True
+            )
+            .order_by("member_id", "-phase__ordinal", "-phase_id")
+            .distinct("member_id")
+            .values("id")
+        )
         phase_states_prefetch = Prefetch(
             "phase_states",
             queryset=PhaseState.objects.filter(
-                Q(phase__in=current_phase_ids) | Q(phase__in=latest_completed_phase_ids)
+                Q(phase__in=current_phase_ids)
+                | Q(phase__in=latest_completed_phase_ids)
+                | Q(id__in=latest_orderable_phase_state_ids)
             ).select_related("member__user").annotate(
                 order_count=Count("orders")
             )
@@ -561,14 +581,23 @@ class Game(BaseModel):
     @cached_property
     def nmrd_member_ids(self):
         with tracer.start_as_current_span("game.models.nmrd_member_ids"):
-            completed = [p for p in self.phases.all() if p.status == PhaseStatus.COMPLETED]
-            if not completed:
-                return set()
-            latest = max(completed, key=lambda p: p.ordinal)
+            completed = sorted(
+                (p for p in self.phases.all() if p.status == PhaseStatus.COMPLETED),
+                key=lambda p: p.ordinal,
+                reverse=True,
+            )
+            latest_outcome_by_member = {}
+            for phase in completed:
+                for phase_state in phase.phase_states.all():
+                    if not phase_state.has_possible_orders:
+                        continue
+                    latest_outcome_by_member.setdefault(
+                        phase_state.member_id, phase_state.orders_outcome
+                    )
             return {
-                phase_state.member_id
-                for phase_state in latest.phase_states.all()
-                if phase_state.orders_outcome == PhaseState.OrdersOutcome.NMR
+                member_id
+                for member_id, outcome in latest_outcome_by_member.items()
+                if outcome == PhaseState.OrdersOutcome.NMR
             }
 
     def get_phase_duration_seconds(self, phase_type):

--- a/service/game/models.py
+++ b/service/game/models.py
@@ -578,25 +578,38 @@ class Game(BaseModel):
     def bot_members(self):
         return self.members.filter(user__profile__kind__in=UserKind.BOT_KINDS).select_related("user")
 
-    @cached_property
-    def nmrd_member_ids(self):
-        with tracer.start_as_current_span("game.models.nmrd_member_ids"):
+    def _latest_orderable_outcomes(self):
+        if "phases" in getattr(self, "_prefetched_objects_cache", {}):
             completed = sorted(
                 (p for p in self.phases.all() if p.status == PhaseStatus.COMPLETED),
                 key=lambda p: p.ordinal,
                 reverse=True,
             )
-            latest_outcome_by_member = {}
+            outcomes = {}
             for phase in completed:
                 for phase_state in phase.phase_states.all():
                     if not phase_state.has_possible_orders:
                         continue
-                    latest_outcome_by_member.setdefault(
-                        phase_state.member_id, phase_state.orders_outcome
-                    )
+                    outcomes.setdefault(phase_state.member_id, phase_state.orders_outcome)
+            return outcomes
+
+        return dict(
+            PhaseState.objects.filter(
+                phase__game=self,
+                phase__status=PhaseStatus.COMPLETED,
+                has_possible_orders=True,
+            )
+            .order_by("member_id", "-phase__ordinal", "-phase_id")
+            .distinct("member_id")
+            .values_list("member_id", "orders_outcome")
+        )
+
+    @cached_property
+    def nmrd_member_ids(self):
+        with tracer.start_as_current_span("game.models.nmrd_member_ids"):
             return {
                 member_id
-                for member_id, outcome in latest_outcome_by_member.items()
+                for member_id, outcome in self._latest_orderable_outcomes().items()
                 if outcome == PhaseState.OrdersOutcome.NMR
             }
 
@@ -692,7 +705,12 @@ class Game(BaseModel):
 
     def can_remove_member(self, member):
         with tracer.start_as_current_span("game.models.can_remove_member"):
-            if member.is_game_master or member.kicked or member.replaced_by_id is not None:
+            if (
+                member.is_game_master
+                or member.kicked
+                or member.eliminated
+                or member.replaced_by_id is not None
+            ):
                 return False
             if self.status in (GameStatus.PENDING, GameStatus.MUSTERING):
                 return True

--- a/service/game/tests.py
+++ b/service/game/tests.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 from rest_framework import status
 from common.constants import PhaseStatus, PhaseType, GameStatus, MovementPhaseDuration, DeadlineMode, OrderType, PhaseFrequency, UnitType
 
-from phase.models import Phase
+from phase.models import Phase, PhaseState
 from nation.models import Nation
 from province.models import Province
 from notification.models import Notification, NotificationDelivery
@@ -1213,6 +1213,59 @@ class TestGameListViewQueryPerformance:
         query_count = len(connection.queries)
 
         assert query_count == 8
+
+    @pytest.mark.django_db
+    def test_list_games_query_count_with_deep_phase_history(
+        self,
+        authenticated_client,
+        db,
+        classical_variant,
+        primary_user,
+        secondary_user,
+        classical_england_nation,
+        classical_france_nation,
+    ):
+        for i in range(2):
+            game = Game.objects.create(
+                name=f"Deep game {i}",
+                variant=classical_variant,
+                status=GameStatus.ACTIVE,
+            )
+            member1 = game.members.create(user=primary_user, nation=classical_england_nation)
+            member2 = game.members.create(user=secondary_user, nation=classical_france_nation)
+
+            for ordinal in range(1, 9):
+                phase = game.phases.create(
+                    game=game,
+                    variant=game.variant,
+                    season="Spring",
+                    year=1900 + ordinal,
+                    type=PhaseType.MOVEMENT,
+                    status=PhaseStatus.ACTIVE if ordinal == 8 else PhaseStatus.COMPLETED,
+                    ordinal=ordinal,
+                )
+                for member in (member1, member2):
+                    phase.phase_states.create(
+                        member=member,
+                        has_possible_orders=ordinal < 3,
+                        orders_outcome=(
+                            PhaseState.OrdersOutcome.NMR if ordinal == 2 else None
+                        ),
+                    )
+
+        url = reverse(list_viewname)
+        connection.queries_log.clear()
+
+        with override_settings(DEBUG=True):
+            response = authenticated_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(connection.queries) == 8
+        assert all(
+            member["removable"]
+            for game_data in response.data["results"]
+            for member in game_data["members"]
+        )
 
     @pytest.mark.django_db
     def test_list_games_hydrates_units_for_current_phase_only(

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -523,21 +523,24 @@ def _record_nmr(game, member):
     return phase
 
 
-def _record_phase(game, member, ordinal, phase_type, has_possible_orders, orders_outcome):
-    phase = game.phases.create(
-        variant=game.variant,
-        season="Spring",
-        year=1900,
-        type=phase_type,
-        status=PhaseStatus.COMPLETED,
-        ordinal=ordinal,
-    )
-    phase.phase_states.create(
-        member=member,
-        has_possible_orders=has_possible_orders,
-        orders_outcome=orders_outcome,
-    )
-    return phase
+def _record_history(game, member, entries):
+    active_phase = game.current_phase
+    active_phase.ordinal = len(entries) + 1
+    active_phase.save(update_fields=["ordinal"])
+    for ordinal, (phase_type, has_possible_orders, orders_outcome) in enumerate(entries, start=1):
+        phase = game.phases.create(
+            variant=game.variant,
+            season="Spring",
+            year=1900 + ordinal,
+            type=phase_type,
+            status=PhaseStatus.COMPLETED,
+            ordinal=ordinal,
+        )
+        phase.phase_states.create(
+            member=member,
+            has_possible_orders=has_possible_orders,
+            orders_outcome=orders_outcome,
+        )
 
 
 class TestRemoveMemberFromActiveGame:
@@ -727,8 +730,14 @@ class TestRemovalRequiresMissedOrders:
     ):
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
-        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
-        _record_phase(game, member, 1, "Retreat", False, None)
+        _record_history(
+            game,
+            member,
+            [
+                ("Movement", True, PhaseState.OrdersOutcome.NMR),
+                ("Retreat", False, None),
+            ],
+        )
 
         url = reverse(kick_viewname, args=[game.id, member.id])
         response = authenticated_client.delete(url)
@@ -741,9 +750,15 @@ class TestRemovalRequiresMissedOrders:
     ):
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
-        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
-        _record_phase(game, member, 1, "Retreat", False, None)
-        _record_phase(game, member, 2, "Adjustment", False, None)
+        _record_history(
+            game,
+            member,
+            [
+                ("Movement", True, PhaseState.OrdersOutcome.NMR),
+                ("Retreat", False, None),
+                ("Adjustment", False, None),
+            ],
+        )
 
         url = reverse(kick_viewname, args=[game.id, member.id])
         response = authenticated_client.delete(url)
@@ -756,9 +771,15 @@ class TestRemovalRequiresMissedOrders:
     ):
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
-        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
-        _record_phase(game, member, 1, "Retreat", True, PhaseState.OrdersOutcome.RECEIVED)
-        _record_phase(game, member, 2, "Adjustment", False, None)
+        _record_history(
+            game,
+            member,
+            [
+                ("Movement", True, PhaseState.OrdersOutcome.NMR),
+                ("Retreat", True, PhaseState.OrdersOutcome.RECEIVED),
+                ("Adjustment", False, None),
+            ],
+        )
 
         url = reverse(kick_viewname, args=[game.id, member.id])
         response = authenticated_client.delete(url)
@@ -771,12 +792,55 @@ class TestRemovalRequiresMissedOrders:
     ):
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
-        _record_phase(game, member, 0, "Movement", False, None)
+        _record_history(game, member, [("Movement", False, None)])
 
         url = reverse(kick_viewname, args=[game.id, member.id])
         response = authenticated_client.delete(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_eliminated_member_who_missed_orders_cannot_be_removed(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_history(
+            game,
+            member,
+            [
+                ("Movement", True, PhaseState.OrdersOutcome.NMR),
+                ("Movement", False, None),
+            ],
+        )
+        member.eliminated = True
+        member.save()
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_removability_does_not_scale_queries_with_phase_history(
+        self, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_history(
+            game,
+            member,
+            [("Movement", True, PhaseState.OrdersOutcome.NMR)]
+            + [("Movement", False, None)] * 20,
+        )
+        fresh = Game.objects.get(id=game.id)
+        fresh_member = fresh.members.get(id=member.id)
+
+        connection.queries_log.clear()
+        with override_settings(DEBUG=True):
+            assert fresh.can_remove_member(fresh_member) is True
+
+        assert len(connection.queries) == 3
 
     @pytest.mark.django_db
     def test_already_removed_member_cannot_be_removed_again(
@@ -822,8 +886,14 @@ class TestRemovableSerialization:
     ):
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
-        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
-        _record_phase(game, member, 1, "Retreat", False, None)
+        _record_history(
+            game,
+            member,
+            [
+                ("Movement", True, PhaseState.OrdersOutcome.NMR),
+                ("Retreat", False, None),
+            ],
+        )
 
         response = authenticated_client.get(reverse(retrieve_viewname, args=[game.id]))
 

--- a/service/member/tests.py
+++ b/service/member/tests.py
@@ -523,6 +523,23 @@ def _record_nmr(game, member):
     return phase
 
 
+def _record_phase(game, member, ordinal, phase_type, has_possible_orders, orders_outcome):
+    phase = game.phases.create(
+        variant=game.variant,
+        season="Spring",
+        year=1900,
+        type=phase_type,
+        status=PhaseStatus.COMPLETED,
+        ordinal=ordinal,
+    )
+    phase.phase_states.create(
+        member=member,
+        has_possible_orders=has_possible_orders,
+        orders_outcome=orders_outcome,
+    )
+    return phase
+
+
 class TestRemoveMemberFromActiveGame:
 
     @pytest.mark.django_db
@@ -705,6 +722,63 @@ class TestRemovalRequiresMissedOrders:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
     @pytest.mark.django_db
+    def test_member_who_missed_orders_stays_removable_across_a_phase_they_could_not_order_in(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
+        _record_phase(game, member, 1, "Retreat", False, None)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @pytest.mark.django_db
+    def test_member_who_missed_orders_stays_removable_across_several_such_phases(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
+        _record_phase(game, member, 1, "Retreat", False, None)
+        _record_phase(game, member, 2, "Adjustment", False, None)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @pytest.mark.django_db
+    def test_member_who_ordered_after_missing_orders_cannot_be_removed(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
+        _record_phase(game, member, 1, "Retreat", True, PhaseState.OrdersOutcome.RECEIVED)
+        _record_phase(game, member, 2, "Adjustment", False, None)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
+    def test_member_who_never_had_orders_to_give_cannot_be_removed(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_phase(game, member, 0, "Movement", False, None)
+
+        url = reverse(kick_viewname, args=[game.id, member.id])
+        response = authenticated_client.delete(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.django_db
     def test_already_removed_member_cannot_be_removed_again(
         self, authenticated_client, active_game_factory
     ):
@@ -736,6 +810,20 @@ class TestRemovableSerialization:
         game = active_game_factory()
         member = game.members.exclude(user=game.admin).first()
         _record_nmr(game, member)
+
+        response = authenticated_client.get(reverse(retrieve_viewname, args=[game.id]))
+
+        members_by_id = {m["id"]: m for m in response.data["members"]}
+        assert members_by_id[member.id]["removable"] is True
+
+    @pytest.mark.django_db
+    def test_removable_survives_a_phase_the_member_could_not_order_in(
+        self, authenticated_client, active_game_factory
+    ):
+        game = active_game_factory()
+        member = game.members.exclude(user=game.admin).first()
+        _record_phase(game, member, 0, "Movement", True, PhaseState.OrdersOutcome.NMR)
+        _record_phase(game, member, 1, "Retreat", False, None)
 
         response = authenticated_client.get(reverse(retrieve_viewname, args=[game.id]))
 


### PR DESCRIPTION
## What this PR does

Fixes a Discord bug report: a GM could not remove a player who had NMR'd, while removing two other players from the same game worked fine.

`Game.can_remove_member` gates on `nmrd_member_ids` (`service/game/models.py`), which only ever looked at the **single most recent completed phase**. A player who missed orders in a movement phase stopped being removable as soon as any later phase resolved in which they had nothing to order — a retreat phase with no dislodged units, or an adjustment phase with no builds or disbands.

Those phase states carry `has_possible_orders=False`, and `_set_orders_outcome` (`service/phase/models.py:298`) only writes an outcome for states with `has_possible_orders=True`, so their `orders_outcome` stays `NULL`. The NMR simply dropped out of view. The frontend hides the control entirely when `removable` is false (`packages/web/src/components/PlayerInfoContent.tsx:103`), so the GM got no error — the button was just gone.

This also explains why the other two removals succeeded: they were players whose miss landed in the latest completed phase, or who were already in civil disorder.

### The change

`nmrd_member_ids` now resolves each member's outcome from the most recent completed phase in which they **actually had orders to give**, walking back past phases they could not order in. A member who submitted orders after missing them is still not removable.

It resolves those outcomes two ways, mirroring how `current_phase` already chooses between prefetched and live data:

- **Prefetched** (game list and retrieve): walks the prefetched phases. `with_list_data` and `with_retrieve_data` narrowed `phase_states` to the current and latest completed phase, so the walk would have found nothing beyond those; both now also load each member's latest completed orderable phase state via a set-based subquery, matching the existing `distinct(...)` idiom beside it. Endpoints stay at a constant query count.
- **Not prefetched** (`IsRemovableMember` via `resolve_game`, `MemberSerializer.get_removable` via `obj.game`): a single `DISTINCT ON` query. Flat at 3 queries regardless of history depth.

Also guards removal on `member.eliminated`, matching `Member.replaceable` which already excludes eliminated members. Without it, the new backwards walk never expires, so an eliminated player who missed orders before elimination would stay removable for the rest of the game.

No migration, no serializer or schema change, so no codegen. The fix is computed at read time: affected games become removable as soon as this deploys.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md)

### Review findings

`/review-pr` raised four findings on the first commit. Three are fixed in `99d1ac3`:

1. **N+1 on un-prefetched paths** — the walk called `phase_states.all()` per phase. Measured 24 queries on a 20-phase history; now 3, flat. Fixed by the dual path above, with a test that pins the count.
2. **Eliminated players stayed removable forever** — fixed by the `eliminated` guard, with a test.
3. **Colliding test ordinals** — my new tests put completed phases at ordinal 1, the same ordinal the active game factory gives its live phase. Since `current_phase` is the highest ordinal broken by id, the completed phase shadowed the live one and the removal never exercised `_vacate_phase`. The history now sits below the live phase.

One finding I did **not** fix, flagging for your call:

4. **`latest_orderable_phase_state_ids` is not scoped to the page's games**, so Postgres computes the `DISTINCT ON` over the whole `PhaseState ⋈ Phase` set. The query *count* stays at 8, so no test catches it. I left it because the two subqueries directly above it (`current_phase_ids`, `latest_completed_phase_ids`) are already global in exactly the same way, and diverging from them unilaterally felt like the wrong call — but `PhaseState` is a much bigger table than `Phase`, so the argument is weaker here.

   The clean fix is to stop deriving this from phase history at all and denormalise onto `Member` (a `missed_orders` boolean maintained at resolution). That makes it O(1) everywhere, removes both prefetch changes, and lets `nmrd_member_ids` go away entirely. It needs a migration with a backfill, which is an architectural decision I did not want to make silently. Happy to do it in a follow-up if you want it.

### On tests

Six new tests in `service/member/tests.py` and one in `service/game/tests.py`. I verified each fails without the specific change it covers:

- Against `origin/main`, the three "stays removable" tests and the deep-history query-count test fail.
- Against the first commit, the eliminated test and the query-count test fail.
- Reverting only the prefetch widening → the deep-history test fails with `removable is False`, because the walk silently sees no orderable states.

Full backend suite: 2365 passed, 8 skipped.

### On screenshots

No frontend code changed. The visible effect is that the pre-existing "Remove" control appears for a player it was wrongly hidden for; there is no new or altered component, layout, copy, or state to show. Flagging this rather than silently skipping the checklist item.

### Note on scope

I could not confirm the diagnosis against the reporter's actual game — production queries were blocked by the permission classifier in this session. The diagnosis is instead confirmed by local reproduction: the failing scenario reproduces exactly as described (403 on kick) against a game with an NMR followed by a non-orderable phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD3HRmfKzkav1N9x4LS5jV