### PR TITLE
Stop recording an NMR for a forced full disband

### DIFF
--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -258,6 +258,7 @@ class PhaseManager(models.Manager):
             time_left = format_time_remaining(time_until_deadline)
 
             actionable_units = phase.actionable_units
+            forced_nations = phase.nations_with_forced_orders
 
             is_adjustment = phase.type == PhaseType.ADJUSTMENT
             warned_states = []
@@ -266,6 +267,8 @@ class PhaseManager(models.Manager):
                 if not ps.has_possible_orders:
                     continue
                 if ps.deadline_warning_sent_for == phase.scheduled_resolution:
+                    continue
+                if ps.member.nation_id in forced_nations:
                     continue
 
                 total_units = actionable_units.get(ps.member.nation_id, 0)
@@ -297,6 +300,8 @@ class PhaseManager(models.Manager):
     def _set_orders_outcome(self, phase):
         base_qs = phase.phase_states.filter(
             has_possible_orders=True
+        ).exclude(
+            member__nation_id__in=phase.nations_with_forced_orders
         ).annotate(order_count=Count("orders"))
 
         received_ids = list(base_qs.filter(order_count__gt=0).values_list("id", flat=True))
@@ -807,6 +812,25 @@ class Phase(BaseModel):
         return unit_counts
 
     @property
