### PR TITLE
Suppress deadline warnings for confirmed players in fixed-time games

### DIFF
--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -4696,6 +4696,42 @@ class TestSendDeadlineWarnings:
         mock_send_notification_to_users.assert_not_called()
 
     @pytest.mark.django_db
+    def test_fixed_time_confirmed_no_orders_no_notification(
+        self,
+        deadline_warning_game_factory,
+        add_italy_germany_units,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        add_italy_germany_units(phase)
+        phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+    @pytest.mark.django_db
+    def test_fixed_time_confirmed_some_orders_no_notification(
+        self,
+        deadline_warning_game_factory,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_venice_province,
+        italy_vs_germany_rome_province,
+        mock_send_notification_to_users,
+    ):
+        now = timezone.now()
+        game, italy, germany, phase = deadline_warning_game_factory(DeadlineMode.FIXED_TIME, now + timedelta(minutes=10))
+        phase.units.create(province=italy_vs_germany_venice_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        phase.units.create(province=italy_vs_germany_rome_province, type=UnitType.ARMY, nation=italy_vs_germany_italy_nation)
+        italy_ps = phase.phase_states.create(member=italy, has_possible_orders=True, orders_confirmed=True)
+        italy_ps.orders.create(source=italy_vs_germany_venice_province, order_type=OrderType.HOLD)
+
+        Phase.objects.send_deadline_warnings()
+
+        mock_send_notification_to_users.assert_not_called()
+
+    @pytest.mark.django_db
     def test_fixed_time_some_orders_sends_partial_notification(
         self,
         deadline_warning_game_factory,

--- a/service/phase/utils.py
+++ b/service/phase/utils.py
@@ -37,10 +37,11 @@ def build_notification_body(
     else:
         nmr_suffix = "If no orders given, the game will stop waiting for you for next turns."
 
+    if orders_confirmed:
+        return None
+
     if is_fixed_time:
         if orders_given == total_units:
-            if orders_confirmed:
-                return None
             return (
                 f"All orders ready. Confirm to advance the game early — "
                 f"the next deadline may move sooner too. {time_left} remaining."
@@ -58,8 +59,6 @@ def build_notification_body(
             f"{nmr_suffix}"
         )
     else:
-        if orders_confirmed:
-            return None
         if orders_given == total_units:
             return (
                 f"Deadline approaching - orders ready, waiting confirmation. "


### PR DESCRIPTION
## What this PR does

`build_notification_body` (`service/phase/utils.py`) checked `orders_confirmed` in two structurally different places: the duration branch checked it first and unconditionally, while the fixed-time branch only checked it inside the `orders_given == total_units` arm. A fixed-time player who confirmed a partial or empty order set fell past that guard, past the `orders_given > 0` guard, and was told "Deadline approaching - no orders given. Your units have not received orders." — despite having explicitly confirmed. This hoists the check above the fixed-time/duration split so it governs both modes, and drops the two now-unreachable copies.

Behavioural delta is confined to fixed-time games with `orders_confirmed=True`; duration behaviour is unchanged.

| `orders_given` | before | after |
| --- | --- | --- |
| `== total_units` | no warning | no warning (unchanged) |
| partial | "orders incomplete" | no warning |
| zero | "no orders given" | no warning |

Closes [#1219](https://github.com/johnpooch/diplicity-react/issues/1219).

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [x] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings — n/a, four-line hoist
- [x] Tests cover the change — two new tests in `TestSendDeadlineWarnings` (`service/phase/tests.py`) pin the fixed-time confirmed-with-zero-orders and confirmed-with-partial-orders cases. Both were verified to fail against the unmodified `utils.py`, reproducing the reported copy verbatim, and pass after the fix. `pytest phase notification` is green at 485 passed, 8 skipped.
- [x] Screenshots embedded in the PR description for any visual changes — n/a, backend notification copy only, no rendered UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsZiGEA2ZpayuLKaqskbJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsZiGEA2ZpayuLKaqskbJ6)_