### PR TITLE
Scale support-hold and convoy order markers with unit scale

### DIFF
--- a/packages/web/src/components/InteractiveMap/mapRenderer.test.ts
+++ b/packages/web/src/components/InteractiveMap/mapRenderer.test.ts
@@ -510,6 +510,55 @@ describe("DiplicityMap unit scaling", () => {
     const svg = new DiplicityMap(TOY_DSVG, 3).render({ selected: ["beta"] });
     expect(svg).toContain('stroke-width="5"');
   });
+
+  test("scales the support-hold marker octagon with unit scale", () => {
+    const opts: RenderState = {
+      nationColors: { England: "#1b4f9c" },
+      orders: [
+        { type: "Support", nation: "England", source: "alpha", aux: "beta", target: "beta" },
+      ],
+    };
+    const octRadius = (svg: string): number => {
+      const pts = (svg.match(/<polygon points="([^"]+)"/)?.[1] ?? "")
+        .split(" ")
+        .map((p) => p.split(",").map(Number));
+      const cx = pts.reduce((sum, p) => sum + p[0], 0) / pts.length;
+      const cy = pts.reduce((sum, p) => sum + p[1], 0) / pts.length;
+      return Math.hypot(pts[0][0] - cx, pts[0][1] - cy);
+    };
+    const base = new DiplicityMap(TOY_DSVG, 1).render(opts);
+    const scaled = new DiplicityMap(TOY_DSVG, 2).render(opts);
+    expect(octRadius(scaled) / octRadius(base)).toBeCloseTo(2, 2);
+    expect(scaled).toMatch(/<polygon[^>]*stroke-width="6"/);
+  });
+
+  test("scales the convoy line's terminal dot with unit scale", () => {
+    const opts: RenderState = {
+      nationColors: { England: "#1b4f9c" },
+      orders: [
+        { type: "Convoy", nation: "England", source: "beta", aux: "alpha", target: "gamma" },
+      ],
+    };
+    expect(new DiplicityMap(CONVOY_DSVG, 1).render(opts)).toContain('r="5" fill="white"');
+    expect(new DiplicityMap(CONVOY_DSVG, 2).render(opts)).toContain('r="10" fill="white"');
+  });
+
+  test("scales the convoy wave amplitude with unit scale", () => {
+    const opts: RenderState = {
+      nationColors: { England: "#1b4f9c" },
+      orders: [
+        { type: "Convoy", nation: "England", source: "beta", aux: "alpha", target: "gamma" },
+      ],
+    };
+    const lateralSpread = (svg: string): number => {
+      const d = svg.match(/<path d="(M [^"]*C[^"]*)"/)?.[1] ?? "";
+      const xs = [...d.matchAll(/(-?\d+(?:\.\d+)?) -?\d+(?:\.\d+)?/g)].map((m) => Number(m[1]));
+      return Math.max(...xs) - Math.min(...xs);
+    };
+    const base = new DiplicityMap(CONVOY_DSVG, 1).render(opts);
+    const scaled = new DiplicityMap(CONVOY_DSVG, 2).render(opts);
+    expect(lateralSpread(scaled) / lateralSpread(base)).toBeCloseTo(2, 1);
+  });
 });
 
 describe("DiplicityMap layering", () => {

--- a/packages/web/src/components/InteractiveMap/mapRenderer.ts
+++ b/packages/web/src/components/InteractiveMap/mapRenderer.ts
@@ -82,6 +82,12 @@ const ORDER_STROKE_WIDTH = 2.5;
 const ORDER_DASH = { length: 4, spacing: 2 };
 const SUCCESS_COLOR = "rgba(0,0,0,1)";
 const HOLD_OCTAGON_SIZE = 24;
+const SUPPORT_HOLD_TIP_GAP = 1;
+const SUPPORT_HOLD_OCTAGON_SIZE = 8;
+const SUPPORT_HOLD_OCTAGON_STROKE_WIDTH = 3;
+const CONVOY_DOT_RADIUS = 5;
+const CONVOY_WAVE_AMPLITUDE = 5;
+const CONVOY_WAVE_LENGTH = 30;
 const FAILED_CROSS_WIDTH = 3;
 const FAILED_CROSS_LENGTH = 16;
 const FAILED_CROSS_ANGLE = 45;
@@ -495,6 +501,9 @@ const supportOrderParts = (
           fill: color,
           stroke: SUCCESS_COLOR,
           strokeWidth: ORDER_STROKE_WIDTH * scale,
+          tipGap: SUPPORT_HOLD_TIP_GAP * scale,
+          octagonSize: SUPPORT_HOLD_OCTAGON_SIZE * scale,
+          octagonStrokeWidth: SUPPORT_HOLD_OCTAGON_STROKE_WIDTH * scale,
           dash: { length: ORDER_DASH.length * scale, spacing: ORDER_DASH.spacing * scale },
           renderCenter,
         })
@@ -631,6 +640,9 @@ const convoyOrderParts = (
         offset: UNIT_RADIUS * scale,
         stroke: SUCCESS_COLOR,
         strokeWidth: ORDER_STROKE_WIDTH * scale,
+        dotRadius: CONVOY_DOT_RADIUS * scale,
+        waveAmplitude: CONVOY_WAVE_AMPLITUDE * scale,
+        waveLength: CONVOY_WAVE_LENGTH * scale,
         fill: nationColor(state, order.nation),
         attachmentPoint: route?.attachments.get(order.source),
         renderCenter: order.failed

--- a/packages/web/src/components/InteractiveMap/svgPrimitives.test.ts
+++ b/packages/web/src/components/InteractiveMap/svgPrimitives.test.ts
@@ -210,6 +210,9 @@ const SUPPORT_HOLD_OPTS: SupportHoldArrowOptions = {
   fill: "#1b4f9c",
   stroke: "black",
   strokeWidth: 2.5,
+  tipGap: 1,
+  octagonSize: 8,
+  octagonStrokeWidth: 3,
 };
 
 const CONVOY_OPTS: ConvoyArrowOptions = {
@@ -224,6 +227,9 @@ const CONVOY_OPTS: ConvoyArrowOptions = {
   fill: "#3b9c3b",
   stroke: "black",
   strokeWidth: 2.5,
+  dotRadius: 5,
+  waveAmplitude: 5,
+  waveLength: 30,
 };
 
 const MOVE_VIA_CONVOY_OPTS: MoveViaConvoyArrowOptions = {

--- a/packages/web/src/components/InteractiveMap/svgPrimitives.ts
+++ b/packages/web/src/components/InteractiveMap/svgPrimitives.ts
@@ -332,6 +332,9 @@ export type SupportHoldArrowOptions = {
   fill: string;
   stroke: string;
   strokeWidth: number;
+  tipGap: number;
+  octagonSize: number;
+  octagonStrokeWidth: number;
   dash?: Dash;
   renderCenter?: (x: number, y: number, angle: number) => string;
 };
@@ -341,8 +344,8 @@ export const supportHoldArrow = (o: SupportHoldArrowOptions): string => {
   const endOffset = o.endOffset ?? o.offset;
   const startX = o.x1 + o.offset * Math.cos(angle);
   const startY = o.y1 + o.offset * Math.sin(angle);
-  const endX = o.x2 - endOffset * Math.cos(angle) - Math.cos(angle);
-  const endY = o.y2 - endOffset * Math.sin(angle) - Math.sin(angle);
+  const endX = o.x2 - (endOffset + o.tipGap) * Math.cos(angle);
+  const endY = o.y2 - (endOffset + o.tipGap) * Math.sin(angle);
   const centerX = (startX + endX) / 2;
   const centerY = (startY + endY) / 2;
   const d = `M ${n(startX)} ${n(startY)} L ${n(endX)} ${n(endY)}`;
@@ -354,20 +357,23 @@ export const supportHoldArrow = (o: SupportHoldArrowOptions): string => {
     octagon({
       x: endX,
       y: endY,
-      size: 8,
+      size: o.octagonSize,
       stroke: o.stroke,
       fill: o.fill,
-      strokeWidth: 3,
+      strokeWidth: o.octagonStrokeWidth,
     }) +
     `</g>`
   );
 };
 
-const WAVE_AMPLITUDE = 5;
-const WAVE_LENGTH = 30;
 const BEZIER_K = 4 / 3;
 
-const wavyPath = (start: Point, end: Point): string => {
+const wavyPath = (
+  start: Point,
+  end: Point,
+  amplitude: number,
+  waveLength: number
+): string => {
   const dx = end.x - start.x;
   const dy = end.y - start.y;
   const length = Math.sqrt(dx * dx + dy * dy);
@@ -378,7 +384,7 @@ const wavyPath = (start: Point, end: Point): string => {
   const uy = dy / length;
   const px = -uy;
   const py = ux;
-  const rawHalfWaves = Math.round(length / (WAVE_LENGTH / 2));
+  const rawHalfWaves = Math.round(length / (waveLength / 2));
   const halfWaves = Math.max(
     2,
     rawHalfWaves % 2 === 0 ? rawHalfWaves : rawHalfWaves + 1
@@ -391,10 +397,10 @@ const wavyPath = (start: Point, end: Point): string => {
     const sy = start.y + i * halfWaveLength * uy;
     const ex = start.x + (i + 1) * halfWaveLength * ux;
     const ey = start.y + (i + 1) * halfWaveLength * uy;
-    const cp1x = sx + halfWaveLength * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
-    const cp1y = sy + halfWaveLength * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
-    const cp2x = ex - halfWaveLength * 0.25 * ux + sign * WAVE_AMPLITUDE * BEZIER_K * px;
-    const cp2y = ey - halfWaveLength * 0.25 * uy + sign * WAVE_AMPLITUDE * BEZIER_K * py;
+    const cp1x = sx + halfWaveLength * 0.25 * ux + sign * amplitude * BEZIER_K * px;
+    const cp1y = sy + halfWaveLength * 0.25 * uy + sign * amplitude * BEZIER_K * py;
+    const cp2x = ex - halfWaveLength * 0.25 * ux + sign * amplitude * BEZIER_K * px;
+    const cp2y = ey - halfWaveLength * 0.25 * uy + sign * amplitude * BEZIER_K * py;
     d += ` C ${n(cp1x)} ${n(cp1y)} ${n(cp2x)} ${n(cp2y)} ${n(ex)} ${n(ey)}`;
   }
   return d;
@@ -412,6 +418,9 @@ export type ConvoyArrowOptions = {
   fill: string;
   stroke: string;
   strokeWidth: number;
+  dotRadius: number;
+  waveAmplitude: number;
+  waveLength: number;
   attachmentPoint?: Point;
   dash?: Dash;
   renderCenter?: (x: number, y: number, angle: number) => string;
@@ -438,13 +447,13 @@ export const convoyArrow = (o: ConvoyArrowOptions): string => {
   const angle = Math.atan2(end.y - start.y, end.x - start.x);
   const centerX = (start.x + end.x) / 2;
   const centerY = (start.y + end.y) / 2;
-  const d = wavyPath(start, end);
+  const d = wavyPath(start, end, o.waveAmplitude, o.waveLength);
   return (
     `<g>` +
     strokeLine(d, o.stroke, o.lineWidth + o.strokeWidth * 2, o.dash) +
     strokeLine(d, o.fill, o.lineWidth, o.dash) +
     (o.renderCenter ? o.renderCenter(centerX, centerY, angle) : "") +
-    `<circle cx="${n(end.x)}" cy="${n(end.y)}" r="5" fill="white" stroke="black" stroke-width="${n(o.strokeWidth)}"/>` +
+    `<circle cx="${n(end.x)}" cy="${n(end.y)}" r="${n(o.dotRadius)}" fill="white" stroke="black" stroke-width="${n(o.strokeWidth)}"/>` +
     `</g>`
   );
 };


### PR DESCRIPTION
## Problem

`unitScaling` scales unit tokens and most order markup, but three indicators stay a fixed size at any scale ≠ 1:

- **Support‑to‑Hold** order: the octagon marker at the arrow tip (measured circumradius 5.66 / stroke 3 at scale 1, 2, and 0.5 alike).
- **Convoy** line: the white dot at the end of the wavy line (`r="5"` at every scale, while its own stroke does scale — so the ring thickens but the dot doesn't grow).
- **Convoy** line: the wave itself — amplitude and wavelength are fixed in map units, so at large `unitScaling` the convoy line is a near‑straight thick band and at small scale a dense squiggle.

Everything else — plain move / support‑move / move‑via‑convoy arrows, failed‑order crosses, build/disband markers, the plain hold octagon, retreat flag, civil‑disorder badge — already scales correctly.

## Cause

Follow‑up to `ed7e8d9a` / `15200029`. That work multiplied every **caller‑supplied** dimension by `scale`, but `supportHoldArrow`, `convoyArrow`, and `wavyPath` in `svgPrimitives.ts` carried **baked‑in** marker sizes that weren't in their options objects, so the call sites had nothing to multiply:

| Location | Hardcoded |
|---|---|
| `supportHoldArrow` octagon | `size: 8`, `strokeWidth: 3` |
| `supportHoldArrow` tip pull‑back | fixed `- Math.cos(angle)` / `- Math.sin(angle)` (~1px) |
| `convoyArrow` end dot | `r="5"` |
| `wavyPath` | `WAVE_AMPLITUDE = 5`, `WAVE_LENGTH = 30` (module constants) |

## Fix

All three primitives now take their sizes as options. `mapRenderer.ts` passes new `SUPPORT_HOLD_*` / `CONVOY_*` constants multiplied by `scale`, matching the existing `UNIT_RADIUS * scale` / `ORDER_LINE_WIDTH * scale` pattern.

At scale 1 every value equals the old literal, so output is **byte‑identical** — the committed `shape-support-hold.svg`, `toy-convoy.svg`, `toy-board.svg` and `toy-board.classical.svg` artifact snapshots are unchanged.

## Tests

`svgPrimitives.test.ts` fixtures gain the new required fields. New regression tests in `mapRenderer.test.ts`:

- support‑hold octagon circumradius **and** stroke scale 2× at `unitScaling = 2`
- convoy end dot `r` 5 → 10
- convoy wave lateral spread scales ~2×

Full `packages/web` InteractiveMap suite: 130/130 pass. Lint + `tsc --noEmit` clean.

## Context

Third in a series on `unitScaling` rendering fidelity, after the A/F label centering (#1329) and the diagnosis in that thread. No `variant-creator` change needed — its Unit Scaling preview doesn't render support‑hold or convoy arrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)