### PR TITLE
Center the A/F unit label at every unit scale

### DIFF
--- a/packages/web/src/components/InteractiveMap/mapRenderer.test.ts
+++ b/packages/web/src/components/InteractiveMap/mapRenderer.test.ts
@@ -452,6 +452,16 @@ describe("DiplicityMap unit scaling", () => {
     expect(svg).toContain('font-size="30"');
   });
 
+  test("scales the label baseline offset so the glyph stays centred", () => {
+    // Unit centre is cy=130; the +5 baseline drop scales with the unit, so at
+    // scale 2 the text baseline is cy + 5 * 2 = 140 (not a fixed cy + 5 = 135).
+    const svg = new DiplicityMap(TOY_DSVG, 2).render({
+      nationColors: { England: "#1b4f9c" },
+      units: [{ province: "alpha", nation: "England", type: "Army" }],
+    });
+    expect(svg).toContain('<text x="150" y="140"');
+  });
+
   test("scales the unit token's outline stroke width along with its radius", () => {
     const svg = new DiplicityMap(TOY_DSVG, 2).render({
       nationColors: { England: "#1b4f9c" },

--- a/packages/web/src/components/InteractiveMap/mapRenderer.ts
+++ b/packages/web/src/components/InteractiveMap/mapRenderer.ts
@@ -241,7 +241,7 @@ const unitToken = (
   const label = type === "Army" ? "A" : "F";
   return (
     `<circle cx="${formatCoord(cx)}" cy="${formatCoord(cy)}" r="${UNIT_RADIUS * scale}" fill="${color}" stroke="black" stroke-width="${2 * scale}"${opacityAttr(circleOpacity)}/>` +
-    `<text x="${formatCoord(cx)}" y="${formatCoord(cy + 5)}" font-size="${15 * scale}" font-weight="bold" fill="black" text-anchor="middle"${opacityAttr(textOpacity)}>${label}</text>`
+    `<text x="${formatCoord(cx)}" y="${formatCoord(cy + 5 * scale)}" font-size="${15 * scale}" font-weight="bold" fill="black" text-anchor="middle"${opacityAttr(textOpacity)}>${label}</text>`
   );
 };
 


### PR DESCRIPTION
## Problem

The unit token's "A"/"F" label only looks right at `unitScaling = 1`:

- **Enlarged** (scale > 1): the letter sits too high in the circle.
- **Shrunk** (scale < 1): the letter sits too low.

## Cause

`unitToken` in `mapRenderer.ts` drew the label with a **fixed** `cy + 5` baseline drop while `font-size` scaled as `15 * scale`:

```js
`<text x="${cx}" y="${cy + 5}" font-size="${15 * scale}" .../>`
```

The `+5` is tuned so a 15px glyph's visual centre lands on the circle centre. Because it doesn't scale, the glyph centre drifts by `~5 - 5.25*scale` px — unbounded, linear in `|scale - 1|`. The circle (radius and stroke both `* scale`) is always centred, so only the label is off.

## Fix

Multiply the baseline offset by `scale` too:

```js
`y="${formatCoord(cy + 5 * scale)}"`
```

The whole token becomes a uniform zoom of its `scale = 1` rendering about `(cx, cy)`, so the label stays centred at every value. `scale = 1` output is unchanged — the existing `mapRenderer.classical.test.ts` board-state artifact test still passes.

## Tests

- Added `scales the label baseline offset so the glyph stays centred` — asserts `<text x="150" y="140"` at scale 2 (was `y="135"`).
- Full `mapRenderer.test.ts` + `mapRenderer.classical.test.ts`: 53/53 pass. Lint clean.

## Also fixed in the variant-creator

The dVAR Creator's Unit Scaling preview carries a deliberate copy of this renderer and had the identical `cy + 5` / `15 * scale` bug. It's already fixed there in [JorenC/variant-creator#39](https://github.com/JorenC/variant-creator/pull/39) with the same one-line change — that PR is ready and can be pulled independently of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