+    def nations_with_forced_orders(self):
+        if self.type != PhaseType.ADJUSTMENT:
+            return set()
+
+        unit_counts = {}
+        for unit in self.units.all():
+            unit_counts[unit.nation_id] = unit_counts.get(unit.nation_id, 0) + 1
+
+        sc_counts = {}
+        for supply_center in self.supply_centers.all():
+            sc_counts[supply_center.nation_id] = sc_counts.get(supply_center.nation_id, 0) + 1
+
+        return {
+            nation_id
+            for nation_id, unit_count in unit_counts.items()
+            if unit_count > 0 and sc_counts.get(nation_id, 0) == 0
+        }
+
+    @property
     def members_that_require_nmr_extension(self):
         phase_states = (
             self.phase_states.filter(
@@ -819,10 +843,12 @@ class Phase(BaseModel):
             .select_related("member")
         )
         actionable_units = self.actionable_units
+        forced_nations = self.nations_with_forced_orders
         return [
             phase_state.member
             for phase_state in phase_states
             if actionable_units.get(phase_state.member.nation_id, 0) > 0
+            and phase_state.member.nation_id not in forced_nations
         ]
 
     @property

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3931,7 +3931,15 @@ class TestCivilDisorderEliminationReconciliation:
 
 class TestSetOrdersOutcome:
 
-    def _setup_phase(self, variant, italy_nation, germany_nation, primary_user, secondary_user):
+    def _setup_phase(
+        self,
+        variant,
+        italy_nation,
+        germany_nation,
+        primary_user,
+        secondary_user,
+        phase_type=PhaseType.MOVEMENT,
+    ):
         game = Game.objects.create(
             variant=variant,
             name="Orders Outcome Test",
@@ -3944,7 +3952,7 @@ class TestSetOrdersOutcome:
             variant=variant,
             season="Spring",
             year=1901,
-            type=PhaseType.MOVEMENT,
+            type=phase_type,
             ordinal=1,
             status=PhaseStatus.ACTIVE,
         )
@@ -4043,6 +4051,156 @@ class TestSetOrdersOutcome:
         ps = phase.phase_states.create(
             member=italy, has_possible_orders=True, orders_confirmed=True
         )
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome == PhaseState.OrdersOutcome.NMR
+
+    @pytest.mark.django_db
+    def test_adjustment_forced_full_disband_stays_null(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+            phase_type=PhaseType.ADJUSTMENT,
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome is None
+
+    @pytest.mark.django_db
+    def test_adjustment_partial_disband_gets_nmr(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+            phase_type=PhaseType.ADJUSTMENT,
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.supply_centers.create(
+            province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        ps.refresh_from_db()
+        assert ps.orders_outcome == PhaseState.OrdersOutcome.NMR
+
+    @pytest.mark.django_db
+    def test_adjustment_forced_full_disband_does_not_mask_another_nation(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_kiel_province,
+        italy_vs_germany_berlin_province,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, germany = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+            phase_type=PhaseType.ADJUSTMENT,
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_kiel_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_germany_nation,
+        )
+        phase.supply_centers.create(
+            province=italy_vs_germany_kiel_province, nation=italy_vs_germany_germany_nation
+        )
+        phase.supply_centers.create(
+            province=italy_vs_germany_berlin_province, nation=italy_vs_germany_germany_nation
+        )
+        italy_state = phase.phase_states.create(member=italy, has_possible_orders=True)
+        germany_state = phase.phase_states.create(member=germany, has_possible_orders=True)
+
+        Phase.objects._set_orders_outcome(phase)
+
+        italy_state.refresh_from_db()
+        germany_state.refresh_from_db()
+        assert italy_state.orders_outcome is None
+        assert germany_state.orders_outcome == PhaseState.OrdersOutcome.NMR
+
+    @pytest.mark.django_db
+    def test_movement_phase_with_no_supply_centers_still_gets_nmr(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+    ):
+        phase, italy, _ = self._setup_phase(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            primary_user,
+            secondary_user,
+        )
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        ps = phase.phase_states.create(member=italy, has_possible_orders=True)
 
         Phase.objects._set_orders_outcome(phase)
 
@@ -4650,6 +4808,37 @@ class TestPhaseToCanonicalGameStatePerformance:
 
 
 class TestSendDeadlineWarnings:
+
+    @pytest.mark.django_db
+    def test_adjustment_forced_full_disband_gets_no_warning(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(
+            DeadlineMode.FIXED_TIME, now + timedelta(minutes=10)
+        )
+        phase.type = PhaseType.ADJUSTMENT
+        phase.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
 
     @pytest.mark.django_db
     def test_fixed_time_all_orders_not_confirmed_sends_confirm_prompt(
@@ -5524,6 +5713,83 @@ class TestNMRExtensionsNothingToOrder:
         germany.refresh_from_db()
         assert italy.nmr_extensions_remaining == 1
         assert germany.nmr_extensions_remaining == 0
+
+    @pytest.mark.django_db
+    def test_adjustment_forced_full_disband_does_not_consume_extension(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(
+            DeadlineMode.DURATION, now - timedelta(minutes=1)
+        )
+        game.movement_phase_duration = "48 hours"
+        game.save()
+        phase.type = PhaseType.ADJUSTMENT
+        phase.save()
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        result = Phase.objects._apply_nmr_extensions(phase)
+
+        assert result is None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 1
+        phase.refresh_from_db()
+        assert phase.scheduled_resolution == now - timedelta(minutes=1)
+
+    @pytest.mark.django_db
+    def test_adjustment_partial_disband_consumes_extension(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(
+            DeadlineMode.DURATION, now - timedelta(minutes=1)
+        )
+        game.movement_phase_duration = "48 hours"
+        game.save()
+        phase.type = PhaseType.ADJUSTMENT
+        phase.save()
+        italy.nmr_extensions_remaining = 1
+        italy.save()
+        phase.units.create(
+            province=italy_vs_germany_venice_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.units.create(
+            province=italy_vs_germany_rome_province,
+            type=UnitType.ARMY,
+            nation=italy_vs_germany_italy_nation,
+        )
+        phase.supply_centers.create(
+            province=italy_vs_germany_rome_province, nation=italy_vs_germany_italy_nation
+        )
+        phase.phase_states.create(member=italy, has_possible_orders=True)
+
+        result = Phase.objects._apply_nmr_extensions(phase)
+
+        assert result is not None
+        italy.refresh_from_db()
+        assert italy.nmr_extensions_remaining == 0
 
 
 def _elimination_notifications():


### PR DESCRIPTION
## What this PR does

Fixes #1310. A player with units and no supply centres must disband every unit they have, and the engine fills those disbands in for them — but they were still recorded as having NMRed, shown an NMR badge on their way out of the game, and charged an NMR extension that pushed the deadline out for everyone.

`_adjustment_options` emits a Disband option per unit whenever `required_disbands() > 0` (`service/adjudicator/options.py:485-505`), so `has_possible_orders` stayed `True` and `_set_orders_outcome` marked `orders_outcome=nmr` on zero submitted orders. `EnforceDisbandLimits` / `ApplyCivilDisorder` (`service/adjudicator/engine.py:154-168`) fill the missing disbands in anyway, so the board resolves identically whether or not the player submitted anything.

`required_disbands()` is `max(0, units - supply_centres)` (`service/adjudicator/types.py:1121-1124`), so it equals the unit count exactly when the nation holds no supply centres. New `Phase.nations_with_forced_orders` derives that set from the same counts `actionable_units` already walks, and three call sites now skip those nations:

- `_set_orders_outcome` — leaves `orders_outcome` null rather than `nmr`
- `members_that_require_nmr_extension` — no extension consumed
- `send_deadline_warnings` — no "you'll lose an extension" warning, which would no longer be true

A partial disband (3 units, 1 supply centre, where *which* two units go is a real choice) still counts as an NMR. Movement and Retreat phases are untouched.

Leaving `orders_outcome` null matches how a phase state with `has_possible_orders=False` is already treated, so the phase drops out of commitment rating via the `orders_outcome__isnull=False` filter in `get_rated_outcomes` (`service/user_profile/commitment.py:49-53`).

### Two things worth a reviewer's opinion

1. **The UI still says orders are required.** `orderStatus` and `PhaseGuidance` derive from `has_possible_orders` / the SC-vs-unit delta, so a forced-disband player still sees "Disband 2 units" and an "Orders required" badge while the backend now asks nothing of them. Surfacing "forced" to the client means a serializer field plus codegen across both schemas, which felt like scope beyond the issue — happy to do it here or in a follow-up.
2. **The retreat case looks like the same bug.** `_retreat_options` appends a Disband option for every dislodged unit regardless of whether a legal retreat exists (`service/adjudicator/options.py:396-405`), so a player whose dislodged units all have nowhere to go is in the identical position. Issue #1310 scopes to Adjustment, so I left it — but it's probably worth its own issue.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only

Seven tests added across `TestSetOrdersOutcome`, `TestNMRExtensionsNothingToOrder` and `TestSendDeadlineWarnings`. The four that pin the bug fail on `main` and pass here; full backend suite is green (2356 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjyUirJePgFH9Q2zPWSp5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUirJePgFH9Q2zPWSp5Z)_