### PR TITLE
Name the active game in removed_from_staging notifications

### DIFF
--- a/service/notification/registry.py
+++ b/service/notification/registry.py
@@ -294,11 +294,11 @@ class SeatFilledSpec(NotificationSpec):
 
 @register("removed_from_staging")
 class RemovedFromStagingSpec(NotificationSpec):
-    def get_title(self):
-        return "Removed from staging games"
-
     def get_body(self):
-        return f"You were removed from {self.context.game.name} because you entered civil disorder in an active game."
+        return (
+            "You were removed from this game because you entered "
+            f"civil disorder in {self.context.payload['active_game_name']}."
+        )
 
 
 @register("civil_disorder")

--- a/service/phase/models.py
+++ b/service/phase/models.py
@@ -408,7 +408,7 @@ class PhaseManager(models.Manager):
             return
 
         cd_user_ids = [m.user_id for m in newly_cd_members if m.user_id is not None]
-        self._remove_from_staging_games(cd_user_ids)
+        self._remove_from_staging_games(cd_user_ids, phase.game)
 
         nation_names = ", ".join(
             m.nation.name for m in newly_cd_members if m.nation is not None
@@ -416,7 +416,7 @@ class PhaseManager(models.Manager):
 
         emit("civil_disorder", game=phase.game, nation_names=nation_names)
 
-    def _remove_from_staging_games(self, user_ids):
+    def _remove_from_staging_games(self, user_ids, active_game):
         if not user_ids:
             return
 
@@ -440,7 +440,12 @@ class PhaseManager(models.Manager):
         for m in staging_members:
             if m.user_id is None:
                 continue
-            emit("removed_from_staging", game=m.game, recipients=[m.user_id])
+            emit(
+                "removed_from_staging",
+                game=m.game,
+                recipients=[m.user_id],
+                active_game_name=active_game.name,
+            )
 
         from game.models import Game
         for game in Game.objects.filter(

--- a/service/phase/tests.py
+++ b/service/phase/tests.py
@@ -3671,6 +3671,15 @@ class TestCivilDisorderStagingRemoval:
         assert staging_removal_notifications.count() == 1
         assert list(staging_removal_notifications.values_list("recipient_id", flat=True)) == [primary_user.id]
 
+        delivery = NotificationDelivery.objects.get(
+            notification=staging_removal_notifications.get(),
+            channel=NotificationDelivery.Channel.PUSH,
+        )
+        assert delivery.heading == "Staging Game"
+        assert delivery.body == (
+            "You were removed from this game because you entered civil disorder in Active CD Game."
+        )
+
 
     @pytest.mark.django_db
     def test_cd_does_not_remove_game_creator_from_staging(
@@ -3706,6 +3715,52 @@ class TestCivilDisorderStagingRemoval:
 
         assert staging_game.members.filter(user=primary_user).exists()
         assert staging_game.members.filter(user=secondary_user).exists()
+
+    @pytest.mark.django_db
+    def test_cd_staging_removal_notification_names_the_active_game_for_every_staging_game(
+        self,
+        italy_vs_germany_variant,
+        italy_vs_germany_italy_nation,
+        italy_vs_germany_germany_nation,
+        italy_vs_germany_venice_province,
+        primary_user,
+        secondary_user,
+        in_memory_procrastinate,
+    ):
+        game, italy, germany, phase2 = self._setup_cd_scenario(
+            italy_vs_germany_variant,
+            italy_vs_germany_italy_nation,
+            italy_vs_germany_germany_nation,
+            italy_vs_germany_venice_province,
+            primary_user,
+            secondary_user,
+        )
+
+        for name in ["First Staging Game", "Second Staging Game"]:
+            staging_game = Game.objects.create(
+                variant=italy_vs_germany_variant,
+                name=name,
+                status=GameStatus.PENDING,
+                created_by=secondary_user,
+            )
+            staging_game.members.create(user=primary_user)
+            staging_game.members.create(user=secondary_user)
+
+        newly_cd_members = Phase.objects._check_civil_disorder(phase2)
+        Phase.objects._notify_civil_disorder(phase2, newly_cd_members)
+
+        deliveries = NotificationDelivery.objects.filter(
+            notification__event_type="removed_from_staging",
+            notification__recipient=primary_user,
+            channel=NotificationDelivery.Channel.PUSH,
+        )
+        assert sorted(deliveries.values_list("heading", flat=True)) == [
+            "First Staging Game",
+            "Second Staging Game",
+        ]
+        assert set(deliveries.values_list("body", flat=True)) == {
+            "You were removed from this game because you entered civil disorder in Active CD Game."
+        }
 
 
 class TestCivilDisorderExcludesEliminatedMembers:


### PR DESCRIPTION
## What this PR does

`removed_from_staging` never named the game where the civil disorder happened, so a player dropped from four pending games got four messages naming those four games and none of the responsible one. The emit now carries the active game down from `_notify_civil_disorder`, and the body names it. Fixes #1225.

**Before** — title `Removed from staging games`, body `You were removed from Autumn Skirmish because you entered civil disorder in an active game.`

**After** — title `Autumn Skirmish` (the staging game), body `You were removed from this game because you entered civil disorder in Winter War.`

Changes:

- `service/phase/models.py` — `_remove_from_staging_games` takes the active game as a second argument (`phase.game` was already in scope at the sole call site) and passes `active_game_name` on the emit.
- `service/notification/registry.py` — `RemovedFromStagingSpec` reads that payload key. The `get_title()` override returning the literal `"Removed from staging games"` is dropped, so the title is the staging game name, per the title rule in `.claude/rules/backend/notification-copy.md`; the body then says "this game" rather than repeating it. This matches its sibling `KickedFromStagingSpec`. The link is unchanged.

`EmitContext` has a single `game` slot and is frozen, so the second game travels as a payload scalar — the same pattern as `GameDeletedSpec`'s `game_name` and `SeatFilledSpec`'s `nation_name`. Payloads are never persisted, so no migration, codegen, or OpenAPI change.

## Checklist

- [x] This PR does one thing — no unrelated fixes, refactors, or drive-by cleanups bundled in
- [ ] For PRs of any significant complexity: I ran `/review-pr` against this PR in Claude Code and addressed (or responded to) its findings
- [x] Tests cover the change
- [x] Screenshots embedded in the PR description for any visual changes (see CLAUDE.md) — n/a, backend only, nothing rendered in the web app

`TestCivilDisorderStagingRemoval::test_cd_staging_removal_sends_notification` now asserts the rendered push heading and body, and a new `test_cd_staging_removal_notification_names_the_active_game_for_every_staging_game` covers the multi-game case from the issue: two staging games, two notifications, each headed by its own staging game and both naming the active one.

Full backend suite: 2374 passed, 8 skipped.

Note: this is the 10th open PR against the project target of ≤ 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAaXdxawKQYsPuH1mgfiMH

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAaXdxawKQYsPuH1mgfiMH)_